### PR TITLE
fix: optimistic dedup removes 15s blocking wait that froze all spawn requests

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -145,15 +145,15 @@ func (d *Daemon) Spawn(req control.Request) (string, string, string, error) {
 		d.logger.Printf("owner %s not accepting (isolated), re-spawning", sid[:8])
 	}
 
-	// 2. Global dedup: if a shared owner for same command+args exists (any cwd), reuse it.
-	//    This prevents N copies of stateless servers (tavily, time, nia) across projects.
+	// 2. Global dedup: if an accepting owner for same command+args exists (any cwd), reuse it.
+	//    Dedup is optimistic: unclassified owners are assumed shared/session-aware.
+	//    If the owner later classifies as isolated, it closes its listener — extra
+	//    sessions get EOF and reconnect, spawning their own owner.
 	if mode == serverid.ModeCwd {
-		existing := d.findSharedOwner(req.Command, req.Args)
-		if existing != nil {
+		if existing := d.findSharedOwner(req.Command, req.Args); existing != nil {
 			existing.LastSession = time.Now()
 			existingSID := existing.ServerID
 			d.mu.Unlock()
-			// Register this project's cwd so roots/list includes it
 			if req.Cwd != "" {
 				existing.Owner.AddCwd(req.Cwd)
 			}
@@ -161,32 +161,9 @@ func (d *Daemon) Spawn(req control.Request) (string, string, string, error) {
 			d.logger.Printf("dedup: reusing shared owner %s for %s (added cwd: %s)", existingSID[:8], req.Command, req.Cwd)
 			return existing.Owner.IPCPath(), existingSID, token, nil
 		}
-		// No dedup match — check if there's an unclassified owner we should wait for.
-		// This prevents spawning duplicate owners during the classification window.
-		if pending := d.findPendingOwner(req.Command, req.Args); pending != nil {
-			d.mu.Unlock()
-			d.logger.Printf("waiting for classification of owner %s before dedup decision", pending.ServerID[:8])
-			classification := d.waitForClassification(pending, 15*time.Second)
-			d.mu.Lock()
-			if classification != "" && classification != "isolated" && pending.Owner.IsAccepting() {
-				pending.LastSession = time.Now()
-				pendingSID := pending.ServerID
-				d.mu.Unlock()
-				if req.Cwd != "" {
-					pending.Owner.AddCwd(req.Cwd)
-				}
-				pending.Owner.SessionMgr().PreRegister(token, req.Cwd)
-				d.logger.Printf("dedup: reusing shared owner %s for %s after classification wait (added cwd: %s)", pendingSID[:8], req.Command, req.Cwd)
-				return pending.Owner.IPCPath(), pendingSID, token, nil
-			}
-			// Classification is isolated or timed out — fall through to spawn new owner.
-			d.mu.Unlock()
-		} else {
-			d.mu.Unlock()
-		}
-	} else {
-		d.mu.Unlock()
 	}
+
+	d.mu.Unlock()
 
 	ipcPath := serverid.IPCPath(sid)
 
@@ -308,70 +285,19 @@ func (d *Daemon) SetPersistent(serverID string, persistent bool) {
 }
 
 // findSharedOwner searches for an existing owner with the same command+args
-// that can be shared across cwds. Both shared and session-aware servers are
-// eligible for dedup — session-aware servers route per-session via token
-// handshake (Session.Cwd) and inflight request correlation (SessionManager).
-// Only isolated servers are excluded: they require a dedicated owner per session.
+// that is still accepting connections. Dedup is optimistic: unclassified owners
+// are assumed shareable. If an owner later classifies as isolated, it closes its
+// IPC listener — extra sessions get EOF and reconnect with their own owner.
 // Must be called with d.mu held.
 func (d *Daemon) findSharedOwner(command string, args []string) *OwnerEntry {
 	needle := command + " " + strings.Join(args, " ")
 	for _, entry := range d.owners {
 		candidate := entry.Command + " " + strings.Join(entry.Args, " ")
-		if candidate == needle {
-			// Skip owners that can't accept connections (isolated with closed listener)
-			if !entry.Owner.IsAccepting() {
-				continue
-			}
-			status := entry.Owner.Status()
-			classification, _ := status["auto_classification"].(string)
-			// Only dedup if classification is known AND not isolated.
-			// Unknown ("") means upstream hasn't responded to tools/list yet — could be isolated.
-			// Isolated servers close their IPC listener after first session.
-			if classification != "" && classification != "isolated" {
-				return entry
-			}
+		if candidate == needle && entry.Owner.IsAccepting() {
+			return entry
 		}
 	}
 	return nil
-}
-
-// findPendingOwner searches for an owner with the same command+args that hasn't
-// been classified yet (auto_classification is empty). Used to detect owners still
-// starting up so we can wait for classification instead of spawning a duplicate.
-// Must be called with d.mu held.
-func (d *Daemon) findPendingOwner(command string, args []string) *OwnerEntry {
-	needle := command + " " + strings.Join(args, " ")
-	for _, entry := range d.owners {
-		candidate := entry.Command + " " + strings.Join(entry.Args, " ")
-		if candidate == needle {
-			if !entry.Owner.IsAccepting() {
-				continue
-			}
-			status := entry.Owner.Status()
-			classification, _ := status["auto_classification"].(string)
-			if classification == "" {
-				return entry
-			}
-		}
-	}
-	return nil
-}
-
-// waitForClassification polls the owner's status until auto_classification is set
-// or timeout expires. Returns the classification or "" on timeout.
-// Called WITHOUT d.mu held.
-func (d *Daemon) waitForClassification(entry *OwnerEntry, timeout time.Duration) string {
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		status := entry.Owner.Status()
-		classification, _ := status["auto_classification"].(string)
-		if classification != "" {
-			return classification
-		}
-		time.Sleep(200 * time.Millisecond)
-	}
-	d.logger.Printf("waitForClassification: timed out for owner %s", entry.ServerID[:8])
-	return ""
 }
 
 // diffEnv returns only the env vars from shim that differ from daemon's own env.


### PR DESCRIPTION
## Summary

v0.4.10 introduced `waitForClassification` which blocked spawn for 15s per request while waiting for upstream to classify. With 4+ CC sessions, this serialized all spawns causing 60s+ delays and tool hangs.

## Fix

Optimistic dedup: any owner with `IsAccepting()` is reusable regardless of classification. If later classified isolated → listener closes → extra sessions EOF → reconnect → own owner.

Removed 86 lines: findPendingOwner, waitForClassification. findSharedOwner reduced to single `IsAccepting()` check.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` all pass
- [ ] Manual: daemon restart with 4 CC sessions — no 15s delays

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Оптимизация производительности**
  * Ускорено порождение процессов в определённом режиме за счёт упрощённой логики повторного использования: убрано ожидающее ожидание классификации, что снижает задержки при создании.

* **Рефакторинг**
  * Упрощена логика поиска и повторного использования существующих процессов/владельцев по совпадению команды и аргументов, улучшено управление подключениями и блокировками.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->