### PR TITLE
fix: prevent dedup of unclassified or non-accepting isolated owners

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -294,11 +294,16 @@ func (d *Daemon) findSharedOwner(command string, args []string) *OwnerEntry {
 	for _, entry := range d.owners {
 		candidate := entry.Command + " " + strings.Join(entry.Args, " ")
 		if candidate == needle {
+			// Skip owners that can't accept connections (isolated with closed listener)
+			if !entry.Owner.IsAccepting() {
+				continue
+			}
 			status := entry.Owner.Status()
 			classification, _ := status["auto_classification"].(string)
-			// Isolated servers need their own owner (closed IPC listener after first session).
-			// Shared and session-aware servers can be deduped across cwds.
-			if classification != "isolated" {
+			// Only dedup if classification is known AND not isolated.
+			// Unknown ("") means upstream hasn't responded to tools/list yet — could be isolated.
+			// Isolated servers close their IPC listener after first session.
+			if classification != "" && classification != "isolated" {
 				return entry
 			}
 		}


### PR DESCRIPTION
## Summary

Fixes playwright, desktop-commander, wsl, and pencil failing in neighbor CC sessions after daemon restart or mux_restart.

## Root Cause

`findSharedOwner` matched owners with:
1. Closed IPC listeners (isolated post-first-session) — `IsAccepting()` not checked
2. Empty classification (upstream still starting) — `""` != `"isolated"` evaluated true

Both led to new sessions getting a dead or soon-to-die owner → "upstream process exited" → CC marked server as failed.

## Fix

- Check `IsAccepting()` before matching — skip owners with closed listeners
- Require non-empty classification — skip unclassified owners (upstream not yet initialized)
- Only dedup explicitly `"shared"` or `"session-aware"` owners

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` all pass  
- [ ] Manual: restart daemon → verify playwright/desktop-commander work in all CC sessions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Исправления ошибок**
  * Улучшена логика выбора общего владельца: система теперь исключает владельцев, неактивно принимающих соединения, из процесса дедупликации.
  * Уточнены условия дедупликации: операция применяется только для записей с явно определённой классификацией, исключая неизвестные состояния и изолированные соединения.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->