### PR TITLE
fix: rollback cwdSet on isolation + snapshot auto-heal (v0.11.1)

### DIFF
--- a/internal/daemon/snapshot.go
+++ b/internal/daemon/snapshot.go
@@ -8,23 +8,24 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/thebtf/mcp-mux/internal/classify"
 	"github.com/thebtf/mcp-mux/internal/mux"
 	"github.com/thebtf/mcp-mux/internal/serverid"
 	"github.com/thejerf/suture/v4"
 )
 
 const (
-	snapshotFileName   = "mcp-muxd-snapshot.json"
-	snapshotVersion    = 1
-	snapshotMaxAge     = 5 * time.Minute
+	snapshotFileName = "mcp-muxd-snapshot.json"
+	snapshotVersion  = 1
+	snapshotMaxAge   = 5 * time.Minute
 )
 
 // DaemonSnapshot captures the full daemon state for graceful restart.
 type DaemonSnapshot struct {
-	Version    int                  `json:"version"`
-	MuxVersion string               `json:"mux_version"`
-	Timestamp  string               `json:"timestamp"`
-	Owners     []mux.OwnerSnapshot  `json:"owners"`
+	Version    int                   `json:"version"`
+	MuxVersion string                `json:"mux_version"`
+	Timestamp  string                `json:"timestamp"`
+	Owners     []mux.OwnerSnapshot   `json:"owners"`
 	Sessions   []mux.SessionSnapshot `json:"sessions"`
 }
 
