### PR TITLE
fix: prevent suture supervisor log spam via Owner.String()

### DIFF
--- a/internal/mux/mux_test.go
+++ b/internal/mux/mux_test.go
@@ -667,63 +667,40 @@ func TestPromptsListCachedAndReplayed(t *testing.T) {
 
 // TestCacheInvalidatedOnListChanged verifies that when upstream sends a
 // notifications/tools/list_changed notification, the tools/list cache is cleared.
+//
+// Uses newMinimalOwner (no real upstream, no proactive init) to avoid a race
+// where proactive init's mux-init-1 (tools/list) response could re-populate
+// the cache AFTER the test's invalidation, causing spurious failures.
 func TestCacheInvalidatedOnListChanged(t *testing.T) {
-	ipcPath := testIPCPath(t)
+	o := newMinimalOwner()
+	o.controlServer = nil
+	defer o.Shutdown()
 
-	owner, err := NewOwner(OwnerConfig{
-		Command: "go",
-		Args:    []string{"run", "../../testdata/mock_server.go"},
-		IPCPath: ipcPath,
-		Logger:  testLogger(t),
-	})
-	if err != nil {
-		t.Fatalf("NewOwner() error: %v", err)
-	}
-	defer owner.Shutdown()
+	// Manually prime the cache (no real upstream needed)
+	o.mu.Lock()
+	o.toolList = []byte(`{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"echo"}]}}`)
+	o.mu.Unlock()
 
-	clientR, serverW := io.Pipe()
-	serverR, clientW := io.Pipe()
-	session := NewSession(serverR, serverW)
-	owner.AddSession(session)
-
-	// Prime the tools/list cache
-	sendReq(t, clientW, 1, "initialize", `{}`)
-	readResp(t, clientR)
-	sendReq(t, clientW, 2, "tools/list", `{}`)
-	readResp(t, clientR)
-
-	// Verify cache is set
-	owner.mu.RLock()
-	hasTools := owner.toolList != nil
-	owner.mu.RUnlock()
+	// Verify cache is set before invalidation
+	o.mu.RLock()
+	hasTools := o.toolList != nil
+	o.mu.RUnlock()
 	if !hasTools {
 		t.Fatal("toolList should be cached before invalidation test")
 	}
 
-	// Drain the client pipe so broadcast doesn't block
-	go func() {
-		buf := make([]byte, 4096)
-		for {
-			if _, err := clientR.Read(buf); err != nil {
-				return
-			}
-		}
-	}()
-
-	// Simulate upstream sending notifications/tools/list_changed by calling broadcast directly
+	// Simulate upstream sending notifications/tools/list_changed via broadcast.
+	// broadcast() is the code path that dispatches to invalidateCache which
+	// clears the tools/list cache.
 	listChangedNotif := []byte(`{"jsonrpc":"2.0","method":"notifications/tools/list_changed"}`)
-	if err := owner.broadcast(listChangedNotif); err != nil {
-		// Ignore broadcast errors (session may not be reading)
-		_ = err
+	if err := o.broadcast(listChangedNotif); err != nil {
+		_ = err // broadcast may fail if no sessions — that's fine, we only care about cache invalidation
 	}
 
-	// Small pause for processing
-	time.Sleep(50 * time.Millisecond)
-
-	// Verify cache is cleared
-	owner.mu.RLock()
-	hasToolsAfter := owner.toolList != nil
-	owner.mu.RUnlock()
+	// Verify cache is cleared synchronously (broadcast invalidation is sync).
+	o.mu.RLock()
+	hasToolsAfter := o.toolList != nil
+	o.mu.RUnlock()
 	if hasToolsAfter {
 		t.Error("toolList cache should have been cleared by notifications/tools/list_changed")
 	}

--- a/internal/mux/owner.go
+++ b/internal/mux/owner.go
@@ -1308,6 +1308,21 @@ func (o *Owner) Done() <-chan struct{} {
 	return o.done
 }
 
+// String implements fmt.Stringer to provide a compact identifier for
+// the suture supervisor's logging. Without this, suture falls back to
+// fmt.Sprintf("%#v", o) which dumps all fields — including raw []byte
+// caches (initResp, toolList can be 10s of KB) — on every termination
+// event. The reflected dump was 25 KB per log line and consumed 93%
+// of log volume during supervisor restart cycles (see aimux→mcp-mux
+// issue #5 comment 2026-04-10).
+func (o *Owner) String() string {
+	sid := o.serverID
+	if len(sid) > 8 {
+		sid = sid[:8]
+	}
+	return fmt.Sprintf("owner[%s %s]", sid, o.command)
+}
+
 // closedChan is a pre-closed channel used by upstreamDeadCh when the owner
 // has no upstream process. Returning a closed channel lets Serve observe
 // upstream-missing as a failure (so suture can backoff/restart) instead of

--- a/internal/mux/owner.go
+++ b/internal/mux/owner.go
@@ -1316,6 +1316,9 @@ func (o *Owner) Done() <-chan struct{} {
 // of log volume during supervisor restart cycles (see aimux→mcp-mux
 // issue #5 comment 2026-04-10).
 func (o *Owner) String() string {
+	if o == nil {
+		return "owner[<nil>]"
+	}
 	sid := o.serverID
 	if len(sid) > 8 {
 		sid = sid[:8]


### PR DESCRIPTION
## Summary

- Add `Owner.String()` to satisfy `fmt.Stringer`. Suture's `serviceName()` falls back to `fmt.Sprintf("%#v", service)` otherwise, dumping all Owner fields — including raw `[]byte` caches (`initResp`, `toolList`) — on every supervisor lifecycle event. Measured impact: ~25 KB per log line, 4.6 MB / 182 lines = 93% of log volume during restart cycles (reported by aimux team in engram issue #5).
- Stabilize `TestCacheInvalidatedOnListChanged`: previous version raced with proactive init's `mux-init-1` response re-populating the cache after invalidation. Switch to `newMinimalOwner()` with manual cache priming and a direct `broadcast()` call.

## Why this matters

After v0.9.2 fixed the acceptLoop spin, the daemon survived restarts — but log volume during restart storms was still pathological because every suture transition serialized the entire Owner struct via reflection. Implementing `fmt.Stringer` is the canonical fix per suture v4 docs and produces a compact `owner[<sid8> <command>]` identifier sufficient for lifecycle tracing.

## Test plan

- [x] `go build ./...` — green
- [x] `go test -count=1 -timeout 180s ./...` — all packages green
- [x] `go test -count=10 -run TestCacheInvalidatedOnListChanged ./internal/mux/` — 10/10 passes (was flaky on master)
- [ ] CodeRabbit / Gemini review pass
- [ ] Deploy via upgrade --restart, confirm aimux team that spam is gone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Примечания к выпуску

* **Tests**
  * Улучшены тесты кэширования: уменьшены внешние зависимости и убрана асинхронная задержка, повысилась надёжность и скорость проверок.

* **Refactor**
  * Уточнено формирование строкового представления внутренних объектов для более компактных и информативных логов без раскрытия крупных данных.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->