### PR TITLE
fix: don't reuse isolated owners with closed IPC listeners

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -132,11 +132,17 @@ func (d *Daemon) Spawn(req control.Request) (string, string, string, error) {
 
 	// 1. Exact match (same command+args+cwd)?
 	if entry, ok := d.owners[sid]; ok {
-		entry.LastSession = time.Now()
-		d.mu.Unlock()
-		entry.Owner.SessionMgr().PreRegister(token, req.Cwd)
-		d.logger.Printf("reusing existing owner %s for %s", sid[:8], req.Command)
-		return entry.Owner.IPCPath(), sid, token, nil
+		if entry.Owner.IsAccepting() {
+			entry.LastSession = time.Now()
+			d.mu.Unlock()
+			entry.Owner.SessionMgr().PreRegister(token, req.Cwd)
+			d.logger.Printf("reusing existing owner %s for %s", sid[:8], req.Command)
+			return entry.Owner.IPCPath(), sid, token, nil
+		}
+		// Owner exists but IPC listener is closed (isolated server) — remove and re-spawn.
+		entry.Owner.Shutdown()
+		delete(d.owners, sid)
+		d.logger.Printf("owner %s not accepting (isolated), re-spawning", sid[:8])
 	}
 
 	// 2. Global dedup: if a shared owner for same command+args exists (any cwd), reuse it.

--- a/internal/mux/owner.go
+++ b/internal/mux/owner.go
@@ -857,6 +857,17 @@ func (o *Owner) IPCPath() string {
 	return o.ipcPath
 }
 
+// IsAccepting returns true if the IPC listener is still active (not closed).
+// Isolated owners close their listener after the first session connects.
+func (o *Owner) IsAccepting() bool {
+	select {
+	case <-o.listenerDone:
+		return false
+	default:
+		return true
+	}
+}
+
 // AddCwd registers an additional project cwd for this owner.
 // Used by dedup: when a second project reuses a shared owner,
 // its cwd is added so roots/list includes all project roots.


### PR DESCRIPTION
## Summary

Isolated servers (desktop-commander, playwright, wsl, pencil) failed to connect in new CC sessions because daemon reused existing owners whose IPC listeners were already closed.

## Root Cause

Isolated owners close their IPC listener after the first session connects (`closing IPC listener — server requires per-session isolation`). When a new CC session started, daemon's exact-match path returned the same owner without checking if it could accept connections. The new shim tried to dial the closed socket → connection refused → CC marked server as failed.

## Fix

- Added `Owner.IsAccepting()` — checks if IPC listener is still active via `listenerDone` channel
- Daemon checks `IsAccepting()` before reuse; if closed, shuts down the old owner and spawns fresh

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` all pass
- [ ] Manual: restart CC session → desktop-commander, playwright, wsl, pencil all connect