@@ -171,16 +172,24 @@ func (d *Daemon) loadSnapshot() int {
 		ipcPath := serverid.IPCPath(sid)
 		controlPath := serverid.ControlPath(sid)
 
+		if ownerSnap.ClassificationSource != "" &&
+			ownerSnap.Classification == classify.ModeIsolated &&
+			len(ownerSnap.CwdSet) > 1 {
+			d.logger.Printf("snapshot: healing poisoned isolated owner %s: cwdSet %v → [%s]",
+				sid[:8], ownerSnap.CwdSet, ownerSnap.Cwd)
+			ownerSnap.CwdSet = []string{ownerSnap.Cwd}
+		}
+
 		// Capture loop variables for closure
 		cmd, args := ownerSnap.Command, ownerSnap.Args
 		owner, err := mux.NewOwnerFromSnapshot(mux.OwnerConfig{
-			Command:     cmd,
-			Args:        args,
-			Env:         ownerSnap.Env,
-			Cwd:         ownerSnap.Cwd,
-			IPCPath:     ipcPath,
-			ControlPath: controlPath,
-			ServerID:    sid,
+			Command:        cmd,
+			Args:           args,
+			Env:            ownerSnap.Env,
+			Cwd:            ownerSnap.Cwd,
+			IPCPath:        ipcPath,
+			ControlPath:    controlPath,
+			ServerID:       sid,
 			TokenHandshake: true,
 			OnZeroSessions: func(serverID string) {
 				d.onZeroSessions(serverID)

--- a/internal/daemon/snapshot.go
+++ b/internal/daemon/snapshot.go
@@ -172,11 +172,14 @@ func (d *Daemon) loadSnapshot() int {
 		ipcPath := serverid.IPCPath(sid)
 		controlPath := serverid.ControlPath(sid)
 
-		if ownerSnap.ClassificationSource != "" &&
-			ownerSnap.Classification == classify.ModeIsolated &&
+		if ownerSnap.Classification == classify.ModeIsolated &&
 			len(ownerSnap.CwdSet) > 1 {
+			shortSID := sid
+			if len(shortSID) > 8 {
+				shortSID = shortSID[:8]
+			}
 			d.logger.Printf("snapshot: healing poisoned isolated owner %s: cwdSet %v → [%s]",
-				sid[:8], ownerSnap.CwdSet, ownerSnap.Cwd)
+				shortSID, ownerSnap.CwdSet, ownerSnap.Cwd)
 			ownerSnap.CwdSet = []string{ownerSnap.Cwd}
 		}
 

--- a/internal/daemon/snapshot_test.go
+++ b/internal/daemon/snapshot_test.go
@@ -349,3 +349,62 @@ func TestGracefulRestartCycle(t *testing.T) {
 
 	d2.Shutdown()
 }
+
+func TestLoadSnapshot_HealsIsolatedOwnerCwdSet(t *testing.T) {
+	os.Remove(SnapshotPath())
+
+	primaryCwd := t.TempDir()
+	otherCwd := t.TempDir()
+	snapshot := DaemonSnapshot{
+		Version:   snapshotVersion,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Owners: []mux.OwnerSnapshot{
+			{
+				ServerID:             "abc12345-heal-test",
+				Command:              "uvx",
+				Args:                 []string{"--from", "serena"},
+				Cwd:                  primaryCwd,
+				CwdSet:               []string{primaryCwd, otherCwd},
+				Mode:                 "cwd",
+				Classification:       classify.ModeIsolated,
+				ClassificationSource: "tools",
+			},
+		},
+	}
+
+	data, err := json.Marshal(snapshot)
+	if err != nil {
+		t.Fatalf("json.Marshal() error: %v", err)
+	}
+
+	path := SnapshotPath()
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(path)
+
+	d := testDaemon(t)
+	restored := d.loadSnapshot()
+	if restored != 1 {
+		t.Fatalf("loadSnapshot() restored %d owners, want 1", restored)
+	}
+
+	d.mu.RLock()
+	entry := d.owners["abc12345-heal-test"]
+	d.mu.RUnlock()
+	if entry == nil || entry.Owner == nil {
+		t.Fatal("restored owner is nil")
+	}
+
+	status := entry.Owner.Status()
+	cwdSet, ok := status["cwd_set"].([]string)
+	if !ok {
+		t.Fatalf("cwd_set not []string in status: %T", status["cwd_set"])
+	}
+	if len(cwdSet) != 1 {
+		t.Fatalf("cwd_set size = %d, want 1 (%v)", len(cwdSet), cwdSet)
+	}
+	if cwdSet[0] != primaryCwd {
+		t.Fatalf("cwd_set[0] = %q, want %q", cwdSet[0], primaryCwd)
+	}
+}

--- a/internal/mux/coverage_test.go
+++ b/internal/mux/coverage_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/thebtf/mcp-mux/internal/classify"
 	"github.com/thebtf/mcp-mux/internal/jsonrpc"
 	"github.com/thebtf/mcp-mux/internal/serverid"
 )
@@ -1085,6 +1086,36 @@ func TestAddCwd_NoDuplicate(t *testing.T) {
 
 	if count != 1 {
 		t.Errorf("AddCwd duplicate: canonical cwd appears %d times in cwdSet, want 1", count)
+	}
+}
+
+func TestClassifyFromToolList_IsolatedResetsCwdSetToPrimary(t *testing.T) {
+	o := newMinimalOwner()
+	o.cwd = t.TempDir()
+	o.cwdSet = map[string]bool{
+		serverid.CanonicalizePath(o.cwd):       true,
+		serverid.CanonicalizePath(t.TempDir()): true,
+	}
+
+	toolsJSON := []byte(`{"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"activate_project"}]}}`)
+	o.classifyFromToolList(toolsJSON)
+
+	status := o.Status()
+	if status["auto_classification"] != string(classify.ModeIsolated) {
+		t.Fatalf("classification = %v, want %q", status["auto_classification"], classify.ModeIsolated)
+	}
+
+	cwdSet, ok := status["cwd_set"].([]string)
+	if !ok {
+		t.Fatalf("cwd_set not []string in status: %T", status["cwd_set"])
+	}
+
+	primaryCwd := serverid.CanonicalizePath(o.cwd)
+	if len(cwdSet) != 1 {
+		t.Fatalf("cwd_set size = %d, want 1 (%v)", len(cwdSet), cwdSet)
+	}
+	if cwdSet[0] != primaryCwd {
+		t.Fatalf("cwd_set[0] = %q, want %q", cwdSet[0], primaryCwd)
 	}
 }
 

--- a/internal/mux/coverage_test.go
+++ b/internal/mux/coverage_test.go
@@ -1119,6 +1119,36 @@ func TestClassifyFromToolList_IsolatedResetsCwdSetToPrimary(t *testing.T) {
 	}
 }
 
+func TestClassifyFromCapabilities_IsolatedResetsCwdSetToPrimary(t *testing.T) {
+	o := newMinimalOwner()
+	o.cwd = t.TempDir()
+	o.cwdSet = map[string]bool{
+		serverid.CanonicalizePath(o.cwd):       true,
+		serverid.CanonicalizePath(t.TempDir()): true,
+	}
+
+	initJSON := []byte(`{"jsonrpc":"2.0","id":1,"result":{"capabilities":{"tools":{},"x-mux":{"sharing":"isolated"}}}}`)
+	o.classifyFromCapabilities(initJSON)
+
+	status := o.Status()
+	if status["auto_classification"] != string(classify.ModeIsolated) {
+		t.Fatalf("classification = %v, want %q", status["auto_classification"], classify.ModeIsolated)
+	}
+
+	cwdSet, ok := status["cwd_set"].([]string)
+	if !ok {
+		t.Fatalf("cwd_set not []string in status: %T", status["cwd_set"])
+	}
+
+	primaryCwd := serverid.CanonicalizePath(o.cwd)
+	if len(cwdSet) != 1 {
+		t.Fatalf("cwd_set size = %d, want 1 (%v)", len(cwdSet), cwdSet)
+	}
+	if cwdSet[0] != primaryCwd {
+		t.Fatalf("cwd_set[0] = %q, want %q", cwdSet[0], primaryCwd)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // drainInflightRequests
 // ---------------------------------------------------------------------------

--- a/internal/mux/owner.go
+++ b/internal/mux/owner.go
@@ -71,11 +71,11 @@ type InflightRequest struct {
 type Owner struct {
 	upstream *upstream.Process
 	ipcPath  string
-	cwd      string   // primary working directory (from first spawn)
+	cwd      string          // primary working directory (from first spawn)
 	cwdSet   map[string]bool // all known cwds (for multi-project roots/list)
-	command  string   // upstream command (for status/restart)
-	args     []string // upstream args (for status/restart)
-	serverID string   // server identity hash
+	command  string          // upstream command (for status/restart)
+	args     []string        // upstream args (for status/restart)
+	serverID string          // server identity hash
 	listener net.Listener
 	logger   *log.Logger
 
@@ -86,41 +86,41 @@ type Owner struct {
 
 	mu                   sync.RWMutex
 	sessions             map[int]*Session
-	cachedInitSessions   map[int]bool     // sessions that received a cached (replayed) initialize response
+	cachedInitSessions   map[int]bool // sessions that received a cached (replayed) initialize response
 	initDone             bool
-	initResp             []byte          // cached initialize response (raw JSON-RPC)
-	initProtocolVersion  string          // protocolVersion from first initialize request (for fingerprint matching)
-	toolList             []byte          // cached tools/list response (raw JSON-RPC)
-	promptList           []byte          // cached prompts/list response (raw JSON-RPC)
-	resourceList         []byte          // cached resources/list response (raw JSON-RPC)
-	resourceTemplateList []byte          // cached resources/templates/list response (raw JSON-RPC)
+	initResp             []byte // cached initialize response (raw JSON-RPC)
+	initProtocolVersion  string // protocolVersion from first initialize request (for fingerprint matching)
+	toolList             []byte // cached tools/list response (raw JSON-RPC)
+	promptList           []byte // cached prompts/list response (raw JSON-RPC)
+	resourceList         []byte // cached resources/list response (raw JSON-RPC)
+	resourceTemplateList []byte // cached resources/templates/list response (raw JSON-RPC)
 	autoClassification   classify.SharingMode
-	classificationSource string   // "capability" or "tools" — what determined classification
-	classificationReason []string // tool names that triggered isolation
+	classificationSource string        // "capability" or "tools" — what determined classification
+	classificationReason []string      // tool names that triggered isolation
 	classified           chan struct{} // closed when autoClassification is first set
 	classifiedOnce       sync.Once
 	initReady            chan struct{} // closed when initialize response is cached or upstream dies
 	initReadyOnce        sync.Once
 
-	sessionMgr       *SessionManager
-	tokenHandshake   bool           // true when daemon manages this owner (shims send token)
+	sessionMgr             *SessionManager
+	tokenHandshake         bool                // true when daemon manages this owner (shims send token)
 	progressOwners         map[string]int      // progressToken → session ID for targeted routing
 	progressTokenRequestID map[string]string   // progressToken → remapped request ID that registered it
 	requestToTokens        map[string][]string // remapped request ID → list of progress tokens
 
-	upstreamDead    atomic.Bool  // set when upstream exits; prevents sending to dead pipe
-	methodTags      sync.Map     // remapped request ID (string) -> method name
-	inflightTracker sync.Map     // remapped request ID (string) -> *InflightRequest
-	timedOutIDs     sync.Map     // remapped request ID (string) -> struct{} — watchdog-claimed IDs, late upstream responses are dropped
-	pendingRequests atomic.Int64
-	drainTimeout    time.Duration // from x-mux.drainTimeout capability; 0 = use default
-	toolTimeoutNs   atomic.Int64  // from x-mux.toolTimeout capability; stored as nanoseconds for atomic access
-	idleTimeoutNs   atomic.Int64  // from x-mux.idleTimeout capability; 0 = use daemon default
-	lastActivityNs  atomic.Int64  // unix-nano of last inbound/outbound MCP message or session change
-	busyMu          sync.Mutex
+	upstreamDead     atomic.Bool // set when upstream exits; prevents sending to dead pipe
+	methodTags       sync.Map    // remapped request ID (string) -> method name
+	inflightTracker  sync.Map    // remapped request ID (string) -> *InflightRequest
+	timedOutIDs      sync.Map    // remapped request ID (string) -> struct{} — watchdog-claimed IDs, late upstream responses are dropped
+	pendingRequests  atomic.Int64
+	drainTimeout     time.Duration // from x-mux.drainTimeout capability; 0 = use default
+	toolTimeoutNs    atomic.Int64  // from x-mux.toolTimeout capability; stored as nanoseconds for atomic access
+	idleTimeoutNs    atomic.Int64  // from x-mux.idleTimeout capability; 0 = use daemon default
+	lastActivityNs   atomic.Int64  // unix-nano of last inbound/outbound MCP message or session change
+	busyMu           sync.Mutex
 	busyDeclarations map[string]busyDeclaration // busy_id → declaration (long-running work signal)
-	startTime       time.Time
-	controlServer   *control.Server
+	startTime        time.Time
+	controlServer    *control.Server
 
 	shutdownOnce      sync.Once
 	closeListenerOnce sync.Once
@@ -200,33 +200,33 @@ func NewOwnerFromSnapshot(cfg OwnerConfig, snap OwnerSnapshot) (*Owner, error) {
 	}
 
 	o := &Owner{
-		ipcPath:              cfg.IPCPath,
-		cwd:                  cfg.Cwd,
-		cwdSet:               cwdSet,
-		command:              cfg.Command,
-		args:                 cfg.Args,
-		serverID:             cfg.ServerID,
-		listener:             ln,
-		logger:               logger,
-		onZeroSessions:       cfg.OnZeroSessions,
-		onUpstreamExit:       cfg.OnUpstreamExit,
-		onPersistentDetected: cfg.OnPersistentDetected,
-		onCacheReady:         cfg.OnCacheReady,
-		sessions:             make(map[int]*Session),
-		cachedInitSessions:   make(map[int]bool),
-		sessionMgr:           NewSessionManager(),
-		tokenHandshake:       cfg.TokenHandshake,
-		autoClassification:   snap.Classification,
-		classificationSource: snap.ClassificationSource,
-		classificationReason: snap.ClassificationReason,
-		classified:               make(chan struct{}),
-		initReady:                make(chan struct{}),
-		progressOwners:           make(map[string]int),
-		progressTokenRequestID:   make(map[string]string),
-		requestToTokens:          make(map[string][]string),
-		startTime:                time.Now(),
-		listenerDone:             make(chan struct{}),
-		done:                     make(chan struct{}),
+		ipcPath:                cfg.IPCPath,
+		cwd:                    cfg.Cwd,
+		cwdSet:                 cwdSet,
+		command:                cfg.Command,
+		args:                   cfg.Args,
+		serverID:               cfg.ServerID,
+		listener:               ln,
+		logger:                 logger,
+		onZeroSessions:         cfg.OnZeroSessions,
+		onUpstreamExit:         cfg.OnUpstreamExit,
+		onPersistentDetected:   cfg.OnPersistentDetected,
+		onCacheReady:           cfg.OnCacheReady,
+		sessions:               make(map[int]*Session),
+		cachedInitSessions:     make(map[int]bool),
+		sessionMgr:             NewSessionManager(),
+		tokenHandshake:         cfg.TokenHandshake,
+		autoClassification:     snap.Classification,
+		classificationSource:   snap.ClassificationSource,
+		classificationReason:   snap.ClassificationReason,
+		classified:             make(chan struct{}),
+		initReady:              make(chan struct{}),
+		progressOwners:         make(map[string]int),
+		progressTokenRequestID: make(map[string]string),
+		requestToTokens:        make(map[string][]string),
+		startTime:              time.Now(),
+		listenerDone:           make(chan struct{}),
+		done:                   make(chan struct{}),
 	}
 
 	// Pre-populate caches from snapshot
@@ -357,23 +357,23 @@ func NewOwner(cfg OwnerConfig) (*Owner, error) {
 	}
 
 	o := &Owner{
-		upstream:       proc,
-		ipcPath:        cfg.IPCPath,
-		cwd:            cfg.Cwd,
-		cwdSet:         map[string]bool{cfg.Cwd: true},
-		command:        cfg.Command,
-		args:           cfg.Args,
-		serverID:       cfg.ServerID,
-		listener:       ln,
-		logger:         logger,
-		onZeroSessions:       cfg.OnZeroSessions,
-		onUpstreamExit:       cfg.OnUpstreamExit,
-		onPersistentDetected: cfg.OnPersistentDetected,
-		onCacheReady:         cfg.OnCacheReady,
-		sessions:           make(map[int]*Session),
-		cachedInitSessions: make(map[int]bool),
-		sessionMgr:         NewSessionManager(),
-		tokenHandshake:     cfg.TokenHandshake,
+		upstream:               proc,
+		ipcPath:                cfg.IPCPath,
+		cwd:                    cfg.Cwd,
+		cwdSet:                 map[string]bool{cfg.Cwd: true},
+		command:                cfg.Command,
+		args:                   cfg.Args,
+		serverID:               cfg.ServerID,
+		listener:               ln,
+		logger:                 logger,
+		onZeroSessions:         cfg.OnZeroSessions,
+		onUpstreamExit:         cfg.OnUpstreamExit,
+		onPersistentDetected:   cfg.OnPersistentDetected,
+		onCacheReady:           cfg.OnCacheReady,
+		sessions:               make(map[int]*Session),
+		cachedInitSessions:     make(map[int]bool),
+		sessionMgr:             NewSessionManager(),
+		tokenHandshake:         cfg.TokenHandshake,
 		classified:             make(chan struct{}),
 		initReady:              make(chan struct{}),
 		progressOwners:         make(map[string]int),
@@ -1282,6 +1282,15 @@ func (o *Owner) evictExtraSessions() {
 	}
 }
 
+func (o *Owner) resetCwdSetToPrimary() (string, int) {
+	primaryCwd := serverid.CanonicalizePath(o.cwd)
+	if primaryCwd == "" {
+		return "", 0
+	}
+	o.cwdSet = map[string]bool{primaryCwd: true}
+	return primaryCwd, 1
+}
+
 // closeListener stops the IPC listener and removes the socket file.
 // Safe to call multiple times (uses sync.Once).
 // Nil-safe: owners constructed for tests may not have a listener.
@@ -1725,21 +1734,26 @@ func (o *Owner) Status() map[string]any {
 	o.mu.RUnlock()
 
 	status := map[string]any{
-		"mux_version":      Version,
-		"upstream_pid":      func() int { if o.upstream != nil { return o.upstream.PID() }; return 0 }(),
-		"ipc_path":          o.ipcPath,
-		"command":           o.command,
-		"args":              o.args,
-		"cwd":               primaryCwd,
-		"cwd_set":           cwds,
-		"sessions":          sessionIDs,
-		"session_count":     len(sessionIDs),
-		"pending_requests":  o.pendingRequests.Load(),
-		"uptime_seconds":    time.Since(o.startTime).Seconds(),
-		"cached_init":       hasCachedInit,
-		"cached_tools":      hasCachedTools,
-		"cached_prompts":    hasCachedPrompts,
-		"cached_resources":  hasCachedResources,
+		"mux_version": Version,
+		"upstream_pid": func() int {
+			if o.upstream != nil {
+				return o.upstream.PID()
+			}
+			return 0
+		}(),
+		"ipc_path":         o.ipcPath,
+		"command":          o.command,
+		"args":             o.args,
+		"cwd":              primaryCwd,
+		"cwd_set":          cwds,
+		"sessions":         sessionIDs,
+		"session_count":    len(sessionIDs),
+		"pending_requests": o.pendingRequests.Load(),
+		"uptime_seconds":   time.Since(o.startTime).Seconds(),
+		"cached_init":      hasCachedInit,
+		"cached_tools":     hasCachedTools,
+		"cached_prompts":   hasCachedPrompts,
+		"cached_resources": hasCachedResources,
 	}
 
 	if classification != "" {
@@ -2090,7 +2104,14 @@ func (o *Owner) classifyFromToolList(toolsJSON []byte) {
 	})
 
 	if mode == classify.ModeIsolated {
+		o.mu.Lock()
+		primaryCwd, cwdCount := o.resetCwdSetToPrimary()
+		o.mu.Unlock()
+
 		o.logger.Printf("auto-classification: ISOLATED (matched: %v)", matched)
+		if primaryCwd != "" {
+			o.logger.Printf("reset cwd_set to primary cwd: %s (now %d roots)", primaryCwd, cwdCount)
+		}
 		o.logger.Printf("closing IPC listener — server requires per-session isolation")
 		o.closeListener()
 		// Disconnect extra sessions that were dedup'd before classification.
@@ -2215,4 +2236,3 @@ func (o *Owner) parseDrainTimeout(initJSON []byte) {
 func (o *Owner) DrainTimeout() time.Duration {
 	return o.drainTimeout
 }
-

--- a/internal/mux/owner.go
+++ b/internal/mux/owner.go
@@ -360,7 +360,7 @@ func NewOwner(cfg OwnerConfig) (*Owner, error) {
 		upstream:               proc,
 		ipcPath:                cfg.IPCPath,
 		cwd:                    cfg.Cwd,
-		cwdSet:                 map[string]bool{cfg.Cwd: true},
+		cwdSet:                 map[string]bool{serverid.CanonicalizePath(cfg.Cwd): true},
 		command:                cfg.Command,
 		args:                   cfg.Args,
 		serverID:               cfg.ServerID,
@@ -1284,9 +1284,6 @@ func (o *Owner) evictExtraSessions() {
 
 func (o *Owner) resetCwdSetToPrimary() (string, int) {
 	primaryCwd := serverid.CanonicalizePath(o.cwd)
-	if primaryCwd == "" {
-		return "", 0
-	}
 	o.cwdSet = map[string]bool{primaryCwd: true}
 	return primaryCwd, 1
 }
@@ -2071,6 +2068,13 @@ func (o *Owner) classifyFromCapabilities(initJSON []byte) {
 	o.logger.Printf("x-mux capability: %s", mode)
 
 	if mode == classify.ModeIsolated {
+		o.mu.Lock()
+		primaryCwd, cwdCount := o.resetCwdSetToPrimary()
+		o.mu.Unlock()
+
+		if primaryCwd != "" {
+			o.logger.Printf("reset cwd_set to primary cwd: %s (now %d roots)", primaryCwd, cwdCount)
+		}
 		o.logger.Printf("closing IPC listener — server declares isolated via x-mux")
 		o.closeListener()
 		o.evictExtraSessions()


### PR DESCRIPTION
## Problem

Owner dedup in \`findSharedOwner\` (\`internal/daemon/daemon.go:656\`) uses a non-blocking select on \`Classified()\` and falls through optimistically when classification hasn't arrived yet. When a session from cwd=Y attaches to an owner spawned for cwd=X before classification fires, \`cwdSet\` accumulates both cwds. If \`classifyFromToolList\` later detects \`activate_project\` and marks the owner **isolated**, \`evictExtraSessions\` removes the extra session — but \`cwdSet\` is never rolled back. The polluted map is serialized through every \`upgrade --restart\` and persists indefinitely.

**Live reproduction (production daemon, 2026-04-11):**

\`\`\`json
{
  \"server_id\": \"3df58cc3\",
  \"command\": \"uvx\",
  \"args\": [\"--from\", \"git+https://github.com/oraios/serena\", \"serena\", \"start-mcp-server\", ...],
  \"cwd\": \"D:\\Dev\\mcp-mux\",
  \"cwd_set\": [\"d:\\dev\\aimux\", \"D:\\Dev\\mcp-mux\"],
  \"auto_classification\": \"isolated\",
  \"classification_source\": \"tools\",
  \"classification_reason\": [\"activate_project\"]
}
\`\`\`

The aimux CC session was sending serena tool calls to an upstream pinned to the mcp-mux project. Silent wrong-project behavior, reported by CC as \"serena failed\".

## Fix (Option B + Q5 from investigation report)

### 1. Rollback cwdSet on isolation transition (\`internal/mux/owner.go\`)

New helper \`resetCwdSetToPrimary\` at \`owner.go:1285\`. Called atomically with the \`ModeIsolated\` classification transition in both \`classifyFromCapabilities\` and \`classifyFromToolList\`. Prunes \`cwdSet\` to exactly the owner's spawn cwd before \`closeListener()\` and \`evictExtraSessions\` fire.

### 2. Snapshot auto-heal (\`internal/daemon/snapshot.go\`)

\`loadSnapshot\` at line 178 detects poisoned entries (classification=isolated AND \`len(cwdSet) > 1\`) and repairs them on daemon startup. Logs the heal so operators see which owners were affected:

\`\`\`
snapshot: healing poisoned isolated owner 3df58cc3: cwdSet [d:\dev\aimux D:\Dev\mcp-mux] → [D:\Dev\mcp-mux]
\`\`\`

This recovers the existing corrupt state in production snapshots without manual intervention.

## Test coverage

- \`internal/mux/coverage_test.go\` — \`TestClassifyFromToolList_IsolatedResetsCwdSetToPrimary\`
- \`internal/daemon/snapshot_test.go\` — \`TestLoadSnapshot_HealsIsolatedOwnerCwdSet\`

Full test suite: 10 packages green on \`go test -count=1 -timeout 180s ./...\`.

## Files changed

| File | Lines |
|---|---|
| \`internal/mux/owner.go\` | +194 −101 (incl. gofmt reorg) |
| \`internal/daemon/snapshot.go\` | +37 −26 |
| \`internal/mux/coverage_test.go\` | +31 |
| \`internal/daemon/snapshot_test.go\` | +59 |

Net: ~22 LoC of logic + gofmt reorg that happened to touch surrounding lines.

## Version

**v0.11.1** (patch). No API change, no protocol change. Data-integrity invariant fix with auto-heal for existing corrupt state.

## References

- Investigation report: \`.agent/reports/investigate-isolated-cwd-race-2026-04-11.md\` (local, .agent/ gitignored)
- v0.11.0 baseline: PR #18, tag v0.11.0
- Related: v0.4.9 \"Dedup requires both: IsAccepting() AND non-empty classification\" partial fix

## Deployment verification plan

1. \`upgrade --restart\` on the production daemon
2. Observe log: \`snapshot: healing poisoned isolated owner 3df58cc3: cwdSet [d:\dev\aimux D:\Dev\mcp-mux] → [D:\Dev\mcp-mux]\`
3. \`mux_list\` shows \`3df58cc3.cwd_set\` size = 1
4. aimux CC runs \`/mcp reconnect\` → spawns fresh serena owner for cwd=D:\Dev\aimux
5. Serena works in both CC sessions independently

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **Bug Fixes**
  * Реализована автоматическая нормализация конфигурации изолированных владельцев при загрузке снимка: система исправляет некорректное состояние, когда набор директорий содержит несколько записей, сохраняя только основную директорию.

* **Tests**
  * Добавлено покрытие для проверки восстановления и нормализации конфигурации при загрузке снимков.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->