### PR TITLE
fix: session transport — replayInit hang, forward roots/list, session-scoped control plane

### DIFF
--- a/cmd/mcp-mux/daemon.go
+++ b/cmd/mcp-mux/daemon.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"os/signal"
 	"syscall"
 	"time"
@@ -35,7 +36,17 @@ func runGlobalDaemon() {
 		}
 	}
 
-	logger := log.New(os.Stderr, "[mcp-muxd] ", log.LstdFlags)
+	// Debug log to file — daemon is detached, stderr goes nowhere.
+	// Always log to file so we can trace issues like roots/list routing.
+	debugLogPath := filepath.Join(os.TempDir(), "mcp-muxd-debug.log")
+	logFile, err := os.OpenFile(debugLogPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	var logger *log.Logger
+	if err == nil {
+		logger = log.New(logFile, "[mcp-muxd] ", log.LstdFlags|log.Lmicroseconds)
+		logger.Printf("=== daemon starting, debug log: %s ===", debugLogPath)
+	} else {
+		logger = log.New(os.Stderr, "[mcp-muxd] ", log.LstdFlags)
+	}
 
 	d, err := daemon.New(daemon.Config{
 		ControlPath: ctlPath,

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -165,7 +165,7 @@ func (d *Daemon) Spawn(req control.Request) (string, string, error) {
 		OnPersistentDetected: func(serverID string) {
 			d.SetPersistent(serverID, true)
 		},
-		Logger: log.New(os.Stderr, fmt.Sprintf("[mcp-mux:%s] ", sid[:8]), log.LstdFlags),
+		Logger: log.New(d.logger.Writer(), fmt.Sprintf("[mcp-mux:%s] ", sid[:8]), log.LstdFlags|log.Lmicroseconds),
 	})
 	if err != nil {
 		return "", "", fmt.Errorf("spawn %s: %w", req.Command, err)

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -658,7 +658,11 @@ func (s *Server) resolveServerID(serverID, name string) (string, error) {
 		}
 
 		// Match against command + args concatenated
-		cmd, _ := data["command"].(string)
+		cmd, ok := data["command"].(string)
+		if !ok {
+			s.logger.Printf("server %s status has invalid 'command' field, skipping", sid)
+			continue
+		}
 		var args []string
 		if rawArgs, ok := data["args"].([]any); ok {
 			for _, a := range rawArgs {

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -292,6 +292,8 @@ func (s *Server) handleToolsList(id json.RawMessage) {
 			"description": "List all running mcp-mux managed MCP server instances. " +
 				"Returns compact summary by default: server name, sessions, classification, version. " +
 				"Set verbose=true for full details (PID, IPC path, cache status, classification reason). " +
+				"By default shows only servers belonging to this CC session's project. " +
+				"Set all=true to see servers from all projects/sessions. " +
 				"Use server_id or name from the output to target mux_stop or mux_restart.",
 			"inputSchema": map[string]any{
 				"type": "object",
@@ -299,6 +301,11 @@ func (s *Server) handleToolsList(id json.RawMessage) {
 					"verbose": map[string]any{
 						"type":        "boolean",
 						"description": "Return full status details for each server (default: compact summary).",
+						"default":     false,
+					},
+					"all": map[string]any{
+						"type":        "boolean",
+						"description": "Show servers from all projects/sessions, not just this one (default: false).",
 						"default":     false,
 					},
 				},
@@ -385,13 +392,20 @@ func (s *Server) handleToolsCall(id json.RawMessage, params json.RawMessage) {
 }
 
 // toolMuxList scans all .ctl.sock files and queries status from each.
+// By default filters to servers belonging to this CC session's project (by cwd).
+// Set all=true to see all servers across all projects.
 func (s *Server) toolMuxList(id json.RawMessage, args json.RawMessage) {
 	var params struct {
 		Verbose bool `json:"verbose"`
+		All     bool `json:"all"`
 	}
 	if args != nil {
 		_ = json.Unmarshal(args, &params)
 	}
+
+	// Determine this session's cwd for filtering
+	myCwd, _ := os.Getwd()
+	myCwd = strings.ToLower(filepath.Clean(myCwd))
 
 	tmpDir := os.TempDir()
 	entries, err := os.ReadDir(tmpDir)
@@ -419,6 +433,13 @@ func (s *Server) toolMuxList(id json.RawMessage, args json.RawMessage) {
 		if resp.OK && resp.Data != nil {
 			var data map[string]any
 			if err := json.Unmarshal(resp.Data, &data); err == nil {
+				// Filter by cwd unless all=true
+				if !params.All && myCwd != "" {
+					if !s.ownerHasCwd(data, myCwd) {
+						continue
+					}
+				}
+
 				if params.Verbose {
 					data["server_id"] = serverID
 					servers = append(servers, data)
@@ -441,6 +462,27 @@ func (s *Server) toolMuxList(id json.RawMessage, args json.RawMessage) {
 
 	result, _ := json.MarshalIndent(servers, "", "  ")
 	s.sendToolResult(id, string(result))
+}
+
+// ownerHasCwd checks if an owner's status data contains a given cwd in its cwdSet or primary cwd.
+func (s *Server) ownerHasCwd(data map[string]any, cwd string) bool {
+	// Check primary cwd
+	if primary, ok := data["cwd"].(string); ok {
+		if strings.ToLower(filepath.Clean(primary)) == cwd {
+			return true
+		}
+	}
+	// Check cwdSet (array of strings in status response)
+	if cwdSet, ok := data["cwd_set"].([]any); ok {
+		for _, c := range cwdSet {
+			if cs, ok := c.(string); ok {
+				if strings.ToLower(filepath.Clean(cs)) == cwd {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }
 
 // toolMuxStop stops a specific server.
@@ -572,7 +614,8 @@ func (s *Server) toolMuxRestart(id json.RawMessage, args json.RawMessage) {
 
 // resolveServerID returns a server ID from either an explicit ID or a name substring match.
 // If name is provided, scans all running instances and matches against command+args (case-insensitive).
-// Fails if neither is provided, or if name matches zero or multiple servers.
+// Prefers servers belonging to this CC session's project (by cwd).
+// Fails if neither is provided, or if name matches zero or multiple servers after cwd filtering.
 func (s *Server) resolveServerID(serverID, name string) (string, error) {
 	if serverID != "" {
 		return serverID, nil
@@ -581,6 +624,8 @@ func (s *Server) resolveServerID(serverID, name string) (string, error) {
 		return "", fmt.Errorf("provide either server_id or name")
 	}
 
+	myCwd, _ := os.Getwd()
+	myCwd = strings.ToLower(filepath.Clean(myCwd))
 	name = strings.ToLower(name)
 	tmpDir := os.TempDir()
 	entries, err := os.ReadDir(tmpDir)
@@ -588,7 +633,11 @@ func (s *Server) resolveServerID(serverID, name string) (string, error) {
 		return "", fmt.Errorf("read temp dir: %v", err)
 	}
 
-	var matches []string
+	type candidate struct {
+		sid    string
+		hasCwd bool // true if this server belongs to our cwd
+	}
+	var candidates []candidate
 	for _, entry := range entries {
 		fname := entry.Name()
 		if !strings.HasPrefix(fname, "mcp-mux-") || !strings.HasSuffix(fname, ".ctl.sock") {
@@ -603,29 +652,57 @@ func (s *Server) resolveServerID(serverID, name string) (string, error) {
 			continue
 		}
 
-		var status struct {
-			Command string   `json:"command"`
-			Args    []string `json:"args"`
-		}
-		if err := json.Unmarshal(resp.Data, &status); err != nil {
+		var data map[string]any
+		if err := json.Unmarshal(resp.Data, &data); err != nil {
 			continue
 		}
 
 		// Match against command + args concatenated
-		haystack := strings.ToLower(status.Command + " " + strings.Join(status.Args, " "))
+		cmd, _ := data["command"].(string)
+		var args []string
+		if rawArgs, ok := data["args"].([]any); ok {
+			for _, a := range rawArgs {
+				if as, ok := a.(string); ok {
+					args = append(args, as)
+				}
+			}
+		}
+		haystack := strings.ToLower(cmd + " " + strings.Join(args, " "))
 		if strings.Contains(haystack, name) {
-			matches = append(matches, sid)
+			candidates = append(candidates, candidate{
+				sid:    sid,
+				hasCwd: s.ownerHasCwd(data, myCwd),
+			})
 		}
 	}
 
-	switch len(matches) {
-	case 0:
+	if len(candidates) == 0 {
 		return "", fmt.Errorf("no server matching '%s' found", name)
-	case 1:
-		return matches[0], nil
-	default:
-		return "", fmt.Errorf("'%s' matches %d servers — be more specific or use server_id", name, len(matches))
 	}
+
+	// Prefer servers belonging to this session's cwd
+	var myCwdMatches []string
+	var allMatches []string
+	for _, c := range candidates {
+		allMatches = append(allMatches, c.sid)
+		if c.hasCwd {
+			myCwdMatches = append(myCwdMatches, c.sid)
+		}
+	}
+
+	// If exactly one match in our cwd — use it (even if there are others)
+	if len(myCwdMatches) == 1 {
+		return myCwdMatches[0], nil
+	}
+	// If multiple in our cwd — still ambiguous
+	if len(myCwdMatches) > 1 {
+		return "", fmt.Errorf("'%s' matches %d servers in this project — use server_id", name, len(myCwdMatches))
+	}
+	// No cwd match — fall back to all matches
+	if len(allMatches) == 1 {
+		return allMatches[0], nil
+	}
+	return "", fmt.Errorf("'%s' matches %d servers (none in this project) — be more specific or use server_id", name, len(allMatches))
 }
 
 // --- JSON-RPC response helpers ---

--- a/internal/mux/owner.go
+++ b/internal/mux/owner.go
@@ -245,6 +245,7 @@ func (o *Owner) readSession(s *Session) {
 
 // handleDownstreamMessage processes a message from a downstream session.
 func (o *Owner) handleDownstreamMessage(s *Session, msg *jsonrpc.Message) error {
+	o.logger.Printf("[TRACE] session %d → owner: type=%s method=%s id=%s (%d bytes)", s.ID, msg.Type, msg.Method, string(msg.ID), len(msg.Raw))
 	switch {
 	case msg.IsNotification():
 		// Suppress notifications/initialized for sessions that received a cached initialize response
@@ -325,7 +326,7 @@ func (o *Owner) handleDownstreamMessage(s *Session, msg *jsonrpc.Message) error 
 	case msg.IsResponse():
 		// Client is responding to a server→client request (e.g., sampling/createMessage).
 		// Forward as-is — the ID belongs to the upstream's request, no remapping needed.
-		o.logger.Printf("session %d: forwarding client response to upstream (id=%s)", s.ID, string(msg.ID))
+		o.logger.Printf("[TRACE] session %d: forwarding client response to upstream (id=%s, %d bytes)", s.ID, string(msg.ID), len(msg.Raw))
 		return o.upstream.WriteLine(msg.Raw)
 
 	default:
@@ -359,6 +360,7 @@ func (o *Owner) readUpstream() {
 // handleUpstreamMessage routes a message from the upstream to the correct session.
 // It also intercepts server→client requests like roots/list.
 func (o *Owner) handleUpstreamMessage(msg *jsonrpc.Message) error {
+	o.logger.Printf("[TRACE] upstream → owner: type=%s method=%s id=%s (%d bytes)", msg.Type, msg.Method, string(msg.ID), len(msg.Raw))
 	if msg.IsNotification() {
 		// Route progress notifications to owning session instead of broadcast
 		if msg.Method == "notifications/progress" {
@@ -405,21 +407,28 @@ func (o *Owner) handleUpstreamMessage(msg *jsonrpc.Message) error {
 	o.mu.RUnlock()
 
 	if !ok {
-		o.logger.Printf("session %d not found for response (may have disconnected)", result.SessionID)
+		o.logger.Printf("[TRACE] owner → session %d: NOT FOUND (disconnected?)", result.SessionID)
 		return nil
 	}
 
+	o.logger.Printf("[TRACE] owner → session %d: response (%d bytes)", result.SessionID, len(restored))
 	return session.WriteRaw(restored)
 }
 
 // handleUpstreamRequest handles server→client requests from the upstream.
-// The most important one is roots/list — the server asks what filesystem
-// boundaries are available. We respond with the owner's cwd as a file:// URI.
+// Most requests (roots/list, sampling, elicitation) are forwarded to the active
+// session — CC itself responds with correct per-session data.
 func (o *Owner) handleUpstreamRequest(msg *jsonrpc.Message) error {
 	switch msg.Method {
 	case "roots/list":
-		o.logger.Printf("upstream requested roots/list, responding with cwd: %s", o.cwd)
-		return o.respondToRootsList(msg.ID)
+		// Forward to the active session — CC knows its own roots.
+		// Falls back to local respondToRootsList if no active session.
+		o.logger.Printf("[TRACE] roots/list received from upstream, forwarding to active session")
+		err := o.routeToLastActiveSession(msg)
+		if err != nil {
+			o.logger.Printf("[TRACE] roots/list forward error: %v", err)
+		}
+		return err
 	case "ping":
 		// Respond locally with empty result — no client involvement needed
 		o.logger.Printf("upstream sent ping, responding locally")
@@ -431,7 +440,8 @@ func (o *Owner) handleUpstreamRequest(msg *jsonrpc.Message) error {
 }
 
 // respondToRootsList sends a roots/list response to the upstream with ALL known cwds.
-// With dedup, multiple projects may share one owner — each project's cwd is a root.
+// Used as fallback when no active session can handle roots/list directly.
+// In normal operation, roots/list is forwarded to the active session (CC answers).
 func (o *Owner) respondToRootsList(id json.RawMessage) error {
 	type rootEntry struct {
 		URI  string `json:"uri"`
@@ -488,15 +498,27 @@ func (o *Owner) routeToLastActiveSession(msg *jsonrpc.Message) error {
 	o.mu.RUnlock()
 
 	if !ok {
-		o.logger.Printf("no active session for server request %s, returning error", msg.Method)
-		if msg.Method == "elicitation/create" {
+		o.logger.Printf("no active session for server request %s", msg.Method)
+		switch msg.Method {
+		case "roots/list":
+			// Fallback: answer locally from cwdSet when no session can handle it
+			o.logger.Printf("roots/list fallback: responding locally with cwdSet")
+			return o.respondToRootsList(msg.ID)
+		case "elicitation/create":
 			return o.respondToElicitationCancel(msg.ID)
+		default:
+			return o.respondWithError(msg.ID, -32603, "no active session available")
 		}
-		return o.respondWithError(msg.ID, -32603, "no active session available")
 	}
 
-	o.logger.Printf("routing server request %s to session %d", msg.Method, sessionID)
-	return session.WriteRaw(msg.Raw)
+	o.logger.Printf("[TRACE] routing server request %s (id=%s) to session %d", msg.Method, string(msg.ID), sessionID)
+	err := session.WriteRaw(msg.Raw)
+	if err != nil {
+		o.logger.Printf("[TRACE] routing %s to session %d failed: %v", msg.Method, sessionID, err)
+	} else {
+		o.logger.Printf("[TRACE] routing %s to session %d succeeded, waiting for response", msg.Method, sessionID)
+	}
+	return err
 }
 
 // respondToElicitationCancel sends an elicitation cancel response to upstream.
@@ -821,12 +843,22 @@ func (o *Owner) Status() map[string]any {
 	hasCachedResources := o.resourceList != nil
 	o.mu.RUnlock()
 
+	// Collect cwdSet for status
+	o.mu.RLock()
+	cwds := make([]string, 0, len(o.cwdSet))
+	for c := range o.cwdSet {
+		cwds = append(cwds, c)
+	}
+	o.mu.RUnlock()
+
 	status := map[string]any{
 		"mux_version":      Version,
 		"upstream_pid":      o.upstream.PID(),
 		"ipc_path":          o.ipcPath,
 		"command":           o.command,
 		"args":              o.args,
+		"cwd":               o.cwd,
+		"cwd_set":           cwds,
 		"sessions":          sessionIDs,
 		"session_count":     len(sessionIDs),
 		"pending_requests":  o.pendingRequests.Load(),
@@ -871,6 +903,7 @@ func (o *Owner) getCachedResponse(method string) []byte {
 
 // replayFromCache sends a cached response to the session with the client's request ID.
 func (o *Owner) replayFromCache(s *Session, msg *jsonrpc.Message, cached []byte) error {
+	o.logger.Printf("[TRACE] cache → session %d: replaying %s (%d bytes)", s.ID, msg.Method, len(cached))
 	replaced, err := jsonrpc.ReplaceID(cached, msg.ID)
 	if err != nil {
 		return fmt.Errorf("replay %s: replace id: %w", msg.Method, err)

--- a/internal/mux/owner.go
+++ b/internal/mux/owner.go
@@ -841,14 +841,11 @@ func (o *Owner) Status() map[string]any {
 	hasCachedTools := o.toolList != nil
 	hasCachedPrompts := o.promptList != nil
 	hasCachedResources := o.resourceList != nil
-	o.mu.RUnlock()
-
-	// Collect cwdSet for status
-	o.mu.RLock()
 	cwds := make([]string, 0, len(o.cwdSet))
 	for c := range o.cwdSet {
 		cwds = append(cwds, c)
 	}
+	primaryCwd := o.cwd
 	o.mu.RUnlock()
 
 	status := map[string]any{
@@ -857,7 +854,7 @@ func (o *Owner) Status() map[string]any {
 		"ipc_path":          o.ipcPath,
 		"command":           o.command,
 		"args":              o.args,
-		"cwd":               o.cwd,
+		"cwd":               primaryCwd,
 		"cwd_set":           cwds,
 		"sessions":          sessionIDs,
 		"session_count":     len(sessionIDs),

--- a/internal/mux/resilient_client.go
+++ b/internal/mux/resilient_client.go
@@ -379,16 +379,25 @@ func (rc *resilientClient) replayInit(conn interface {
 	}
 	rc.log.Printf("resilient: replayed initialize request")
 
-	// Read and discard the response.
-	scanner := bufio.NewScanner(conn)
-	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
-	if !scanner.Scan() {
-		if err := scanner.Err(); err != nil {
+	// Read and discard the response — byte-by-byte to avoid bufio buffering.
+	// A bufio.Scanner would read ahead into its internal buffer, consuming
+	// subsequent messages (tools/list, prompts/list) that belong to runIPCReader.
+	buf := make([]byte, 0, 4096)
+	one := make([]byte, 1)
+	for {
+		_, err = conn.Read(one)
+		if err != nil {
 			return fmt.Errorf("read init response: %w", err)
 		}
-		return fmt.Errorf("read init response: EOF")
+		if one[0] == '\n' {
+			break
+		}
+		buf = append(buf, one[0])
+		if len(buf) > 1024*1024 {
+			return fmt.Errorf("read init response: line too long (%d bytes)", len(buf))
+		}
 	}
-	rc.log.Printf("resilient: discarded init replay response (%d bytes)", len(scanner.Bytes()))
+	rc.log.Printf("resilient: discarded init replay response (%d bytes)", len(buf))
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- **Critical fix**: `replayInit` in resilient_client.go used `bufio.Scanner` which buffered beyond the init response, consuming `tools/list`/`prompts/list` messages. CC hung forever waiting for responses that were already discarded. Fixed with byte-by-byte reading (zero over-read).
- **Forward roots/list**: Owner now forwards `roots/list` to the active CC session instead of answering locally from cwdSet. CC responds with its real, current roots. Fallback to cwdSet when no active session.
- **Debug logging**: Daemon writes to `$TEMP/mcp-muxd-debug.log` with microsecond timestamps. Owner logger shares daemon's writer (previously wrote to nil stderr).
- **Session-scoped mux_list**: `mux_list` filters by caller's cwd by default (shows only this project's servers). `all=true` for full list. `mux_restart(name="aimux")` resolves to this session's instance.

## Test plan

- [x] `go test ./...` — all pass
- [x] TRACE log confirms: `tools/list`, `prompts/list`, `resources/list` flow through Owner after replayInit fix
- [x] TRACE log confirms: `roots/list` forwarded to session → CC responds 79 bytes in <1ms
- [x] `mcp__time__get_current_time` responds instantly (was hanging 30+ min before fix)
- [x] Other CC sessions making `tools/call` successfully
- [ ] Verify `mux_list` default shows only this project's servers
- [ ] Verify `mux_restart(name="aimux")` targets correct instance
- [ ] Multi-project dedup test: roots/list returns correct per-session cwd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Примечания к выпуску

* **New Features**
  * Добавлен параметр `all` для просмотра серверов без фильтрации по текущей директории.
  * Статус сервера теперь включает информацию о рабочей директории и наборе известных директорий.

* **Bug Fixes**
  * Улучшена точность поиска/выбора сервера по контексту проекта и обработка неоднозначностей.
  * Исправлена обработка и отчёт об ошибках при чтении начальных ответов от подключений.

* **Chores**
  * Отладочные логи по умолчанию пишутся в файл с указанием пути.
  * Расширено трассировочное логирование обмена сообщениями и пересылки ответов.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->