### PR TITLE
fix: drain in-flight requests when upstream dies (P0 hang fix)

### DIFF
--- a/internal/mux/owner.go
+++ b/internal/mux/owner.go
@@ -400,7 +400,10 @@ func (o *Owner) handleDownstreamMessage(s *Session, msg *jsonrpc.Message) error 
 
 // readUpstream reads responses from the upstream and routes them to the correct session.
 func (o *Owner) readUpstream() {
-	defer o.upstreamDead.Store(true) // mark dead so new requests fail fast
+	defer func() {
+		o.upstreamDead.Store(true)
+		o.drainInflightRequests() // send error responses for all pending requests
+	}()
 	for {
 		line, err := o.upstream.ReadLine()
 		if err != nil {
@@ -810,6 +813,40 @@ func (o *Owner) closeListener() {
 		o.listener.Close()
 		ipc.Cleanup(o.ipcPath)
 	})
+}
+
+// drainInflightRequests sends JSON-RPC error responses for all in-flight requests
+// when the upstream process dies. Without this, clients wait forever for responses
+// that will never come.
+func (o *Owner) drainInflightRequests() {
+	entries := o.sessionMgr.DrainInflight()
+	if len(entries) == 0 {
+		return
+	}
+	o.logger.Printf("upstream died: sending error responses for %d in-flight requests", len(entries))
+
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+
+	for _, entry := range entries {
+		result, err := remap.Deremap(json.RawMessage(`"` + entry.RemappedID + `"`))
+		if err != nil {
+			o.logger.Printf("drainInflight: deremap error for %s: %v", entry.RemappedID, err)
+			continue
+		}
+		session, ok := o.sessions[result.SessionID]
+		if !ok {
+			continue // session already disconnected
+		}
+		errResp := fmt.Sprintf(
+			`{"jsonrpc":"2.0","id":%s,"error":{"code":-32603,"message":"upstream process exited"}}`,
+			string(result.OriginalID),
+		)
+		if writeErr := session.WriteRaw([]byte(errResp)); writeErr != nil {
+			o.logger.Printf("drainInflight: write error to session %d: %v", result.SessionID, writeErr)
+		}
+		o.pendingRequests.Add(-1)
+	}
 }
 
 // Shutdown stops the owner, closing all sessions and the upstream.

--- a/internal/mux/session_manager.go
+++ b/internal/mux/session_manager.go
@@ -104,6 +104,25 @@ func (sm *SessionManager) CompleteRequest(remappedID string) {
 	delete(sm.inflight, remappedID)
 }
 
+// InflightEntry represents an in-flight request that needs an error response.
+type InflightEntry struct {
+	RemappedID string
+	SessionID  int
+}
+
+// DrainInflight removes all in-flight requests and returns them.
+// Used when upstream dies to send error responses to originating sessions.
+func (sm *SessionManager) DrainInflight() []InflightEntry {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	entries := make([]InflightEntry, 0, len(sm.inflight))
+	for remappedID, sessionID := range sm.inflight {
+		entries = append(entries, InflightEntry{RemappedID: remappedID, SessionID: sessionID})
+	}
+	sm.inflight = make(map[string]int)
+	return entries
+}
+
 // ResolveCallback returns the SessionContext that should handle a server→client
 // callback (roots/list, sampling, elicitation). Resolution logic:
 //  1. Collect unique session IDs from the inflight map.


### PR DESCRIPTION
## Summary

P0 fix: when upstream MCP server dies (crash/OOM/kill), in-flight requests now get immediate JSON-RPC error responses instead of hanging forever.

## Root Cause

`readUpstream` set `upstreamDead` flag on exit (v0.4.4), blocking NEW requests. But requests already sent to upstream (in-flight) never got responses — CC waited indefinitely with no timeout and no way to cancel.

## Fix

`readUpstream` now calls `drainInflightRequests()` on exit:
1. `SessionManager.DrainInflight()` atomically takes all inflight entries
2. Each entry is deremapped to find original request ID and session
3. JSON-RPC error `-32603 "upstream process exited"` sent to session
4. `pendingRequests` counter decremented

## Coverage

| Scenario | Before | After |
|----------|--------|-------|
| New request to dead upstream | Error (v0.4.4) | Error (v0.4.4) |
| In-flight request when upstream dies | **Hang forever** | **Error response** |

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` all pass
- [ ] Manual: kill aimux while tool call in progress → CC gets error, not hang

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Исправления ошибок**
  * При завершении восходящего процесса клиенты теперь получают явные ошибки для всех незавершённых запросов (вместо бесконечного ожидания). В результате некорректно зависшие ожидания очищаются и счётчики ожидающих запросов корректно уменьшаются, предотвращая блокировку взаимодействия.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->