### PR TITLE
feat: dedup session-aware servers across cwds (4 aimux → 1)

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -284,9 +284,10 @@ func (d *Daemon) SetPersistent(serverID string, persistent bool) {
 }
 
 // findSharedOwner searches for an existing owner with the same command+args
-// that is classified as shared (stateless — no per-session state).
-// Session-aware and isolated servers are NOT deduped: they need per-cwd owners
-// because upstream uses roots/list to determine the working directory.
+// that can be shared across cwds. Both shared and session-aware servers are
+// eligible for dedup — session-aware servers route per-session via token
+// handshake (Session.Cwd) and inflight request correlation (SessionManager).
+// Only isolated servers are excluded: they require a dedicated owner per session.
 // Must be called with d.mu held.
 func (d *Daemon) findSharedOwner(command string, args []string) *OwnerEntry {
 	needle := command + " " + strings.Join(args, " ")
@@ -295,9 +296,9 @@ func (d *Daemon) findSharedOwner(command string, args []string) *OwnerEntry {
 		if candidate == needle {
 			status := entry.Owner.Status()
 			classification, _ := status["auto_classification"].(string)
-			// Only truly stateless (shared) servers can be deduped across cwds.
-			// Session-aware servers need per-cwd roots for correct upstream behavior.
-			if classification == "" || classification == "shared" {
+			// Isolated servers need their own owner (closed IPC listener after first session).
+			// Shared and session-aware servers can be deduped across cwds.
+			if classification != "isolated" {
 				return entry
 			}
 		}


### PR DESCRIPTION
## Summary

Session-aware servers (aimux) were excluded from dedup — 4 CC sessions = 4 aimux instances. Now they share one upstream via SessionManager per-session routing.

## Root Cause

`findSharedOwner` only returned owners with `classification == "shared"`. Session-aware was excluded because the old comment said "they need per-cwd owners for correct upstream behavior." This was true before Session Transport Layer — but with token handshake, SessionManager inflight correlation, and roots/list forward, session-aware servers can safely share one upstream.

## Fix

Changed `classification == "" || classification == "shared"` to `classification != "isolated"`. Only truly isolated servers get per-session owners now.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` all pass
- [ ] Manual: restart daemon → verify only 1 aimux instance for all CC sessions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **Улучшения**
  * Оптимизирована логика повторного использования существующих серверных соединений, что позволяет эффективнее переиспользовать ресурсы в различных рабочих контекстах, за исключением изолированных конфигураций.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->