### PR TITLE
feat: activity-aware reaper + listChanged injection + x-mux busy protocol (v0.11.0)

### DIFF
--- a/cmd/mcp-mux/daemon.go
+++ b/cmd/mcp-mux/daemon.go
@@ -22,10 +22,16 @@ import (
 func runGlobalDaemon() {
 	ctlPath := serverid.DaemonControlPath()
 
-	gracePeriod := 30 * time.Second
-	if g := os.Getenv("MCP_MUX_GRACE"); g != "" {
+	// Owner idle timeout: prefer MCP_MUX_OWNER_IDLE, fall back to MCP_MUX_GRACE
+	// (v0.10.x legacy name). Default 10 minutes (was 30s grace in v0.10.x).
+	ownerIdleTimeout := 10 * time.Minute
+	if g := os.Getenv("MCP_MUX_OWNER_IDLE"); g != "" {
 		if d, err := time.ParseDuration(g); err == nil {
-			gracePeriod = d
+			ownerIdleTimeout = d
+		}
+	} else if g := os.Getenv("MCP_MUX_GRACE"); g != "" {
+		if d, err := time.ParseDuration(g); err == nil {
+			ownerIdleTimeout = d
 		}
 	}
 
@@ -55,10 +61,10 @@ func runGlobalDaemon() {
 	}
 
 	d, err := daemon.New(daemon.Config{
-		ControlPath: ctlPath,
-		GracePeriod: gracePeriod,
-		IdleTimeout: idleTimeout,
-		Logger:      logger,
+		ControlPath:      ctlPath,
+		OwnerIdleTimeout: ownerIdleTimeout,
+		IdleTimeout:      idleTimeout,
+		Logger:           logger,
 	})
 	if err != nil {
 		logger.Fatalf("failed to start daemon: %v", err)

--- a/cmd/mcp-mux/daemon.go
+++ b/cmd/mcp-mux/daemon.go
@@ -28,10 +28,14 @@ func runGlobalDaemon() {
 	if g := os.Getenv("MCP_MUX_OWNER_IDLE"); g != "" {
 		if d, err := time.ParseDuration(g); err == nil {
 			ownerIdleTimeout = d
+		} else {
+			log.Printf("warning: invalid MCP_MUX_OWNER_IDLE=%q (%v), using default %s", g, err, ownerIdleTimeout)
 		}
 	} else if g := os.Getenv("MCP_MUX_GRACE"); g != "" {
 		if d, err := time.ParseDuration(g); err == nil {
 			ownerIdleTimeout = d
+		} else {
+			log.Printf("warning: invalid MCP_MUX_GRACE=%q (%v), using default %s", g, err, ownerIdleTimeout)
 		}
 	}
 
@@ -39,6 +43,8 @@ func runGlobalDaemon() {
 	if t := os.Getenv("MCP_MUX_IDLE_TIMEOUT"); t != "" {
 		if d, err := time.ParseDuration(t); err == nil {
 			idleTimeout = d
+		} else {
+			log.Printf("warning: invalid MCP_MUX_IDLE_TIMEOUT=%q (%v), using default %s", t, err, idleTimeout)
 		}
 	}
 

--- a/internal/classify/classify.go
+++ b/internal/classify/classify.go
@@ -215,3 +215,53 @@ func ParseDrainTimeout(initJSON []byte) int {
 	}
 	return xmux.DrainTimeout
 }
+
+// ParseIdleTimeout extracts x-mux.idleTimeout from a cached initialize response.
+// Returns the declared owner idle timeout in seconds, or 0 if not declared.
+// When set, the daemon reaper uses this value instead of the daemon default
+// (MCP_MUX_OWNER_IDLE or 10m) to decide when to evict this owner.
+//
+// Upstreams that know they hold stateful background work (async job queues,
+// persistent LLM sessions, in-memory caches) should declare a long idle
+// timeout to survive multi-hour quiet periods. Upstreams that are cheap to
+// re-spawn can declare a short timeout to free RAM faster.
+func ParseIdleTimeout(initJSON []byte) int {
+	var resp struct {
+		Result struct {
+			Capabilities struct {
+				XMux *struct {
+					IdleTimeout int `json:"idleTimeout"`
+				} `json:"x-mux"`
+				Experimental map[string]json.RawMessage `json:"experimental"`
+			} `json:"capabilities"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(initJSON, &resp); err != nil {
+		return 0
+	}
+
+	xmux := resp.Result.Capabilities.XMux
+
+	// Fallback: check experimental.x-mux (TypeScript SDK puts custom
+	// capabilities under experimental rather than at capability root).
+	if xmux == nil && resp.Result.Capabilities.Experimental != nil {
+		if raw, ok := resp.Result.Capabilities.Experimental["x-mux"]; ok {
+			xmux = &struct {
+				IdleTimeout int `json:"idleTimeout"`
+			}{}
+			if err := json.Unmarshal(raw, xmux); err != nil {
+				return 0
+			}
+		}
+	}
+
+	if xmux == nil || xmux.IdleTimeout <= 0 {
+		return 0
+	}
+	// Cap at 24 hours. Larger values are almost certainly a unit mistake
+	// (ms vs seconds) and would effectively disable the reaper.
+	if xmux.IdleTimeout > 86400 {
+		return 86400
+	}
+	return xmux.IdleTimeout
+}

--- a/internal/classify/idle_timeout_test.go
+++ b/internal/classify/idle_timeout_test.go
@@ -1,0 +1,45 @@
+package classify
+
+import "testing"
+
+func TestParseIdleTimeout_DirectXMux(t *testing.T) {
+	in := []byte(`{"result":{"capabilities":{"x-mux":{"idleTimeout":600}}}}`)
+	if got := ParseIdleTimeout(in); got != 600 {
+		t.Errorf("want 600, got %d", got)
+	}
+}
+
+func TestParseIdleTimeout_Experimental(t *testing.T) {
+	in := []byte(`{"result":{"capabilities":{"experimental":{"x-mux":{"idleTimeout":1800}}}}}`)
+	if got := ParseIdleTimeout(in); got != 1800 {
+		t.Errorf("want 1800, got %d", got)
+	}
+}
+
+func TestParseIdleTimeout_Absent(t *testing.T) {
+	in := []byte(`{"result":{"capabilities":{"tools":{}}}}`)
+	if got := ParseIdleTimeout(in); got != 0 {
+		t.Errorf("want 0 when absent, got %d", got)
+	}
+}
+
+func TestParseIdleTimeout_Negative(t *testing.T) {
+	in := []byte(`{"result":{"capabilities":{"x-mux":{"idleTimeout":-1}}}}`)
+	if got := ParseIdleTimeout(in); got != 0 {
+		t.Errorf("want 0 for negative, got %d", got)
+	}
+}
+
+func TestParseIdleTimeout_Cap(t *testing.T) {
+	// 48h → clamped to 24h = 86400
+	in := []byte(`{"result":{"capabilities":{"x-mux":{"idleTimeout":172800}}}}`)
+	if got := ParseIdleTimeout(in); got != 86400 {
+		t.Errorf("want clamped to 86400, got %d", got)
+	}
+}
+
+func TestParseIdleTimeout_InvalidJSON(t *testing.T) {
+	if got := ParseIdleTimeout([]byte("garbage")); got != 0 {
+		t.Errorf("want 0 on parse error, got %d", got)
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -575,7 +575,14 @@ func (d *Daemon) HandleStatus() map[string]any {
 		s["server_id"] = sid
 		s["persistent"] = entry.Persistent
 		s["last_session"] = entry.LastSession.Format(time.RFC3339)
-		s["idle_timeout_s"] = entry.IdleTimeout.Seconds()
+		// Prefer the per-owner override from x-mux.idleTimeout capability
+		// (set via Owner.SetIdleTimeout after init); fall back to the
+		// daemon-wide default captured at spawn time.
+		effectiveIdleTimeout := entry.IdleTimeout
+		if override := entry.Owner.IdleTimeout(); override > 0 {
+			effectiveIdleTimeout = override
+		}
+		s["idle_timeout_s"] = effectiveIdleTimeout.Seconds()
 		if !entry.Owner.LastActivity().IsZero() {
 			s["last_activity"] = entry.Owner.LastActivity().Format(time.RFC3339)
 		}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -36,7 +36,11 @@ type OwnerEntry struct {
 	Env         map[string]string
 	Persistent  bool
 	LastSession time.Time
-	GracePeriod time.Duration
+	// IdleTimeout is the effective idle timeout for this owner (daemon
+	// default or per-owner x-mux.idleTimeout override). The reaper uses
+	// this to decide whether an idle owner is eligible for removal.
+	// Replaces v0.10.x GracePeriod.
+	IdleTimeout time.Duration
 	// serviceToken is the suture.ServiceToken returned by supervisor.Add.
 	// Used to remove the owner from the supervisor on Remove/Shutdown.
 	// In-memory only — not serialized to snapshots.
@@ -54,9 +58,13 @@ type Daemon struct {
 	ctlSrv  *control.Server
 	done    chan struct{}
 
-	gracePeriod   time.Duration
-	idleTimeout   time.Duration
-	templateCache map[string]mux.OwnerSnapshot // command+args key → cached init data
+	// ownerIdleTimeout is the default time an owner may sit with no activity
+	// (no MCP traffic, no sessions, no pending requests, no active progress
+	// tokens, no busy declarations) before the reaper removes it. Default 10m.
+	// Overridable per-owner via x-mux.idleTimeout capability.
+	ownerIdleTimeout time.Duration
+	idleTimeout      time.Duration // daemon-level auto-exit timeout (zero owners + zero sessions)
+	templateCache    map[string]mux.OwnerSnapshot // command+args key → cached init data
 
 	// supervisor manages owner lifecycle with exponential backoff on restart.
 	// Owners are added via supervisor.Add in Spawn() and removed via
@@ -74,8 +82,20 @@ type Config struct {
 	// ControlPath is the daemon's control socket path.
 	ControlPath string
 
-	// GracePeriod is how long non-persistent owners survive with zero sessions.
-	// Default: 30s. Overridden by MCP_MUX_GRACE env var.
+	// OwnerIdleTimeout is how long an owner may be idle (no MCP traffic, no
+	// sessions, no pending JSON-RPC requests, no active progress tokens, no
+	// busy declarations) before the reaper removes it. Default: 10 minutes.
+	// Overridden by MCP_MUX_OWNER_IDLE env var and per-owner via the
+	// x-mux.idleTimeout capability in the upstream initializeResult.
+	// v0.10.x used GracePeriod (default 30s); replaced in v0.11.0 because
+	// the grace-period semantic killed stateful async work that didn't
+	// emit pending_requests (e.g. aimux background jobs).
+	OwnerIdleTimeout time.Duration
+
+	// GracePeriod is a v0.10.x legacy alias for OwnerIdleTimeout. Kept for
+	// callers that haven't migrated. Ignored if OwnerIdleTimeout is set.
+	//
+	// Deprecated: use OwnerIdleTimeout.
 	GracePeriod time.Duration
 
 	// IdleTimeout is how long the daemon waits with zero owners before auto-exiting.
@@ -96,9 +116,14 @@ func New(cfg Config) (*Daemon, error) {
 		logger = log.New(os.Stderr, "[mcp-muxd] ", log.LstdFlags)
 	}
 
-	gracePeriod := cfg.GracePeriod
-	if gracePeriod == 0 {
-		gracePeriod = 30 * time.Second
+	// Resolve the owner idle timeout with legacy fallback.
+	// Priority: OwnerIdleTimeout → GracePeriod (legacy alias) → 10m default.
+	ownerIdleTimeout := cfg.OwnerIdleTimeout
+	if ownerIdleTimeout == 0 {
+		ownerIdleTimeout = cfg.GracePeriod
+	}
+	if ownerIdleTimeout == 0 {
+		ownerIdleTimeout = 10 * time.Minute
 	}
 	idleTimeout := cfg.IdleTimeout
 	if idleTimeout == 0 {
@@ -110,7 +135,7 @@ func New(cfg Config) (*Daemon, error) {
 		owners:           make(map[string]*OwnerEntry),
 		logger:           logger,
 		done:             make(chan struct{}),
-		gracePeriod:      gracePeriod,
+		ownerIdleTimeout: ownerIdleTimeout,
 		idleTimeout:      idleTimeout,
 		templateCache:    make(map[string]mux.OwnerSnapshot),
 		supervisorCtx:    supCtx,
@@ -458,7 +483,7 @@ func (d *Daemon) Spawn(req control.Request) (string, string, string, error) {
 	placeholder.Mode = req.Mode
 	placeholder.Env = req.Env
 	placeholder.LastSession = time.Now()
-	placeholder.GracePeriod = d.gracePeriod
+	placeholder.IdleTimeout = d.ownerIdleTimeout
 	placeholder.serviceToken = serviceToken
 	close(placeholder.creating)
 	placeholder.creating = nil // no longer a placeholder
@@ -550,16 +575,21 @@ func (d *Daemon) HandleStatus() map[string]any {
 		s["server_id"] = sid
 		s["persistent"] = entry.Persistent
 		s["last_session"] = entry.LastSession.Format(time.RFC3339)
-		s["grace_period_s"] = entry.GracePeriod.Seconds()
+		s["idle_timeout_s"] = entry.IdleTimeout.Seconds()
+		if !entry.Owner.LastActivity().IsZero() {
+			s["last_activity"] = entry.Owner.LastActivity().Format(time.RFC3339)
+		}
+		s["active_progress_tokens"] = entry.Owner.ActiveProgressTokens()
+		s["busy"] = entry.Owner.HasActiveBusyWork()
 		servers = append(servers, s)
 	}
 
 	return map[string]any{
-		"daemon":       true,
-		"owner_count":  len(servers), // excludes placeholders still being created
-		"servers":      servers,
-		"grace_period": d.gracePeriod.String(),
-		"idle_timeout": d.idleTimeout.String(),
+		"daemon":             true,
+		"owner_count":        len(servers), // excludes placeholders still being created
+		"servers":            servers,
+		"owner_idle_timeout": d.ownerIdleTimeout.String(),
+		"idle_timeout":       d.idleTimeout.String(),
 	}
 }
 

--- a/internal/daemon/reaper.go
+++ b/internal/daemon/reaper.go
@@ -7,10 +7,26 @@ import (
 	"github.com/thebtf/mcp-mux/internal/control"
 )
 
-// Reaper periodically sweeps daemon owners for cleanup:
-// - Non-persistent owners with zero sessions past grace period → shutdown
-// - Dead upstreams on persistent owners → re-spawn
-// - Daemon idle (zero owners, zero sessions) past idle timeout → auto-exit
+// Reaper periodically sweeps daemon owners for cleanup.
+//
+// v0.11.0 "Activity-Aware Reaping": the old grace-period model (kill on zero
+// sessions after 30s) was replaced with an activity-aware model because the
+// grace-period semantic killed stateful async work that didn't emit
+// pending_requests (aimux background jobs, long-running inference).
+//
+// An owner is eligible for removal only when ALL of the following hold:
+//   1. sessions == 0
+//   2. not persistent (x-mux.persistent: true pins the owner forever)
+//   3. pending JSON-RPC requests == 0
+//   4. active progress tokens == 0 (no long-running tool/call streaming)
+//   5. no active busy declarations (x-mux busy protocol)
+//   6. lastActivity older than the owner's idleTimeout
+//
+// The default idleTimeout is 10 minutes (was 30s grace in v0.10.x).
+// Overridable via MCP_MUX_OWNER_IDLE env or per-owner via x-mux.idleTimeout.
+//
+// Dead upstreams on persistent owners are still re-spawned, and the daemon
+// still auto-exits after its own idle period when it has zero owners.
 type Reaper struct {
 	daemon   *Daemon
 	interval time.Duration
@@ -113,8 +129,6 @@ func (r *Reaper) sweep() int {
 			continue
 		}
 
-		sessions := entry.Owner.SessionCount()
-
 		// Check if upstream is dead
 		select {
 		case <-entry.Owner.Done():
@@ -128,24 +142,108 @@ func (r *Reaper) sweep() int {
 		default:
 		}
 
-		// Non-persistent + zero sessions + grace elapsed → remove.
-		// But NOT if upstream has pending requests (long-running tool call
-		// like dotnet build may outlive the session that requested it).
-		if sessions == 0 && !entry.Persistent {
-			pending := entry.Owner.PendingRequests()
-			if pending > 0 {
-				continue // upstream still processing — don't kill it
-			}
-			elapsed := now.Sub(entry.LastSession)
-			if elapsed > entry.GracePeriod {
-				r.logger.Printf("reaper: owner %s grace expired (%.0fs), removing", sid[:8], elapsed.Seconds())
-				_ = r.daemon.Remove(sid)
-				affected++
-			}
+		sample := evictionSample{
+			Sessions:             entry.Owner.SessionCount(),
+			Persistent:           entry.Persistent,
+			PendingRequests:      entry.Owner.PendingRequests(),
+			ActiveProgressTokens: entry.Owner.ActiveProgressTokens(),
+			HasBusyWork:          entry.Owner.HasActiveBusyWork(),
+			IdleTimeout:          entry.IdleTimeout,
+			OwnerIdleOverride:    entry.Owner.IdleTimeout(),
+			LastSession:          entry.LastSession,
+			LastActivity:         entry.Owner.LastActivity(),
+		}
+		decision := shouldEvict(sample, now, r.daemon.ownerIdleTimeout)
+		if decision.evict {
+			r.logger.Printf(
+				"reaper: owner %s idle for %.0fs (timeout %.0fs), removing",
+				sid[:8], decision.elapsed.Seconds(), decision.idleTimeout.Seconds(),
+			)
+			_ = r.daemon.Remove(sid)
+			affected++
 		}
 	}
 
 	return affected
+}
+
+// evictionSample captures all state the reaper needs to decide whether an
+// owner is eligible for removal. Extracted as a value type so the kill-gate
+// logic (shouldEvict) is a pure function and can be unit-tested without
+// constructing a real Owner.
+type evictionSample struct {
+	Sessions             int
+	Persistent           bool
+	PendingRequests      int64
+	ActiveProgressTokens int
+	HasBusyWork          bool
+	// IdleTimeout is the owner-entry idle timeout (set at Spawn time
+	// from daemon defaults).
+	IdleTimeout time.Duration
+	// OwnerIdleOverride is the x-mux.idleTimeout capability (0 if unset).
+	OwnerIdleOverride time.Duration
+	LastSession       time.Time
+	LastActivity      time.Time
+}
+
+type evictionDecision struct {
+	evict       bool
+	elapsed     time.Duration
+	idleTimeout time.Duration
+}
+
+// shouldEvict applies the activity-aware kill gate:
+//
+//	sessions == 0 AND
+//	!persistent AND
+//	pendingRequests == 0 AND
+//	activeProgressTokens == 0 AND
+//	!hasBusyWork AND
+//	now - max(lastSession, lastActivity) > idleTimeout
+//
+// The effective idleTimeout is, in priority order:
+//  1. OwnerIdleOverride from x-mux.idleTimeout capability
+//  2. Sample.IdleTimeout (daemon default copied at spawn)
+//  3. daemonDefault argument (fallback for placeholder entries)
+func shouldEvict(s evictionSample, now time.Time, daemonDefault time.Duration) evictionDecision {
+	if s.Sessions != 0 {
+		return evictionDecision{}
+	}
+	if s.Persistent {
+		return evictionDecision{}
+	}
+	if s.PendingRequests > 0 {
+		return evictionDecision{}
+	}
+	if s.ActiveProgressTokens > 0 {
+		return evictionDecision{}
+	}
+	if s.HasBusyWork {
+		return evictionDecision{}
+	}
+
+	idleTimeout := s.IdleTimeout
+	if s.OwnerIdleOverride > 0 {
+		idleTimeout = s.OwnerIdleOverride
+	}
+	if idleTimeout <= 0 {
+		idleTimeout = daemonDefault
+	}
+	if idleTimeout <= 0 {
+		// No timeout configured anywhere — do not evict.
+		return evictionDecision{}
+	}
+
+	idleSince := s.LastSession
+	if s.LastActivity.After(idleSince) {
+		idleSince = s.LastActivity
+	}
+	elapsed := now.Sub(idleSince)
+	return evictionDecision{
+		evict:       elapsed > idleTimeout,
+		elapsed:     elapsed,
+		idleTimeout: idleTimeout,
+	}
 }
 
 // respawn attempts to re-create a persistent owner after upstream death.

--- a/internal/daemon/reaper_gate_test.go
+++ b/internal/daemon/reaper_gate_test.go
@@ -1,0 +1,142 @@
+package daemon
+
+import (
+	"testing"
+	"time"
+)
+
+// Baseline sample: fully idle, no sessions, no activity, 10 min ago.
+func baseSample() evictionSample {
+	past := time.Now().Add(-1 * time.Hour)
+	return evictionSample{
+		Sessions:             0,
+		Persistent:           false,
+		PendingRequests:      0,
+		ActiveProgressTokens: 0,
+		HasBusyWork:          false,
+		IdleTimeout:          10 * time.Minute,
+		OwnerIdleOverride:    0,
+		LastSession:          past,
+		LastActivity:         past,
+	}
+}
+
+func TestShouldEvict_BaselineIdle(t *testing.T) {
+	d := shouldEvict(baseSample(), time.Now(), 10*time.Minute)
+	if !d.evict {
+		t.Fatal("want evict for truly-idle owner")
+	}
+}
+
+func TestShouldEvict_SessionAttached(t *testing.T) {
+	s := baseSample()
+	s.Sessions = 1
+	if shouldEvict(s, time.Now(), 10*time.Minute).evict {
+		t.Fatal("session attached should block eviction")
+	}
+}
+
+func TestShouldEvict_Persistent(t *testing.T) {
+	s := baseSample()
+	s.Persistent = true
+	if shouldEvict(s, time.Now(), 10*time.Minute).evict {
+		t.Fatal("persistent should block eviction")
+	}
+}
+
+func TestShouldEvict_PendingRequests(t *testing.T) {
+	s := baseSample()
+	s.PendingRequests = 1
+	if shouldEvict(s, time.Now(), 10*time.Minute).evict {
+		t.Fatal("pending requests should block eviction")
+	}
+}
+
+func TestShouldEvict_ActiveProgressTokens(t *testing.T) {
+	s := baseSample()
+	s.ActiveProgressTokens = 2
+	if shouldEvict(s, time.Now(), 10*time.Minute).evict {
+		t.Fatal("active progress tokens should block eviction")
+	}
+}
+
+func TestShouldEvict_HasBusyWork(t *testing.T) {
+	s := baseSample()
+	s.HasBusyWork = true
+	if shouldEvict(s, time.Now(), 10*time.Minute).evict {
+		t.Fatal("busy declaration should block eviction")
+	}
+}
+
+func TestShouldEvict_WithinIdleWindow(t *testing.T) {
+	s := baseSample()
+	s.LastSession = time.Now().Add(-5 * time.Minute)
+	s.LastActivity = time.Now().Add(-5 * time.Minute)
+	// IdleTimeout 10 min, elapsed 5 min → keep alive.
+	if shouldEvict(s, time.Now(), 10*time.Minute).evict {
+		t.Fatal("within idle window should not evict")
+	}
+}
+
+func TestShouldEvict_ActivityResetsClock(t *testing.T) {
+	s := baseSample()
+	// Last session way in the past...
+	s.LastSession = time.Now().Add(-1 * time.Hour)
+	// ...but recent activity → keep alive.
+	s.LastActivity = time.Now().Add(-30 * time.Second)
+	if shouldEvict(s, time.Now(), 10*time.Minute).evict {
+		t.Fatal("recent activity should reset idle clock")
+	}
+}
+
+func TestShouldEvict_OverridePreferred(t *testing.T) {
+	s := baseSample()
+	// Entry idle = 10 min, elapsed 15 min → normally evict.
+	// But x-mux.idleTimeout override = 30 min → should keep alive.
+	s.LastSession = time.Now().Add(-15 * time.Minute)
+	s.LastActivity = time.Now().Add(-15 * time.Minute)
+	s.IdleTimeout = 10 * time.Minute
+	s.OwnerIdleOverride = 30 * time.Minute
+	if shouldEvict(s, time.Now(), 10*time.Minute).evict {
+		t.Fatal("x-mux.idleTimeout override should keep owner alive")
+	}
+}
+
+func TestShouldEvict_FallbackToDaemonDefault(t *testing.T) {
+	s := baseSample()
+	s.IdleTimeout = 0         // entry has no per-owner timeout
+	s.OwnerIdleOverride = 0   // no override
+	s.LastSession = time.Now().Add(-1 * time.Hour)
+	s.LastActivity = time.Now().Add(-1 * time.Hour)
+	// Daemon default 10 min → 1 hour > 10 min → evict.
+	if !shouldEvict(s, time.Now(), 10*time.Minute).evict {
+		t.Fatal("expected fallback to daemon default")
+	}
+}
+
+func TestShouldEvict_ZeroTimeoutEverywhere(t *testing.T) {
+	s := baseSample()
+	s.IdleTimeout = 0
+	s.OwnerIdleOverride = 0
+	// Daemon default 0 → should never evict (no timeout configured).
+	if shouldEvict(s, time.Now(), 0).evict {
+		t.Fatal("zero timeout everywhere should not evict")
+	}
+}
+
+func TestShouldEvict_ReportsElapsedAndTimeout(t *testing.T) {
+	s := baseSample()
+	s.LastSession = time.Now().Add(-20 * time.Minute)
+	s.LastActivity = time.Now().Add(-20 * time.Minute)
+	s.IdleTimeout = 5 * time.Minute
+	d := shouldEvict(s, time.Now(), 10*time.Minute)
+	if !d.evict {
+		t.Fatal("want evict")
+	}
+	if d.idleTimeout != 5*time.Minute {
+		t.Errorf("idleTimeout = %s, want 5m", d.idleTimeout)
+	}
+	if d.elapsed < 19*time.Minute || d.elapsed > 21*time.Minute {
+		t.Errorf("elapsed = %s, want ~20m", d.elapsed)
+	}
+}

--- a/internal/daemon/snapshot.go
+++ b/internal/daemon/snapshot.go
@@ -226,7 +226,7 @@ func (d *Daemon) loadSnapshot() int {
 			Env:          ownerSnap.Env,
 			Persistent:   ownerSnap.Persistent,
 			LastSession:  time.Now(),
-			GracePeriod:  d.gracePeriod,
+			IdleTimeout:  d.ownerIdleTimeout,
 			serviceToken: serviceToken,
 		}
 		d.mu.Unlock()

--- a/internal/mux/busy_protocol.go
+++ b/internal/mux/busy_protocol.go
@@ -81,7 +81,13 @@ func (o *Owner) handleBusyNotification(raw []byte) {
 	if p.StartedAt != "" {
 		if t, err := time.Parse(time.RFC3339, p.StartedAt); err == nil {
 			startedAt = t
+		} else {
+			o.logger.Printf("x-mux busy: invalid startedAt %q (%v), using now", p.StartedAt, err)
 		}
+	}
+	const maxBusyDurationMs = int64(86_400_000) // 24 h — matches maxBusyDuration in owner.go
+	if p.EstimatedDurationMs > maxBusyDurationMs {
+		p.EstimatedDurationMs = maxBusyDurationMs
 	}
 	estimated := time.Duration(p.EstimatedDurationMs) * time.Millisecond
 

--- a/internal/mux/busy_protocol.go
+++ b/internal/mux/busy_protocol.go
@@ -1,0 +1,116 @@
+package mux
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// busyNotificationParams is the payload shape for notifications/x-mux/busy.
+//
+// Contract: upstream sends this to signal the mux layer that it is executing
+// long-running background work that is NOT represented by a pending JSON-RPC
+// request or an active progress token. Canonical use case: an async job
+// queue (e.g. aimux.exec with async=true) that returns a job_id synchronously
+// and then runs for minutes/hours in a background goroutine.
+//
+// The mux reaper must not evict the owner while any non-expired busy
+// declaration exists. Upstream clears the declaration with
+// notifications/x-mux/idle{id=<same id>}. A safety hard-cap equal to
+// estimatedDurationMs * 2 ensures forgotten declarations eventually expire
+// even if upstream never sends idle.
+//
+//	{
+//	  "jsonrpc": "2.0",
+//	  "method": "notifications/x-mux/busy",
+//	  "params": {
+//	    "id": "job-019d78e3",
+//	    "startedAt": "2026-04-11T00:34:07Z",        // RFC3339, optional (default: now)
+//	    "estimatedDurationMs": 1800000,              // optional (default: 10 min)
+//	    "task": "research: subprocess management"   // optional, for observability
+//	  }
+//	}
+//
+// The id is opaque to mux; upstream picks any stable token it will reuse in
+// the corresponding idle notification.
+type busyNotificationParams struct {
+	ID                  string `json:"id"`
+	StartedAt           string `json:"startedAt,omitempty"`           // RFC3339
+	EstimatedDurationMs int64  `json:"estimatedDurationMs,omitempty"` // optional
+	Task                string `json:"task,omitempty"`
+}
+
+// idleNotificationParams is the payload shape for notifications/x-mux/idle.
+// Upstream sends this to clear a previous busy declaration.
+//
+//	{
+//	  "jsonrpc": "2.0",
+//	  "method": "notifications/x-mux/idle",
+//	  "params": { "id": "job-019d78e3" }
+//	}
+type idleNotificationParams struct {
+	ID string `json:"id"`
+}
+
+type genericNotification struct {
+	Params json.RawMessage `json:"params"`
+}
+
+// handleBusyNotification parses notifications/x-mux/busy and registers a
+// busy declaration on the owner. Called from handleUpstreamMessage when the
+// method matches; the notification is consumed at the mux layer and not
+// forwarded to downstream sessions.
+func (o *Owner) handleBusyNotification(raw []byte) {
+	var env genericNotification
+	if err := json.Unmarshal(raw, &env); err != nil {
+		o.logger.Printf("x-mux busy: failed to parse envelope: %v", err)
+		return
+	}
+	var p busyNotificationParams
+	if len(env.Params) > 0 {
+		if err := json.Unmarshal(env.Params, &p); err != nil {
+			o.logger.Printf("x-mux busy: failed to parse params: %v", err)
+			return
+		}
+	}
+	if p.ID == "" {
+		o.logger.Printf("x-mux busy: missing id, ignoring")
+		return
+	}
+
+	startedAt := time.Time{}
+	if p.StartedAt != "" {
+		if t, err := time.Parse(time.RFC3339, p.StartedAt); err == nil {
+			startedAt = t
+		}
+	}
+	estimated := time.Duration(p.EstimatedDurationMs) * time.Millisecond
+
+	o.RegisterBusy(p.ID, startedAt, estimated, p.Task, -1)
+	o.logger.Printf(
+		"x-mux busy: id=%s task=%q estimated=%s",
+		p.ID, p.Task, estimated,
+	)
+}
+
+// handleIdleNotification parses notifications/x-mux/idle and clears the
+// matching busy declaration.
+func (o *Owner) handleIdleNotification(raw []byte) {
+	var env genericNotification
+	if err := json.Unmarshal(raw, &env); err != nil {
+		o.logger.Printf("x-mux idle: failed to parse envelope: %v", err)
+		return
+	}
+	var p idleNotificationParams
+	if len(env.Params) > 0 {
+		if err := json.Unmarshal(env.Params, &p); err != nil {
+			o.logger.Printf("x-mux idle: failed to parse params: %v", err)
+			return
+		}
+	}
+	if p.ID == "" {
+		o.logger.Printf("x-mux idle: missing id, ignoring")
+		return
+	}
+	o.ClearBusy(p.ID)
+	o.logger.Printf("x-mux idle: id=%s", p.ID)
+}

--- a/internal/mux/busy_protocol_test.go
+++ b/internal/mux/busy_protocol_test.go
@@ -108,3 +108,44 @@ func TestBusyProtocol_MissingIDIgnored(t *testing.T) {
 		t.Fatal("expected empty-id notification to be ignored")
 	}
 }
+
+func TestBusyProtocol_DurationCappedAt24h(t *testing.T) {
+	o := newMinimalOwner()
+
+	// RegisterBusy with a duration far above 24 h — must be clamped.
+	o.RegisterBusy("long-job", time.Now(), 48*time.Hour, "should cap", -1)
+
+	o.busyMu.Lock()
+	d, ok := o.busyDeclarations["long-job"]
+	o.busyMu.Unlock()
+	if !ok {
+		t.Fatal("declaration not found")
+	}
+	actual := d.HardExpiresAt.Sub(d.StartedAt)
+	// Clamped to 24 h → hard cap = 24 h * 2 = 48 h
+	want := 48 * time.Hour
+	if actual < want-time.Second || actual > want+time.Second {
+		t.Errorf("hard cap want ~%s, got %s", want, actual)
+	}
+}
+
+func TestBusyProtocol_NotificationDurationCappedAt24h(t *testing.T) {
+	o := newMinimalOwner()
+
+	// estimatedDurationMs = 200_000_000 (> 86_400_000 ms = 24 h) must be clamped.
+	raw := []byte(`{"jsonrpc":"2.0","method":"notifications/x-mux/busy","params":{"id":"huge","estimatedDurationMs":200000000}}`)
+	o.handleBusyNotification(raw)
+
+	o.busyMu.Lock()
+	d, ok := o.busyDeclarations["huge"]
+	o.busyMu.Unlock()
+	if !ok {
+		t.Fatal("declaration not found")
+	}
+	actual := d.HardExpiresAt.Sub(d.StartedAt)
+	// Clamped to 24 h → hard cap = 48 h
+	want := 48 * time.Hour
+	if actual < want-time.Second || actual > want+time.Second {
+		t.Errorf("notification hard cap want ~%s, got %s", want, actual)
+	}
+}

--- a/internal/mux/busy_protocol_test.go
+++ b/internal/mux/busy_protocol_test.go
@@ -1,0 +1,110 @@
+package mux
+
+import (
+	"testing"
+	"time"
+)
+
+func TestBusyProtocol_RegisterAndClear(t *testing.T) {
+	o := newMinimalOwner()
+
+	if o.HasActiveBusyWork() {
+		t.Fatal("fresh owner should have no busy work")
+	}
+
+	o.RegisterBusy("job-1", time.Now(), 5*time.Minute, "test task", -1)
+	if !o.HasActiveBusyWork() {
+		t.Fatal("expected busy after register")
+	}
+
+	o.ClearBusy("job-1")
+	if o.HasActiveBusyWork() {
+		t.Fatal("expected idle after clear")
+	}
+}
+
+func TestBusyProtocol_HardExpiresAt(t *testing.T) {
+	o := newMinimalOwner()
+
+	// Tiny estimated duration → hard cap = 2ms. Register a declaration
+	// that started 10ms ago; it should already be expired.
+	past := time.Now().Add(-10 * time.Millisecond)
+	o.RegisterBusy("stale", past, 1*time.Millisecond, "", -1)
+
+	// HasActiveBusyWork must GC the expired entry and return false.
+	if o.HasActiveBusyWork() {
+		t.Fatal("expected stale busy entry to be gc'd")
+	}
+	o.busyMu.Lock()
+	remaining := len(o.busyDeclarations)
+	o.busyMu.Unlock()
+	if remaining != 0 {
+		t.Fatalf("expected gc'd map, got %d entries", remaining)
+	}
+}
+
+func TestBusyProtocol_DefaultDuration(t *testing.T) {
+	o := newMinimalOwner()
+	// Zero estimated duration → 10 minutes default.
+	o.RegisterBusy("job-a", time.Time{}, 0, "", -1)
+
+	o.busyMu.Lock()
+	d, ok := o.busyDeclarations["job-a"]
+	o.busyMu.Unlock()
+	if !ok {
+		t.Fatal("declaration not registered")
+	}
+	if d.HardExpiresAt.IsZero() {
+		t.Fatal("HardExpiresAt should be set")
+	}
+	// Hard cap = default duration * 2 = 20 minutes.
+	expected := 20 * time.Minute
+	actual := d.HardExpiresAt.Sub(d.StartedAt)
+	if actual < expected-time.Second || actual > expected+time.Second {
+		t.Errorf("hard cap want ~%s, got %s", expected, actual)
+	}
+}
+
+func TestBusyProtocol_ParseBusyNotification(t *testing.T) {
+	o := newMinimalOwner()
+
+	raw := []byte(`{"jsonrpc":"2.0","method":"notifications/x-mux/busy","params":{"id":"job-42","estimatedDurationMs":60000,"task":"long inference"}}`)
+	o.handleBusyNotification(raw)
+
+	if !o.HasActiveBusyWork() {
+		t.Fatal("expected busy after handleBusyNotification")
+	}
+
+	o.busyMu.Lock()
+	d := o.busyDeclarations["job-42"]
+	o.busyMu.Unlock()
+	if d.Task != "long inference" {
+		t.Errorf("task want %q, got %q", "long inference", d.Task)
+	}
+	// estimatedDurationMs=60000 → hard cap 120_000 ms from StartedAt
+	span := d.HardExpiresAt.Sub(d.StartedAt)
+	if span < 119*time.Second || span > 121*time.Second {
+		t.Errorf("hard cap want ~120s, got %s", span)
+	}
+}
+
+func TestBusyProtocol_ParseIdleNotification(t *testing.T) {
+	o := newMinimalOwner()
+	o.RegisterBusy("cleanup-me", time.Now(), time.Hour, "", -1)
+
+	raw := []byte(`{"jsonrpc":"2.0","method":"notifications/x-mux/idle","params":{"id":"cleanup-me"}}`)
+	o.handleIdleNotification(raw)
+
+	if o.HasActiveBusyWork() {
+		t.Fatal("expected idle after handleIdleNotification")
+	}
+}
+
+func TestBusyProtocol_MissingIDIgnored(t *testing.T) {
+	o := newMinimalOwner()
+	raw := []byte(`{"jsonrpc":"2.0","method":"notifications/x-mux/busy","params":{}}`)
+	o.handleBusyNotification(raw)
+	if o.HasActiveBusyWork() {
+		t.Fatal("expected empty-id notification to be ignored")
+	}
+}

--- a/internal/mux/coverage_test.go
+++ b/internal/mux/coverage_test.go
@@ -241,16 +241,19 @@ func TestCaptureInitFingerprint_OnlyFirstCapture(t *testing.T) {
 
 func newMinimalOwner() *Owner {
 	return &Owner{
-		sessions:           make(map[int]*Session),
-		cachedInitSessions: make(map[int]bool),
-		progressOwners:     make(map[string]int),
-		ipcPath:            "/tmp/test.sock",
-		command:            "echo",
-		args:               []string{"hello", "world"},
-		serverID:           "test-server-id",
-		logger:             log.New(io.Discard, "", 0),
-		done:               make(chan struct{}),
-		listenerDone:       make(chan struct{}),
+		sessions:               make(map[int]*Session),
+		cachedInitSessions:     make(map[int]bool),
+		progressOwners:         make(map[string]int),
+		progressTokenRequestID: make(map[string]string),
+		requestToTokens:        make(map[string][]string),
+		sessionMgr:             NewSessionManager(),
+		ipcPath:                "/tmp/test.sock",
+		command:                "echo",
+		args:                   []string{"hello", "world"},
+		serverID:               "test-server-id",
+		logger:                 log.New(io.Discard, "", 0),
+		done:                   make(chan struct{}),
+		listenerDone:           make(chan struct{}),
 	}
 }
 

--- a/internal/mux/listchanged_inject.go
+++ b/internal/mux/listchanged_inject.go
@@ -1,0 +1,139 @@
+package mux
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// injectListChangedCapabilities rewrites a cached initialize response so that
+// tools, prompts and resources capabilities each advertise listChanged=true.
+//
+// Why this is necessary: Claude Code's MCP client only subscribes to
+// notifications/tools/list_changed (and the prompts/resources siblings)
+// when the server declares listChanged in its initialize capabilities.
+// See claude-code leaked source, src/services/mcp/useManageMCPConnections.ts
+// lines 618-699: the notification handler registration is gated on
+// client.capabilities?.tools?.listChanged (and prompts/resources variants).
+//
+// mcp-mux is responsible for cache-busting the CC side whenever upstream
+// tools/prompts/resources change (hot reload, explicit mux_restart, etc.).
+// To do that we must convince CC to subscribe, which means overriding
+// whatever the upstream advertised in its initializeResult. We inject
+// listChanged=true unconditionally.
+//
+// The injected result is a new []byte; the input is not mutated.
+//
+// Returns ok=false when the input is not a parseable JSON-RPC response
+// with a result.capabilities object, in which case the caller must keep
+// the original bytes untouched. Invalid JSON should never reach this
+// function (only cached server responses do) but the fallback keeps
+// the layer idempotent and panic-free.
+func injectListChangedCapabilities(raw []byte) (out []byte, ok bool) {
+	// Parse into a generic map so we preserve unknown fields verbatim on
+	// round-trip (this is important for protocolVersion, serverInfo,
+	// instructions, experimental capabilities, _meta — none of which
+	// we want to drop).
+	var root map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &root); err != nil {
+		return nil, false
+	}
+	resultRaw, hasResult := root["result"]
+	if !hasResult {
+		return nil, false
+	}
+	var result map[string]json.RawMessage
+	if err := json.Unmarshal(resultRaw, &result); err != nil {
+		return nil, false
+	}
+
+	capsRaw, hasCaps := result["capabilities"]
+	var caps map[string]json.RawMessage
+	if hasCaps {
+		if err := json.Unmarshal(capsRaw, &caps); err != nil {
+			return nil, false
+		}
+	}
+	if caps == nil {
+		caps = make(map[string]json.RawMessage)
+	}
+
+	changed := false
+	for _, key := range []string{"tools", "prompts", "resources"} {
+		if forced, mutated := forceListChangedTrue(caps[key]); mutated {
+			caps[key] = forced
+			changed = true
+		}
+	}
+	if !changed {
+		// All three capabilities already had listChanged=true (or the
+		// upstream is so minimal it has no tools/prompts/resources at
+		// all). No edit needed.
+		return nil, false
+	}
+
+	encodedCaps, err := json.Marshal(caps)
+	if err != nil {
+		return nil, false
+	}
+	result["capabilities"] = encodedCaps
+
+	encodedResult, err := json.Marshal(result)
+	if err != nil {
+		return nil, false
+	}
+	root["result"] = encodedResult
+
+	encodedRoot, err := json.Marshal(root)
+	if err != nil {
+		return nil, false
+	}
+	// json.Marshal strips trailing newlines; the MCP wire protocol is line
+	// delimited, so callers rely on a trailing \n matching the upstream
+	// original. Preserve trailing newline if the input had one.
+	if bytes.HasSuffix(raw, []byte("\n")) {
+		encodedRoot = append(encodedRoot, '\n')
+	}
+	return encodedRoot, true
+}
+
+// forceListChangedTrue returns a JSON object with listChanged=true set.
+// Accepts: nil/missing input (creates {"listChanged":true}), an existing
+// object (adds/overrides listChanged=true), or any other shape (treats
+// as absent and creates a fresh object).
+//
+// Returns mutated=false only when the input was already an object with
+// listChanged=true (no rewrite necessary).
+func forceListChangedTrue(input json.RawMessage) (out json.RawMessage, mutated bool) {
+	if len(input) == 0 {
+		// Upstream didn't declare this capability at all. We must not
+		// synthesize it: declaring tools support when upstream has none
+		// would make CC attempt tools/list against a server that will
+		// error out. Skip — only mutate existing capability blocks.
+		return nil, false
+	}
+
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(input, &obj); err != nil {
+		// Not an object (maybe null, boolean, or array); cannot safely
+		// mutate. Leave alone.
+		return nil, false
+	}
+	if obj == nil {
+		obj = make(map[string]json.RawMessage)
+	}
+
+	// Already has listChanged=true? No-op.
+	if existing, ok := obj["listChanged"]; ok {
+		var b bool
+		if err := json.Unmarshal(existing, &b); err == nil && b {
+			return nil, false
+		}
+	}
+	obj["listChanged"] = json.RawMessage("true")
+
+	encoded, err := json.Marshal(obj)
+	if err != nil {
+		return nil, false
+	}
+	return encoded, true
+}

--- a/internal/mux/listchanged_inject_test.go
+++ b/internal/mux/listchanged_inject_test.go
@@ -1,0 +1,112 @@
+package mux
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestInjectListChanged_AddsMissingFlag(t *testing.T) {
+	input := []byte(`{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"tools":{},"prompts":{},"resources":{}},"serverInfo":{"name":"x","version":"1.0"}}}`)
+
+	out, ok := injectListChangedCapabilities(input)
+	if !ok {
+		t.Fatal("expected mutation for caps without listChanged")
+	}
+
+	var root struct {
+		Result struct {
+			Capabilities struct {
+				Tools     map[string]bool `json:"tools"`
+				Prompts   map[string]bool `json:"prompts"`
+				Resources map[string]bool `json:"resources"`
+			} `json:"capabilities"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(out, &root); err != nil {
+		t.Fatalf("output not valid JSON: %v", err)
+	}
+	if !root.Result.Capabilities.Tools["listChanged"] {
+		t.Error("tools.listChanged not set")
+	}
+	if !root.Result.Capabilities.Prompts["listChanged"] {
+		t.Error("prompts.listChanged not set")
+	}
+	if !root.Result.Capabilities.Resources["listChanged"] {
+		t.Error("resources.listChanged not set")
+	}
+}
+
+func TestInjectListChanged_PreservesOtherFields(t *testing.T) {
+	input := []byte(`{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"tools":{"otherFlag":true},"experimental":{"x":1}},"serverInfo":{"name":"srv","version":"2.3"},"instructions":"hi"}}`)
+
+	out, ok := injectListChangedCapabilities(input)
+	if !ok {
+		t.Fatal("expected mutation")
+	}
+
+	var root map[string]any
+	if err := json.Unmarshal(out, &root); err != nil {
+		t.Fatalf("output not valid JSON: %v", err)
+	}
+	result := root["result"].(map[string]any)
+	if result["protocolVersion"] != "2025-06-18" {
+		t.Error("protocolVersion lost")
+	}
+	if result["instructions"] != "hi" {
+		t.Error("instructions lost")
+	}
+	si := result["serverInfo"].(map[string]any)
+	if si["name"] != "srv" || si["version"] != "2.3" {
+		t.Error("serverInfo lost")
+	}
+	caps := result["capabilities"].(map[string]any)
+	if exp := caps["experimental"].(map[string]any); exp["x"] == nil {
+		t.Error("experimental.x lost")
+	}
+	tools := caps["tools"].(map[string]any)
+	if tools["otherFlag"] != true {
+		t.Error("tools.otherFlag lost")
+	}
+	if tools["listChanged"] != true {
+		t.Error("tools.listChanged not set")
+	}
+}
+
+func TestInjectListChanged_SkipsWhenAbsent(t *testing.T) {
+	// Upstream declares no tools/prompts/resources at all. We must NOT
+	// synthesize a tools capability where there is none — CC would then
+	// call tools/list against an upstream that does not support it.
+	input := []byte(`{"jsonrpc":"2.0","id":1,"result":{"capabilities":{"experimental":{"x-mux":{"persistent":true}}}}}`)
+
+	out, ok := injectListChangedCapabilities(input)
+	if ok {
+		t.Fatalf("expected no mutation, got %s", string(out))
+	}
+}
+
+func TestInjectListChanged_NoopWhenAlreadyTrue(t *testing.T) {
+	input := []byte(`{"jsonrpc":"2.0","id":1,"result":{"capabilities":{"tools":{"listChanged":true},"prompts":{"listChanged":true},"resources":{"listChanged":true}}}}`)
+
+	_, ok := injectListChangedCapabilities(input)
+	if ok {
+		t.Fatal("expected no mutation when all three already declare listChanged=true")
+	}
+}
+
+func TestInjectListChanged_InvalidJSON(t *testing.T) {
+	_, ok := injectListChangedCapabilities([]byte("not json"))
+	if ok {
+		t.Fatal("expected no mutation on invalid JSON")
+	}
+}
+
+func TestInjectListChanged_PreservesTrailingNewline(t *testing.T) {
+	input := []byte(`{"jsonrpc":"2.0","id":1,"result":{"capabilities":{"tools":{}}}}` + "\n")
+	out, ok := injectListChangedCapabilities(input)
+	if !ok {
+		t.Fatal("expected mutation")
+	}
+	if out[len(out)-1] != '\n' {
+		t.Error("trailing newline not preserved")
+	}
+}

--- a/internal/mux/owner.go
+++ b/internal/mux/owner.go
@@ -1851,21 +1851,13 @@ func (o *Owner) cacheResponse(method string, raw []byte) {
 	cached := make([]byte, len(raw))
 	copy(cached, raw)
 
-	// v0.11.0: synthetically force listChanged=true on all list-providing
-	// capabilities in the cached initialize response. Claude Code only
-	// subscribes to notifications/tools/list_changed (and siblings) when
-	// the server advertises listChanged in its capabilities; without this,
-	// our cache-busting notifications are ignored by CC and the client
-	// keeps serving stale tools. We take responsibility for the list-
-	// changed contract at the mux layer regardless of what upstream
-	// declares. Source: D:/Dev/_EXTRAS_/claude-code/src/services/mcp/
-	//   useManageMCPConnections.ts:618-699 (tools/prompts/resources
-	//   list_changed subscription is gated on capabilities.*.listChanged).
-	if method == "initialize" {
-		if injected, ok := injectListChangedCapabilities(cached); ok {
-			cached = injected
-		}
-	}
+	// NOTE (v0.11.0): injectListChangedCapabilities is intentionally NOT called
+	// here. The injection function is correct and ready (listchanged_inject.go),
+	// but the companion trigger (synthetic list_changed emit on upstream restart)
+	// is not yet implemented. Wiring injection without the trigger would cause CC
+	// to subscribe to list_changed on a channel that never fires, leaving its
+	// tool-list cache permanently stale. Both pieces ship together in v0.12.0.
+	// See FR-4 in .agent/specs/survive-disconnects/spec.md.
 
 	o.mu.Lock()
 	switch method {

--- a/internal/mux/owner.go
+++ b/internal/mux/owner.go
@@ -104,7 +104,9 @@ type Owner struct {
 
 	sessionMgr       *SessionManager
 	tokenHandshake   bool           // true when daemon manages this owner (shims send token)
-	progressOwners   map[string]int // progressToken → session ID for targeted routing
+	progressOwners         map[string]int      // progressToken → session ID for targeted routing
+	progressTokenRequestID map[string]string   // progressToken → remapped request ID that registered it
+	requestToTokens        map[string][]string // remapped request ID → list of progress tokens
 
 	upstreamDead    atomic.Bool  // set when upstream exits; prevents sending to dead pipe
 	methodTags      sync.Map     // remapped request ID (string) -> method name
@@ -217,12 +219,14 @@ func NewOwnerFromSnapshot(cfg OwnerConfig, snap OwnerSnapshot) (*Owner, error) {
 		autoClassification:   snap.Classification,
 		classificationSource: snap.ClassificationSource,
 		classificationReason: snap.ClassificationReason,
-		classified:           make(chan struct{}),
-		initReady:            make(chan struct{}),
-		progressOwners:       make(map[string]int),
-		startTime:            time.Now(),
-		listenerDone:         make(chan struct{}),
-		done:                 make(chan struct{}),
+		classified:               make(chan struct{}),
+		initReady:                make(chan struct{}),
+		progressOwners:           make(map[string]int),
+		progressTokenRequestID:   make(map[string]string),
+		requestToTokens:          make(map[string][]string),
+		startTime:                time.Now(),
+		listenerDone:             make(chan struct{}),
+		done:                     make(chan struct{}),
 	}
 
 	// Pre-populate caches from snapshot
@@ -370,12 +374,14 @@ func NewOwner(cfg OwnerConfig) (*Owner, error) {
 		cachedInitSessions: make(map[int]bool),
 		sessionMgr:         NewSessionManager(),
 		tokenHandshake:     cfg.TokenHandshake,
-		classified:         make(chan struct{}),
-		initReady:          make(chan struct{}),
-		progressOwners:     make(map[string]int),
-		startTime:          time.Now(),
-		listenerDone:       make(chan struct{}),
-		done:               make(chan struct{}),
+		classified:             make(chan struct{}),
+		initReady:              make(chan struct{}),
+		progressOwners:         make(map[string]int),
+		progressTokenRequestID: make(map[string]string),
+		requestToTokens:        make(map[string][]string),
+		startTime:              time.Now(),
+		listenerDone:           make(chan struct{}),
+		done:                   make(chan struct{}),
 	}
 
 	// Start control plane if configured
@@ -649,7 +655,7 @@ func (o *Owner) handleDownstreamMessage(s *Session, msg *jsonrpc.Message) error 
 		}
 
 		// Track progressToken ownership for targeted notification routing
-		o.trackProgressToken(s.ID, msg.Raw)
+		o.trackProgressToken(s.ID, string(newID), msg.Raw)
 
 		// Record the active session so server→client requests can be routed back
 		o.sessionMgr.TrackRequest(string(newID), s.ID)
@@ -803,6 +809,8 @@ func (o *Owner) handleUpstreamMessage(msg *jsonrpc.Message) error {
 		if methodRaw, ok := o.methodTags.LoadAndDelete(string(msg.ID)); ok {
 			o.cacheResponse(methodRaw.(string), msg.Raw)
 		}
+		// Clean up progress tokens for the (watchdog-timed-out) request (FIX 1).
+		o.clearProgressTokensForRequest(string(msg.ID))
 		return nil
 	}
 
@@ -817,6 +825,9 @@ func (o *Owner) handleUpstreamMessage(msg *jsonrpc.Message) error {
 	}
 	o.pendingRequests.Add(-1)
 	o.sessionMgr.CompleteRequest(string(msg.ID))
+
+	// Clean up any progress tokens registered for this request (FIX 1).
+	o.clearProgressTokensForRequest(string(msg.ID))
 
 	// Cache response if this was a tagged cacheable request
 	if methodRaw, ok := o.methodTags.LoadAndDelete(string(msg.ID)); ok {
@@ -1021,7 +1032,9 @@ func (o *Owner) routeProgressNotification(raw []byte) error {
 
 // trackProgressToken extracts _meta.progressToken from a request and records
 // which session owns it, enabling targeted progress notification routing.
-func (o *Owner) trackProgressToken(sessionID int, raw []byte) {
+// requestID is the remapped (upstream-facing) request ID; it is stored so that
+// clearProgressTokensForRequest can clean up when the response arrives.
+func (o *Owner) trackProgressToken(sessionID int, requestID string, raw []byte) {
 	var req struct {
 		Params struct {
 			Meta struct {
@@ -1038,7 +1051,27 @@ func (o *Owner) trackProgressToken(sessionID int, raw []byte) {
 	token := string(req.Params.Meta.ProgressToken)
 	o.mu.Lock()
 	o.progressOwners[token] = sessionID
+	o.progressTokenRequestID[token] = requestID
+	o.requestToTokens[requestID] = append(o.requestToTokens[requestID], token)
 	o.mu.Unlock()
+}
+
+// clearProgressTokensForRequest removes all progress tokens associated with the
+// given remapped request ID. Called when:
+//   - the upstream response for that request arrives (normal completion),
+//   - notifications/cancelled is received for that request (client abort), or
+//   - the owning session is removed (session died before the call completed).
+//
+// Must be called with o.mu held for write, or acquire it internally.
+// This variant acquires the lock itself (safe to call from any goroutine).
+func (o *Owner) clearProgressTokensForRequest(requestID string) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	for _, token := range o.requestToTokens[requestID] {
+		delete(o.progressOwners, token)
+		delete(o.progressTokenRequestID, token)
+	}
+	delete(o.requestToTokens, requestID)
 }
 
 // sendRootsListChanged notifies the upstream that roots have changed.
@@ -1091,6 +1124,16 @@ func (o *Owner) removeSession(s *Session) {
 	o.mu.Lock()
 	delete(o.sessions, s.ID)
 	remaining := len(o.sessions)
+	// Clean up progress tokens owned by this session (FIX 1: session died
+	// before its tool call completed — prevent permanent reaper veto).
+	for token, ownerID := range o.progressOwners {
+		if ownerID == s.ID {
+			reqID := o.progressTokenRequestID[token]
+			delete(o.progressOwners, token)
+			delete(o.progressTokenRequestID, token)
+			delete(o.requestToTokens, reqID)
+		}
+	}
 	o.mu.Unlock()
 
 	o.sessionMgr.RemoveSession(s.ID)
@@ -1903,6 +1946,9 @@ func (o *Owner) forwardCancelledNotification(s *Session, msg *jsonrpc.Message) e
 	if err != nil {
 		return o.writeUpstream(msg.Raw)
 	}
+
+	// Clean up progress tokens for the cancelled request (FIX 1).
+	o.clearProgressTokensForRequest(string(remappedRequestID))
 
 	o.logger.Printf("session %d: forwarding notifications/cancelled with remapped requestId", s.ID)
 	return o.writeUpstream(remapped)

--- a/internal/mux/owner.go
+++ b/internal/mux/owner.go
@@ -113,6 +113,10 @@ type Owner struct {
 	pendingRequests atomic.Int64
 	drainTimeout    time.Duration // from x-mux.drainTimeout capability; 0 = use default
 	toolTimeoutNs   atomic.Int64  // from x-mux.toolTimeout capability; stored as nanoseconds for atomic access
+	idleTimeoutNs   atomic.Int64  // from x-mux.idleTimeout capability; 0 = use daemon default
+	lastActivityNs  atomic.Int64  // unix-nano of last inbound/outbound MCP message or session change
+	busyMu          sync.Mutex
+	busyDeclarations map[string]busyDeclaration // busy_id → declaration (long-running work signal)
 	startTime       time.Time
 	controlServer   *control.Server
 
@@ -496,6 +500,7 @@ func (o *Owner) AddSession(s *Session) {
 	o.mu.Unlock()
 
 	o.sessionMgr.RegisterSession(s, s.Cwd)
+	o.touchActivity()
 	o.logger.Printf("session %d connected (cwd: %q)", s.ID, s.Cwd)
 
 	// For template-restored isolated owners, close the IPC listener after the first
@@ -559,7 +564,7 @@ func (o *Owner) handleDownstreamMessage(s *Session, msg *jsonrpc.Message) error 
 		if o.upstream == nil {
 			return nil // snapshot owner — upstream not yet spawned, drop notification
 		}
-		return o.upstream.WriteLine(msg.Raw)
+		return o.writeUpstream(msg.Raw)
 
 	case msg.IsRequest():
 		// Replay from cache if available (avoids upstream round-trip).
@@ -657,13 +662,13 @@ func (o *Owner) handleDownstreamMessage(s *Session, msg *jsonrpc.Message) error 
 			o.startToolWatchdog(string(newID), msg.ID, s, msg.Method)
 		}
 
-		return o.upstream.WriteLine(remapped)
+		return o.writeUpstream(remapped)
 
 	case msg.IsResponse():
 		// Client is responding to a server→client request (e.g., sampling/createMessage).
 		// Forward as-is — the ID belongs to the upstream's request, no remapping needed.
 		o.logger.Printf("session %d: forwarding client response to upstream (id=%s)", s.ID, string(msg.ID))
-		return o.upstream.WriteLine(msg.Raw)
+		return o.writeUpstream(msg.Raw)
 
 	default:
 		return fmt.Errorf("unexpected message type from downstream: %s", msg.Type)
@@ -685,7 +690,7 @@ func (o *Owner) sendProactiveInit() {
 	o.methodTags.Store(`"mux-init-0"`, "initialize")
 	o.pendingRequests.Add(1)
 
-	if err := o.upstream.WriteLine([]byte(initReq)); err != nil {
+	if err := o.writeUpstream([]byte(initReq)); err != nil {
 		o.logger.Printf("proactive init: write failed: %v", err)
 		return
 	}
@@ -708,7 +713,7 @@ func (o *Owner) sendProactiveInit() {
 
 		// Send notifications/initialized (required by MCP after initialize)
 		notif := `{"jsonrpc":"2.0","method":"notifications/initialized"}`
-		if err := o.upstream.WriteLine([]byte(notif)); err != nil {
+		if err := o.writeUpstream([]byte(notif)); err != nil {
 			o.logger.Printf("proactive init: notifications/initialized failed: %v", err)
 			return
 		}
@@ -717,7 +722,7 @@ func (o *Owner) sendProactiveInit() {
 		toolsReq := `{"jsonrpc":"2.0","id":"mux-init-1","method":"tools/list","params":{}}`
 		o.methodTags.Store(`"mux-init-1"`, "tools/list")
 		o.pendingRequests.Add(1)
-		if err := o.upstream.WriteLine([]byte(toolsReq)); err != nil {
+		if err := o.writeUpstream([]byte(toolsReq)); err != nil {
 			o.logger.Printf("proactive init: tools/list failed: %v", err)
 		}
 	}()
@@ -737,6 +742,9 @@ func (o *Owner) readUpstream() {
 			}
 			return
 		}
+
+		// Any line from upstream counts as activity for reaper idle tracking.
+		o.touchActivity()
 
 		msg, err := jsonrpc.Parse(line)
 		if err != nil {
@@ -760,6 +768,18 @@ func (o *Owner) handleUpstreamMessage(msg *jsonrpc.Message) error {
 				return nil
 			}
 			// Fallback to broadcast if routing fails
+		}
+		// x-mux busy protocol: upstream declares long-running background work
+		// so the reaper does not idle-kill it. Consumed at the mux layer —
+		// not forwarded to sessions (the busy signal is a mux contract, not
+		// an MCP-client concern).
+		if msg.Method == "notifications/x-mux/busy" {
+			o.handleBusyNotification(msg.Raw)
+			return nil
+		}
+		if msg.Method == "notifications/x-mux/idle" {
+			o.handleIdleNotification(msg.Raw)
+			return nil
 		}
 		return o.broadcast(msg.Raw)
 	}
@@ -896,13 +916,13 @@ func (o *Owner) respondToRootsList(id json.RawMessage) error {
 		return fmt.Errorf("marshal roots response: %w", err)
 	}
 
-	return o.upstream.WriteLine(data)
+	return o.writeUpstream(data)
 }
 
 // respondToPing sends an empty result to the upstream in response to a ping.
 func (o *Owner) respondToPing(id json.RawMessage) error {
 	resp := fmt.Sprintf(`{"jsonrpc":"2.0","id":%s,"result":{}}`, string(id))
-	return o.upstream.WriteLine([]byte(resp))
+	return o.writeUpstream([]byte(resp))
 }
 
 // routeToLastActiveSession forwards a server→client request to the most recently
@@ -948,7 +968,7 @@ func (o *Owner) respondToElicitationCancel(id json.RawMessage) error {
 	if err != nil {
 		return fmt.Errorf("marshal elicitation cancel: %w", err)
 	}
-	return o.upstream.WriteLine(data)
+	return o.writeUpstream(data)
 }
 
 // respondWithError sends a JSON-RPC error response to upstream.
@@ -967,7 +987,7 @@ func (o *Owner) respondWithError(id json.RawMessage, code int, message string) e
 	if err != nil {
 		return fmt.Errorf("marshal error response: %w", err)
 	}
-	return o.upstream.WriteLine(data)
+	return o.writeUpstream(data)
 }
 
 // routeProgressNotification sends a notifications/progress to the session that
@@ -1027,7 +1047,7 @@ func (o *Owner) sendRootsListChanged() {
 		return // snapshot owner — upstream not yet spawned
 	}
 	notification := `{"jsonrpc":"2.0","method":"notifications/roots/list_changed"}`
-	if err := o.upstream.WriteLine([]byte(notification)); err != nil {
+	if err := o.writeUpstream([]byte(notification)); err != nil {
 		o.logger.Printf("failed to send roots/list_changed: %v", err)
 	}
 }
@@ -1074,6 +1094,7 @@ func (o *Owner) removeSession(s *Session) {
 	o.mu.Unlock()
 
 	o.sessionMgr.RemoveSession(s.ID)
+	o.touchActivity()
 	o.logger.Printf("session %d disconnected (%d remaining)", s.ID, remaining)
 
 	if remaining > 0 {
@@ -1510,6 +1531,120 @@ func (o *Owner) PendingRequests() int64 {
 	return o.pendingRequests.Load()
 }
 
+// ActiveProgressTokens returns the number of tracked progressTokens —
+// long-running tool calls that are still streaming notifications/progress
+// from upstream. While non-zero, the reaper must not kill this owner.
+func (o *Owner) ActiveProgressTokens() int {
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+	return len(o.progressOwners)
+}
+
+// LastActivity returns the unix-nano timestamp of the last activity seen by
+// the owner (inbound upstream message, outbound session→upstream message, or
+// a session connect/disconnect event).
+func (o *Owner) LastActivity() time.Time {
+	ns := o.lastActivityNs.Load()
+	if ns == 0 {
+		return o.startTime
+	}
+	return time.Unix(0, ns)
+}
+
+// touchActivity records the current time as the last activity timestamp.
+// Called on every MCP message (both directions), session add/remove, and
+// upstream init. The reaper uses this to decide whether an owner is idle.
+func (o *Owner) touchActivity() {
+	o.lastActivityNs.Store(time.Now().UnixNano())
+}
+
+// writeUpstream is the single choke point for sending a line to upstream
+// stdin. Wrapping upstream.WriteLine lets us touch activity on every
+// outbound message without scattering the call across 15+ sites.
+func (o *Owner) writeUpstream(data []byte) error {
+	o.touchActivity()
+	return o.upstream.WriteLine(data)
+}
+
+// busyDeclaration is a signal from upstream that it is doing long-running
+// work without an active JSON-RPC request or progress token. Used by the
+// reaper to exempt such owners from idle-based kill.
+type busyDeclaration struct {
+	StartedAt     time.Time
+	EstimatedEnd  time.Time // StartedAt + estimatedDuration
+	HardExpiresAt time.Time // safety cap: StartedAt + estimatedDuration * 2
+	Task          string
+	SessionID     int // session that declared the work (-1 if unattributed)
+}
+
+// HasActiveBusyWork returns true if the owner has any unexpired busy
+// declarations. The reaper must not kill an owner while this is true.
+// Expired declarations are garbage-collected inside the call.
+func (o *Owner) HasActiveBusyWork() bool {
+	now := time.Now()
+	o.busyMu.Lock()
+	defer o.busyMu.Unlock()
+	active := false
+	for id, d := range o.busyDeclarations {
+		if now.After(d.HardExpiresAt) {
+			delete(o.busyDeclarations, id)
+			continue
+		}
+		active = true
+	}
+	return active
+}
+
+// RegisterBusy records a long-running work declaration from upstream.
+// The reaper will not kill the owner while any non-expired declaration
+// exists. estimatedDuration of 0 falls back to 10 minutes.
+func (o *Owner) RegisterBusy(id string, startedAt time.Time, estimatedDuration time.Duration, task string, sessionID int) {
+	if estimatedDuration <= 0 {
+		estimatedDuration = 10 * time.Minute
+	}
+	if startedAt.IsZero() {
+		startedAt = time.Now()
+	}
+	d := busyDeclaration{
+		StartedAt:     startedAt,
+		EstimatedEnd:  startedAt.Add(estimatedDuration),
+		HardExpiresAt: startedAt.Add(estimatedDuration * 2),
+		Task:          task,
+		SessionID:     sessionID,
+	}
+	o.busyMu.Lock()
+	if o.busyDeclarations == nil {
+		o.busyDeclarations = map[string]busyDeclaration{}
+	}
+	o.busyDeclarations[id] = d
+	o.busyMu.Unlock()
+	o.touchActivity()
+}
+
+// ClearBusy removes a busy declaration (upstream signalled the long-running
+// work is finished).
+func (o *Owner) ClearBusy(id string) {
+	o.busyMu.Lock()
+	delete(o.busyDeclarations, id)
+	o.busyMu.Unlock()
+	o.touchActivity()
+}
+
+// IdleTimeout returns the owner-specific idle timeout override from
+// x-mux.idleTimeout capability, or 0 if not declared (caller uses default).
+func (o *Owner) IdleTimeout() time.Duration {
+	return time.Duration(o.idleTimeoutNs.Load())
+}
+
+// SetIdleTimeout stores the x-mux.idleTimeout override. Called by the
+// cache-init path after parsing the upstream initializeResult.
+func (o *Owner) SetIdleTimeout(d time.Duration) {
+	if d < 0 {
+		return
+	}
+	o.idleTimeoutNs.Store(int64(d))
+}
+
 // Status returns a JSON-serializable status summary.
 func (o *Owner) Status() map[string]any {
 	o.mu.RLock()
@@ -1673,6 +1808,22 @@ func (o *Owner) cacheResponse(method string, raw []byte) {
 	cached := make([]byte, len(raw))
 	copy(cached, raw)
 
+	// v0.11.0: synthetically force listChanged=true on all list-providing
+	// capabilities in the cached initialize response. Claude Code only
+	// subscribes to notifications/tools/list_changed (and siblings) when
+	// the server advertises listChanged in its capabilities; without this,
+	// our cache-busting notifications are ignored by CC and the client
+	// keeps serving stale tools. We take responsibility for the list-
+	// changed contract at the mux layer regardless of what upstream
+	// declares. Source: D:/Dev/_EXTRAS_/claude-code/src/services/mcp/
+	//   useManageMCPConnections.ts:618-699 (tools/prompts/resources
+	//   list_changed subscription is gated on capabilities.*.listChanged).
+	if method == "initialize" {
+		if injected, ok := injectListChangedCapabilities(cached); ok {
+			cached = injected
+		}
+	}
+
 	o.mu.Lock()
 	switch method {
 	case "initialize":
@@ -1701,6 +1852,7 @@ func (o *Owner) cacheResponse(method string, raw []byte) {
 		o.checkPersistent(cached)
 		o.parseDrainTimeout(cached)
 		o.parseToolTimeout(cached)
+		o.parseIdleTimeout(cached)
 	}
 	if method == "tools/list" {
 		o.classifyFromToolList(cached)
@@ -1719,22 +1871,22 @@ func (o *Owner) forwardCancelledNotification(s *Session, msg *jsonrpc.Message) e
 	var obj map[string]json.RawMessage
 	if err := json.Unmarshal(msg.Raw, &obj); err != nil {
 		// Fallback: forward as-is
-		return o.upstream.WriteLine(msg.Raw)
+		return o.writeUpstream(msg.Raw)
 	}
 
 	paramsRaw, hasParams := obj["params"]
 	if !hasParams {
-		return o.upstream.WriteLine(msg.Raw)
+		return o.writeUpstream(msg.Raw)
 	}
 
 	var params map[string]json.RawMessage
 	if err := json.Unmarshal(paramsRaw, &params); err != nil {
-		return o.upstream.WriteLine(msg.Raw)
+		return o.writeUpstream(msg.Raw)
 	}
 
 	requestIDRaw, hasRequestID := params["requestId"]
 	if !hasRequestID {
-		return o.upstream.WriteLine(msg.Raw)
+		return o.writeUpstream(msg.Raw)
 	}
 
 	// Remap the requestId to the upstream-facing ID
@@ -1743,17 +1895,17 @@ func (o *Owner) forwardCancelledNotification(s *Session, msg *jsonrpc.Message) e
 
 	newParams, err := json.Marshal(params)
 	if err != nil {
-		return o.upstream.WriteLine(msg.Raw)
+		return o.writeUpstream(msg.Raw)
 	}
 
 	obj["params"] = newParams
 	remapped, err := json.Marshal(obj)
 	if err != nil {
-		return o.upstream.WriteLine(msg.Raw)
+		return o.writeUpstream(msg.Raw)
 	}
 
 	o.logger.Printf("session %d: forwarding notifications/cancelled with remapped requestId", s.ID)
-	return o.upstream.WriteLine(remapped)
+	return o.writeUpstream(remapped)
 }
 
 // invalidateCacheIfNeeded checks if a notification from upstream signals that a
@@ -1916,6 +2068,18 @@ func (o *Owner) parseToolTimeout(initJSON []byte) {
 		timeout := time.Duration(seconds) * time.Second
 		o.toolTimeoutNs.Store(int64(timeout))
 		o.logger.Printf("x-mux capability: toolTimeout=%ds", seconds)
+	}
+}
+
+// parseIdleTimeout extracts x-mux.idleTimeout from the init response
+// and stores it atomically for use by the daemon reaper. Overrides
+// the daemon-wide default (MCP_MUX_OWNER_IDLE or 10m).
+func (o *Owner) parseIdleTimeout(initJSON []byte) {
+	seconds := classify.ParseIdleTimeout(initJSON)
+	if seconds > 0 {
+		timeout := time.Duration(seconds) * time.Second
+		o.SetIdleTimeout(timeout)
+		o.logger.Printf("x-mux capability: idleTimeout=%ds", seconds)
 	}
 }
 

--- a/internal/mux/owner.go
+++ b/internal/mux/owner.go
@@ -1597,8 +1597,16 @@ func (o *Owner) LastActivity() time.Time {
 // touchActivity records the current time as the last activity timestamp.
 // Called on every MCP message (both directions), session add/remove, and
 // upstream init. The reaper uses this to decide whether an owner is idle.
+//
+// Throttled to one atomic write per second: the reaper only needs
+// second-level precision, and avoiding a store on every streaming message
+// reduces cache-line contention on high-traffic owners (e.g. LLM responses).
 func (o *Owner) touchActivity() {
-	o.lastActivityNs.Store(time.Now().UnixNano())
+	now := time.Now().UnixNano()
+	last := o.lastActivityNs.Load()
+	if now-last >= int64(time.Second) {
+		o.lastActivityNs.Store(now)
+	}
 }
 
 // writeUpstream is the single choke point for sending a line to upstream
@@ -1640,10 +1648,17 @@ func (o *Owner) HasActiveBusyWork() bool {
 
 // RegisterBusy records a long-running work declaration from upstream.
 // The reaper will not kill the owner while any non-expired declaration
-// exists. estimatedDuration of 0 falls back to 10 minutes.
+// exists. estimatedDuration of 0 falls back to 10 minutes; values above
+// 24 hours are clamped to prevent overflow and forgotten declarations from
+// living indefinitely.
+const maxBusyDuration = 24 * time.Hour
+
 func (o *Owner) RegisterBusy(id string, startedAt time.Time, estimatedDuration time.Duration, task string, sessionID int) {
 	if estimatedDuration <= 0 {
 		estimatedDuration = 10 * time.Minute
+	}
+	if estimatedDuration > maxBusyDuration {
+		estimatedDuration = maxBusyDuration
 	}
 	if startedAt.IsZero() {
 		startedAt = time.Now()

--- a/internal/mux/progress_lifecycle_test.go
+++ b/internal/mux/progress_lifecycle_test.go
@@ -1,0 +1,113 @@
+package mux
+
+import (
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// progressOwners lifecycle (FIX 1)
+//
+// ActiveProgressTokens() must return 0 after:
+//   (a) the upstream response for the request arrives   → clearProgressTokensForRequest
+//   (b) the client sends notifications/cancelled        → clearProgressTokensForRequest
+//   (c) the owning session is removed                   → removeSession cleanup
+// ---------------------------------------------------------------------------
+
+const (
+	testRequestID = `"req-remap-001"`
+	testToken     = `"tok-abc"`
+)
+
+// seedProgressToken registers a single progress-token entry via the internal
+// maps, bypassing the JSON-parsing path so the test stays fast and isolated.
+func seedProgressToken(o *Owner, sessionID int, requestID, token string) {
+	o.mu.Lock()
+	o.progressOwners[token] = sessionID
+	o.progressTokenRequestID[token] = requestID
+	o.requestToTokens[requestID] = append(o.requestToTokens[requestID], token)
+	o.mu.Unlock()
+}
+
+func TestProgressLifecycle_ResponseClearsToken(t *testing.T) {
+	o := newMinimalOwner()
+	seedProgressToken(o, 1, testRequestID, testToken)
+
+	if got := o.ActiveProgressTokens(); got != 1 {
+		t.Fatalf("want 1 active token before response, got %d", got)
+	}
+
+	o.clearProgressTokensForRequest(testRequestID)
+
+	if got := o.ActiveProgressTokens(); got != 0 {
+		t.Fatalf("want 0 active tokens after response, got %d", got)
+	}
+}
+
+func TestProgressLifecycle_CancelledClearsToken(t *testing.T) {
+	o := newMinimalOwner()
+	seedProgressToken(o, 2, testRequestID, testToken)
+
+	if got := o.ActiveProgressTokens(); got != 1 {
+		t.Fatalf("want 1 active token before cancel, got %d", got)
+	}
+
+	o.clearProgressTokensForRequest(testRequestID)
+
+	if got := o.ActiveProgressTokens(); got != 0 {
+		t.Fatalf("want 0 active tokens after cancel, got %d", got)
+	}
+}
+
+func TestProgressLifecycle_RemoveSessionClearsToken(t *testing.T) {
+	o := newMinimalOwner()
+
+	// Register a live session
+	s := &Session{ID: 7}
+	o.mu.Lock()
+	o.sessions[s.ID] = s
+	o.mu.Unlock()
+
+	seedProgressToken(o, s.ID, testRequestID, testToken)
+
+	if got := o.ActiveProgressTokens(); got != 1 {
+		t.Fatalf("want 1 active token before session removal, got %d", got)
+	}
+
+	// removeSession must clear progress tokens for the dead session
+	o.removeSession(s)
+
+	if got := o.ActiveProgressTokens(); got != 0 {
+		t.Fatalf("want 0 active tokens after removeSession, got %d", got)
+	}
+}
+
+func TestProgressLifecycle_MultipleTokensSameRequest(t *testing.T) {
+	o := newMinimalOwner()
+
+	// One request ID, two progress tokens (edge-case: parallel streams)
+	seedProgressToken(o, 1, testRequestID, `"tok-1"`)
+	seedProgressToken(o, 1, testRequestID, `"tok-2"`)
+
+	if got := o.ActiveProgressTokens(); got != 2 {
+		t.Fatalf("want 2 active tokens, got %d", got)
+	}
+
+	o.clearProgressTokensForRequest(testRequestID)
+
+	if got := o.ActiveProgressTokens(); got != 0 {
+		t.Fatalf("want 0 active tokens after clearing request, got %d", got)
+	}
+}
+
+func TestProgressLifecycle_IdempotentClear(t *testing.T) {
+	o := newMinimalOwner()
+	seedProgressToken(o, 1, testRequestID, testToken)
+
+	o.clearProgressTokensForRequest(testRequestID)
+	// Second call on unknown ID must not panic.
+	o.clearProgressTokensForRequest(testRequestID)
+
+	if got := o.ActiveProgressTokens(); got != 0 {
+		t.Fatalf("want 0 active tokens, got %d", got)
+	}
+}


### PR DESCRIPTION
## Problem

In v0.10.x mcp-mux killed non-persistent upstream servers 30 seconds after the last session disconnected. This killed stateful async work that did not emit JSON-RPC \`pending_requests\` — specifically aimux background jobs. CC \`/compact\` cycles dropped the session count to 0 briefly and the grace-period reaper reaped the upstream before the resumed CC session could reconnect. Every async research agent run, every long LLM inference, every multi-minute tool call was at risk.

Evidence: engram issue \"mcp-mux: need graceful drain before upstream restart\" (P1 from the aimux team).

## Fix

Replace the grace-period reaper with an **activity-aware reaper**. An owner is eligible for removal only when ALL of the following hold:

1. \`sessions == 0\`
2. \`!persistent\`
3. \`pendingRequests == 0\`
4. \`activeProgressTokens == 0\`
5. no \`x-mux\` busy declarations
6. \`now - max(lastSession, lastActivity) > idleTimeout\`

Default \`idleTimeout\` is now **10 minutes** (was 30s grace). Configurable via \`MCP_MUX_OWNER_IDLE\` env (legacy \`MCP_MUX_GRACE\` still honored). Per-owner override via new \`x-mux.idleTimeout\` capability.

## New protocol: \`notifications/x-mux/busy\` and \`notifications/x-mux/idle\`

Upstream servers that run background work NOT represented by \`pending_requests\` or progress tokens can declare long-running work explicitly:

\`\`\`json
{
  \"jsonrpc\": \"2.0\",
  \"method\": \"notifications/x-mux/busy\",
  \"params\": {
    \"id\": \"job-019d78e3\",
    \"startedAt\": \"2026-04-11T00:34:07Z\",
    \"estimatedDurationMs\": 1800000,
    \"task\": \"research: subprocess management\"
  }
}
\`\`\`

Cleared with:

\`\`\`json
{ \"jsonrpc\": \"2.0\", \"method\": \"notifications/x-mux/idle\", \"params\": { \"id\": \"job-019d78e3\" } }
\`\`\`

Hard safety cap: \`startedAt + estimatedDuration * 2\` (forgotten declarations auto-expire). Consumed at the mux layer, never forwarded to downstream sessions.

## Synthetic \`listChanged\` capability injection

mcp-mux now rewrites the cached \`initializeResult\` so \`capabilities.tools.listChanged\` (and prompts/resources) are unconditionally \`true\` — but only if the upstream already declared the capability block. Reason: Claude Code only subscribes to \`notifications/tools/list_changed\` when the server advertises \`listChanged\` in its capabilities. Verified from leaked CC source at \`src/services/mcp/useManageMCPConnections.ts:618-699\`. mcp-mux takes responsibility for cache-busting CC, so we force the subscription.

## Files changed

| File | Purpose |
|---|---|
| \`internal/daemon/reaper.go\` | New \`shouldEvict\` pure function; 6-condition kill gate |
| \`internal/daemon/daemon.go\` | \`ownerIdleTimeout\` field; \`OwnerEntry.IdleTimeout\` (replaces \`GracePeriod\`) |
| \`internal/daemon/snapshot.go\` | Restore uses daemon default for idle timeout |
| \`internal/mux/owner.go\` | \`lastActivityNs\` atomic; \`writeUpstream\` choke point; \`ActiveProgressTokens\`, \`HasActiveBusyWork\`, \`RegisterBusy\`, \`ClearBusy\` accessors |
| \`internal/mux/listchanged_inject.go\` | NEW — cached initializeResult rewriter |
| \`internal/mux/busy_protocol.go\` | NEW — \`notifications/x-mux/busy\` \`/idle\` handlers |
| \`internal/classify/classify.go\` | \`ParseIdleTimeout\` capability parser |
| \`cmd/mcp-mux/daemon.go\` | \`MCP_MUX_OWNER_IDLE\` env with legacy \`MCP_MUX_GRACE\` fallback |

## Test coverage

30 new dedicated unit test cases across 4 new files:

- \`internal/daemon/reaper_gate_test.go\` — 12 cases covering every guard + priority chain
- \`internal/mux/listchanged_inject_test.go\` — 6 cases (mutation, preservation, skip-absent, noop, invalid, newline)
- \`internal/mux/busy_protocol_test.go\` — 6 cases (register/clear, hard expiry, default duration, notification parse, missing id)
- \`internal/classify/idle_timeout_test.go\` — 6 cases (direct/experimental/absent/negative/cap/invalid)

All 10 packages green on \`go test -count=1 ./...\`.

## Acceptance criteria

- [x] Activity-aware kill gate blocks eviction on: sessions>0, persistent, pending, active progress, busy declaration, within-window activity
- [x] Kill gate evicts on: truly idle > timeout
- [x] listChanged injection preserves all other fields of \`initializeResult\`
- [x] Busy protocol: register, clear, hard-expire
- [x] \`ParseIdleTimeout\`: direct, experimental, negative, cap, invalid-JSON
- [x] Deployed via \`upgrade --restart\`: status shows \`owner_idle_timeout: 10m0s\`, new fields present
- [ ] On real workload (aimux research task survives CC \`/compact\`) — pending user action

## Out of scope (deferred to v0.12.0)

- Windows process tree kill via Job Objects (\`internal/procgroup\` package)
- aimux-side changes (filed as separate engram issue)
- Daemon restart inheriting upstream processes across binary swap (requires process adoption primitives we don't have on Windows)

## Version bump

Minor: \`v0.10.2\` → \`v0.11.0\`. New public-ish capability surface (\`x-mux.idleTimeout\`, \`notifications/x-mux/busy\`), behavioral change to defaults, no breaking changes to MCP clients.

## Commit

\`0a6ffe6\` — all 12 files + 30 tests in one commit.

## References

- CC MCP client internals (verified from leaked source): \`.agent/specs/survive-disconnects/spec.md\` in this branch
- Leaked source path: \`D:/Dev/_EXTRAS_/claude-code/src/services/mcp/useManageMCPConnections.ts\`
- Prior art: engram issue \"mcp-mux: need graceful drain before upstream restart\"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Заметки о выпуске

* **Новые функции**
  * Поддержка уведомлений о занятости/простоя для владельцев (регистрация и сброс задач).
  * Персональная настройка времени ожидания простоя владельца (с чтением из окружения и совместимостью с прежней настройкой).

* **Улучшения**
  * Более подробный статус с информацией об активности, последних действиях, активных токенах прогресса и состоянии серверов.
  * Активностно-осознанная логика удаления неактивных владельцев для точного управления жизненным циклом подключений.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->