### PR TITLE
fix: zombie owner cleanup when supervisor gives up (v0.11.2)

### DIFF
--- a/internal/classify/classify.go
+++ b/internal/classify/classify.go
@@ -43,46 +43,45 @@ func ClassifyTools(toolsListJSON []byte) (SharingMode, []string) {
 	return ModeShared, nil
 }
 
+// unmarshalXMux extracts and unmarshals the x-mux capability block from an
+// initialize JSON-RPC response into out. Checks capabilities.x-mux directly
+// first, then falls back to capabilities.experimental["x-mux"] (TypeScript SDK
+// places custom capabilities there). Returns false if absent or if unmarshalling
+// fails.
+func unmarshalXMux(initJSON []byte, out any) bool {
+	var resp struct {
+		Result struct {
+			Capabilities struct {
+				XMux         json.RawMessage            `json:"x-mux"`
+				Experimental map[string]json.RawMessage `json:"experimental"`
+			} `json:"capabilities"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(initJSON, &resp); err != nil {
+		return false
+	}
+	if len(resp.Result.Capabilities.XMux) > 0 {
+		return json.Unmarshal(resp.Result.Capabilities.XMux, out) == nil
+	}
+	raw, ok := resp.Result.Capabilities.Experimental["x-mux"]
+	if !ok {
+		return false
+	}
+	return json.Unmarshal(raw, out) == nil
+}
+
 // ClassifyCapabilities parses an initialize JSON-RPC response and extracts
 // the x-mux capability to determine the server's declared sharing mode.
 //
 // Returns the declared mode and true if x-mux was found, or ("", false) if absent.
 // This takes priority over tool-name classification when present.
 func ClassifyCapabilities(initJSON []byte) (SharingMode, bool) {
-	// Try direct x-mux capability first
-	var resp struct {
-		Result struct {
-			Capabilities struct {
-				XMux *struct {
-					Sharing string `json:"sharing"`
-				} `json:"x-mux"`
-				Experimental map[string]json.RawMessage `json:"experimental"`
-			} `json:"capabilities"`
-		} `json:"result"`
+	var xmux struct {
+		Sharing string `json:"sharing"`
 	}
-	if err := json.Unmarshal(initJSON, &resp); err != nil {
+	if !unmarshalXMux(initJSON, &xmux) {
 		return "", false
 	}
-
-	// Check direct x-mux capability
-	xmux := resp.Result.Capabilities.XMux
-
-	// Fallback: check experimental.x-mux (TypeScript SDK puts custom capabilities here)
-	if xmux == nil && resp.Result.Capabilities.Experimental != nil {
-		if raw, ok := resp.Result.Capabilities.Experimental["x-mux"]; ok {
-			xmux = &struct {
-				Sharing string `json:"sharing"`
-			}{}
-			if err := json.Unmarshal(raw, xmux); err != nil {
-				xmux = nil
-			}
-		}
-	}
-
-	if xmux == nil {
-		return "", false
-	}
-
 	mode := SharingMode(xmux.Sharing)
 	switch mode {
 	case ModeShared, ModeIsolated, ModeSessionAware:
@@ -95,36 +94,10 @@ func ClassifyCapabilities(initJSON []byte) (SharingMode, bool) {
 // ParsePersistent extracts x-mux.persistent from a cached initialize response.
 // Returns true if the server declares itself as persistent.
 func ParsePersistent(initJSON []byte) bool {
-	// Try direct x-mux capability
-	var resp struct {
-		Result struct {
-			Capabilities struct {
-				XMux *struct {
-					Persistent bool `json:"persistent"`
-				} `json:"x-mux"`
-				Experimental map[string]json.RawMessage `json:"experimental"`
-			} `json:"capabilities"`
-		} `json:"result"`
+	var xmux struct {
+		Persistent bool `json:"persistent"`
 	}
-	if err := json.Unmarshal(initJSON, &resp); err != nil {
-		return false
-	}
-
-	xmux := resp.Result.Capabilities.XMux
-
-	// Fallback: check experimental.x-mux
-	if xmux == nil && resp.Result.Capabilities.Experimental != nil {
-		if raw, ok := resp.Result.Capabilities.Experimental["x-mux"]; ok {
-			xmux = &struct {
-				Persistent bool `json:"persistent"`
-			}{}
-			if err := json.Unmarshal(raw, xmux); err != nil {
-				return false
-			}
-		}
-	}
-
-	if xmux == nil {
+	if !unmarshalXMux(initJSON, &xmux) {
 		return false
 	}
 	return xmux.Persistent
@@ -136,34 +109,13 @@ func ParsePersistent(initJSON []byte) bool {
 // JSON-RPC error response if upstream doesn't respond within the timeout.
 // Prevents eternal hangs when upstream deadlocks or crashes silently.
 func ParseToolTimeout(initJSON []byte) int {
-	var resp struct {
-		Result struct {
-			Capabilities struct {
-				XMux *struct {
-					ToolTimeout int `json:"toolTimeout"`
-				} `json:"x-mux"`
-				Experimental map[string]json.RawMessage `json:"experimental"`
-			} `json:"capabilities"`
-		} `json:"result"`
+	var xmux struct {
+		ToolTimeout int `json:"toolTimeout"`
 	}
-	if err := json.Unmarshal(initJSON, &resp); err != nil {
+	if !unmarshalXMux(initJSON, &xmux) {
 		return 0
 	}
-
-	xmux := resp.Result.Capabilities.XMux
-
-	if xmux == nil && resp.Result.Capabilities.Experimental != nil {
-		if raw, ok := resp.Result.Capabilities.Experimental["x-mux"]; ok {
-			xmux = &struct {
-				ToolTimeout int `json:"toolTimeout"`
-			}{}
-			if err := json.Unmarshal(raw, xmux); err != nil {
-				return 0
-			}
-		}
-	}
-
-	if xmux == nil || xmux.ToolTimeout <= 0 {
+	if xmux.ToolTimeout <= 0 {
 		return 0
 	}
 	// Cap at 1 hour to prevent unreasonable values
@@ -178,35 +130,13 @@ func ParseToolTimeout(initJSON []byte) int {
 // Servers use this to tell mux how long they need to gracefully shut down
 // (e.g., drain running async jobs, flush state).
 func ParseDrainTimeout(initJSON []byte) int {
-	var resp struct {
-		Result struct {
-			Capabilities struct {
-				XMux *struct {
-					DrainTimeout int `json:"drainTimeout"`
-				} `json:"x-mux"`
-				Experimental map[string]json.RawMessage `json:"experimental"`
-			} `json:"capabilities"`
-		} `json:"result"`
+	var xmux struct {
+		DrainTimeout int `json:"drainTimeout"`
 	}
-	if err := json.Unmarshal(initJSON, &resp); err != nil {
+	if !unmarshalXMux(initJSON, &xmux) {
 		return 0
 	}
-
-	xmux := resp.Result.Capabilities.XMux
-
-	// Fallback: check experimental.x-mux
-	if xmux == nil && resp.Result.Capabilities.Experimental != nil {
-		if raw, ok := resp.Result.Capabilities.Experimental["x-mux"]; ok {
-			xmux = &struct {
-				DrainTimeout int `json:"drainTimeout"`
-			}{}
-			if err := json.Unmarshal(raw, xmux); err != nil {
-				return 0
-			}
-		}
-	}
-
-	if xmux == nil || xmux.DrainTimeout <= 0 {
+	if xmux.DrainTimeout <= 0 {
 		return 0
 	}
 	// Cap at 5 minutes to prevent runaway drain
@@ -226,36 +156,13 @@ func ParseDrainTimeout(initJSON []byte) int {
 // timeout to survive multi-hour quiet periods. Upstreams that are cheap to
 // re-spawn can declare a short timeout to free RAM faster.
 func ParseIdleTimeout(initJSON []byte) int {
-	var resp struct {
-		Result struct {
-			Capabilities struct {
-				XMux *struct {
-					IdleTimeout int `json:"idleTimeout"`
-				} `json:"x-mux"`
-				Experimental map[string]json.RawMessage `json:"experimental"`
-			} `json:"capabilities"`
-		} `json:"result"`
+	var xmux struct {
+		IdleTimeout int `json:"idleTimeout"`
 	}
-	if err := json.Unmarshal(initJSON, &resp); err != nil {
+	if !unmarshalXMux(initJSON, &xmux) {
 		return 0
 	}
-
-	xmux := resp.Result.Capabilities.XMux
-
-	// Fallback: check experimental.x-mux (TypeScript SDK puts custom
-	// capabilities under experimental rather than at capability root).
-	if xmux == nil && resp.Result.Capabilities.Experimental != nil {
-		if raw, ok := resp.Result.Capabilities.Experimental["x-mux"]; ok {
-			xmux = &struct {
-				IdleTimeout int `json:"idleTimeout"`
-			}{}
-			if err := json.Unmarshal(raw, xmux); err != nil {
-				return 0
-			}
-		}
-	}
-
-	if xmux == nil || xmux.IdleTimeout <= 0 {
+	if xmux.IdleTimeout <= 0 {
 		return 0
 	}
 	// Cap at 24 hours. Larger values are almost certainly a unit mistake
@@ -270,36 +177,13 @@ func ParseIdleTimeout(initJSON []byte) int {
 // initialize JSON response and returns the value in seconds.
 // Returns 0 if absent or invalid. Clamps to 60 if over.
 func ParseProgressInterval(initJSON []byte) int {
-	var resp struct {
-		Result struct {
-			Capabilities struct {
-				XMux *struct {
-					ProgressInterval int `json:"progressInterval"`
-				} `json:"x-mux"`
-				Experimental map[string]json.RawMessage `json:"experimental"`
-			} `json:"capabilities"`
-		} `json:"result"`
+	var xmux struct {
+		ProgressInterval int `json:"progressInterval"`
 	}
-	if err := json.Unmarshal(initJSON, &resp); err != nil {
+	if !unmarshalXMux(initJSON, &xmux) {
 		return 0
 	}
-
-	xmux := resp.Result.Capabilities.XMux
-
-	// Fallback: check experimental.x-mux (TypeScript SDK puts custom
-	// capabilities under experimental rather than at capability root).
-	if xmux == nil && resp.Result.Capabilities.Experimental != nil {
-		if raw, ok := resp.Result.Capabilities.Experimental["x-mux"]; ok {
-			xmux = &struct {
-				ProgressInterval int `json:"progressInterval"`
-			}{}
-			if err := json.Unmarshal(raw, xmux); err != nil {
-				return 0
-			}
-		}
-	}
-
-	if xmux == nil || xmux.ProgressInterval <= 0 {
+	if xmux.ProgressInterval <= 0 {
 		return 0
 	}
 	// Cap at 60 seconds. Larger values defeat the purpose of progress reporting.

--- a/internal/classify/classify.go
+++ b/internal/classify/classify.go
@@ -265,3 +265,46 @@ func ParseIdleTimeout(initJSON []byte) int {
 	}
 	return xmux.IdleTimeout
 }
+
+// ParseProgressInterval reads the x-mux.progressInterval field from an
+// initialize JSON response and returns the value in seconds.
+// Returns 0 if absent or invalid. Clamps to 60 if over.
+func ParseProgressInterval(initJSON []byte) int {
+	var resp struct {
+		Result struct {
+			Capabilities struct {
+				XMux *struct {
+					ProgressInterval int `json:"progressInterval"`
+				} `json:"x-mux"`
+				Experimental map[string]json.RawMessage `json:"experimental"`
+			} `json:"capabilities"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(initJSON, &resp); err != nil {
+		return 0
+	}
+
+	xmux := resp.Result.Capabilities.XMux
+
+	// Fallback: check experimental.x-mux (TypeScript SDK puts custom
+	// capabilities under experimental rather than at capability root).
+	if xmux == nil && resp.Result.Capabilities.Experimental != nil {
+		if raw, ok := resp.Result.Capabilities.Experimental["x-mux"]; ok {
+			xmux = &struct {
+				ProgressInterval int `json:"progressInterval"`
+			}{}
+			if err := json.Unmarshal(raw, xmux); err != nil {
+				return 0
+			}
+		}
+	}
+
+	if xmux == nil || xmux.ProgressInterval <= 0 {
+		return 0
+	}
+	// Cap at 60 seconds. Larger values defeat the purpose of progress reporting.
+	if xmux.ProgressInterval > 60 {
+		return 60
+	}
+	return xmux.ProgressInterval
+}

--- a/internal/classify/progress_interval_test.go
+++ b/internal/classify/progress_interval_test.go
@@ -43,3 +43,17 @@ func TestParseProgressInterval_InvalidJSON(t *testing.T) {
 		t.Errorf("want 0 on parse error, got %d", got)
 	}
 }
+
+func TestParseProgressInterval_MinBoundary(t *testing.T) {
+	in := []byte(`{"result":{"capabilities":{"x-mux":{"progressInterval":1}}}}`)
+	if got := ParseProgressInterval(in); got != 1 {
+		t.Errorf("want 1 (min boundary), got %d", got)
+	}
+}
+
+func TestParseProgressInterval_MaxBoundary(t *testing.T) {
+	in := []byte(`{"result":{"capabilities":{"x-mux":{"progressInterval":60}}}}`)
+	if got := ParseProgressInterval(in); got != 60 {
+		t.Errorf("want 60 (max boundary), got %d", got)
+	}
+}

--- a/internal/classify/progress_interval_test.go
+++ b/internal/classify/progress_interval_test.go
@@ -1,0 +1,45 @@
+package classify
+
+import "testing"
+
+func TestParseProgressInterval_DirectXMux(t *testing.T) {
+	in := []byte(`{"result":{"capabilities":{"x-mux":{"progressInterval":10}}}}`)
+	if got := ParseProgressInterval(in); got != 10 {
+		t.Errorf("want 10, got %d", got)
+	}
+}
+
+func TestParseProgressInterval_Experimental(t *testing.T) {
+	in := []byte(`{"result":{"capabilities":{"experimental":{"x-mux":{"progressInterval":30}}}}}`)
+	if got := ParseProgressInterval(in); got != 30 {
+		t.Errorf("want 30, got %d", got)
+	}
+}
+
+func TestParseProgressInterval_Absent(t *testing.T) {
+	in := []byte(`{"result":{"capabilities":{"tools":{}}}}`)
+	if got := ParseProgressInterval(in); got != 0 {
+		t.Errorf("want 0 when absent, got %d", got)
+	}
+}
+
+func TestParseProgressInterval_Negative(t *testing.T) {
+	in := []byte(`{"result":{"capabilities":{"x-mux":{"progressInterval":-1}}}}`)
+	if got := ParseProgressInterval(in); got != 0 {
+		t.Errorf("want 0 for negative, got %d", got)
+	}
+}
+
+func TestParseProgressInterval_Cap(t *testing.T) {
+	// 120s → clamped to 60s
+	in := []byte(`{"result":{"capabilities":{"x-mux":{"progressInterval":120}}}}`)
+	if got := ParseProgressInterval(in); got != 60 {
+		t.Errorf("want clamped to 60, got %d", got)
+	}
+}
+
+func TestParseProgressInterval_InvalidJSON(t *testing.T) {
+	if got := ParseProgressInterval([]byte("garbage")); got != 0 {
+		t.Errorf("want 0 on parse error, got %d", got)
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -211,35 +211,59 @@ func (d *Daemon) supervisorEventHook(event suture.Event) {
 
 // cleanupDeadOwner finds and removes a permanently-failed owner from the registry.
 // ServiceName format from suture: "owner[XXXXXXXX command args]"
+// NOTE: the format must match Owner.String() in internal/mux/owner.go.
 func (d *Daemon) cleanupDeadOwner(serviceName string) {
 	// Extract server ID prefix: between "owner[" and first space or "]"
 	const prefix = "owner["
 	idx := strings.Index(serviceName, prefix)
 	if idx < 0 {
+		d.logger.Printf("cleanupDeadOwner: unexpected service name format: %q", serviceName)
 		return
 	}
 	rest := serviceName[idx+len(prefix):]
 	// serverID is the first token (8 hex chars before space)
 	spaceIdx := strings.IndexByte(rest, ' ')
 	if spaceIdx < 0 {
+		d.logger.Printf("cleanupDeadOwner: cannot extract serverID from: %q", serviceName)
 		return
 	}
 	sidPrefix := rest[:spaceIdx]
 
+	// Find the matching owner under the lock, then release before calling
+	// Shutdown to avoid blocking while holding d.mu (Shutdown may wait for
+	// upstream I/O). Re-acquire to delete the map entry afterwards.
 	d.mu.Lock()
-	defer d.mu.Unlock()
+	var (
+		found bool
+		sid   string
+		entry *OwnerEntry
+	)
+	for s, e := range d.owners {
+		if strings.HasPrefix(s, sidPrefix) {
+			found = true
+			sid = s
+			entry = e
+			break
+		}
+	}
+	d.mu.Unlock()
 
-	for sid, entry := range d.owners {
-		if !strings.HasPrefix(sid, sidPrefix) {
-			continue
-		}
-		if entry.Owner != nil {
-			d.logger.Printf("cleaning up zombie owner %s", sid[:8])
-			go entry.Owner.Shutdown()
-		}
-		delete(d.owners, sid)
+	if !found {
 		return
 	}
+	if entry.Owner != nil {
+		d.logger.Printf("cleaning up zombie owner %s", sid[:8])
+		// Synchronous shutdown ensures the IPC socket file is removed before
+		// the entry is deleted from the registry. Without this, a concurrent
+		// Spawn for the same SID could call ipc.Listen and find the stale
+		// socket still present. Safe to block here because cleanupDeadOwner
+		// itself is always called from a goroutine (line ~199).
+		entry.Owner.Shutdown()
+	}
+
+	d.mu.Lock()
+	delete(d.owners, sid)
+	d.mu.Unlock()
 }
 
 // cleanStaleSockets removes mcp-mux-*.ctl.sock and mcp-mux-*.sock files from

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -194,6 +194,10 @@ func (d *Daemon) supervisorEventHook(event suture.Event) {
 	case suture.EventServiceTerminate:
 		d.logger.Printf("supervisor: service %q terminated: %v (restarting=%v)",
 			e.ServiceName, e.Err, e.Restarting)
+		if !e.Restarting {
+			d.logger.Printf("supervisor: service %q permanently failed — cleaning up zombie owner", e.ServiceName)
+			go d.cleanupDeadOwner(e.ServiceName)
+		}
 	case suture.EventBackoff:
 		d.logger.Printf("supervisor: backoff — too many failures, slowing restart rate")
 	case suture.EventResume:
@@ -202,6 +206,39 @@ func (d *Daemon) supervisorEventHook(event suture.Event) {
 		d.logger.Printf("supervisor: service %q did not stop in time", e.ServiceName)
 	default:
 		// Unknown event type — ignore silently
+	}
+}
+
+// cleanupDeadOwner finds and removes a permanently-failed owner from the registry.
+// ServiceName format from suture: "owner[XXXXXXXX command args]"
+func (d *Daemon) cleanupDeadOwner(serviceName string) {
+	// Extract server ID prefix: between "owner[" and first space or "]"
+	const prefix = "owner["
+	idx := strings.Index(serviceName, prefix)
+	if idx < 0 {
+		return
+	}
+	rest := serviceName[idx+len(prefix):]
+	// serverID is the first token (8 hex chars before space)
+	spaceIdx := strings.IndexByte(rest, ' ')
+	if spaceIdx < 0 {
+		return
+	}
+	sidPrefix := rest[:spaceIdx]
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	for sid, entry := range d.owners {
+		if !strings.HasPrefix(sid, sidPrefix) {
+			continue
+		}
+		if entry.Owner != nil {
+			d.logger.Printf("cleaning up zombie owner %s", sid[:8])
+			go entry.Owner.Shutdown()
+		}
+		delete(d.owners, sid)
+		return
 	}
 }
 

--- a/internal/daemon/reaper.go
+++ b/internal/daemon/reaper.go
@@ -148,6 +148,7 @@ func (r *Reaper) sweep() int {
 			PendingRequests:      entry.Owner.PendingRequests(),
 			ActiveProgressTokens: entry.Owner.ActiveProgressTokens(),
 			HasBusyWork:          entry.Owner.HasActiveBusyWork(),
+			UpstreamDead:         entry.Owner.UpstreamDead(),
 			IdleTimeout:          entry.IdleTimeout,
 			OwnerIdleOverride:    entry.Owner.IdleTimeout(),
 			LastSession:          entry.LastSession,
@@ -177,6 +178,7 @@ type evictionSample struct {
 	PendingRequests      int64
 	ActiveProgressTokens int
 	HasBusyWork          bool
+	UpstreamDead         bool
 	// IdleTimeout is the owner-entry idle timeout (set at Spawn time
 	// from daemon defaults).
 	IdleTimeout time.Duration
@@ -206,6 +208,10 @@ type evictionDecision struct {
 //  2. Sample.IdleTimeout (daemon default copied at spawn)
 //  3. daemonDefault argument (fallback for placeholder entries)
 func shouldEvict(s evictionSample, now time.Time, daemonDefault time.Duration) evictionDecision {
+	// Zombie: upstream dead + zero sessions = evict immediately regardless of other conditions.
+	if s.UpstreamDead && s.Sessions == 0 {
+		return evictionDecision{evict: true}
+	}
 	if s.Sessions != 0 {
 		return evictionDecision{}
 	}

--- a/internal/daemon/reaper.go
+++ b/internal/daemon/reaper.go
@@ -156,10 +156,14 @@ func (r *Reaper) sweep() int {
 		}
 		decision := shouldEvict(sample, now, r.daemon.ownerIdleTimeout)
 		if decision.evict {
-			r.logger.Printf(
-				"reaper: owner %s idle for %.0fs (timeout %.0fs), removing",
-				sid[:8], decision.elapsed.Seconds(), decision.idleTimeout.Seconds(),
-			)
+			if decision.reason == "zombie" {
+				r.logger.Printf("reaper: owner %s upstream dead with 0 sessions, removing", sid[:8])
+			} else {
+				r.logger.Printf(
+					"reaper: owner %s idle for %.0fs (timeout %.0fs), removing",
+					sid[:8], decision.elapsed.Seconds(), decision.idleTimeout.Seconds(),
+				)
+			}
 			_ = r.daemon.Remove(sid)
 			affected++
 		}
@@ -192,6 +196,7 @@ type evictionDecision struct {
 	evict       bool
 	elapsed     time.Duration
 	idleTimeout time.Duration
+	reason      string // "zombie" or "idle"
 }
 
 // shouldEvict applies the activity-aware kill gate:
@@ -210,7 +215,7 @@ type evictionDecision struct {
 func shouldEvict(s evictionSample, now time.Time, daemonDefault time.Duration) evictionDecision {
 	// Zombie: upstream dead + zero sessions = evict immediately regardless of other conditions.
 	if s.UpstreamDead && s.Sessions == 0 {
-		return evictionDecision{evict: true}
+		return evictionDecision{evict: true, reason: "zombie"}
 	}
 	if s.Sessions != 0 {
 		return evictionDecision{}
@@ -249,6 +254,7 @@ func shouldEvict(s evictionSample, now time.Time, daemonDefault time.Duration) e
 		evict:       elapsed > idleTimeout,
 		elapsed:     elapsed,
 		idleTimeout: idleTimeout,
+		reason:      "idle",
 	}
 }
 

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -551,12 +551,19 @@ func (s *Server) toolMuxRestart(id json.RawMessage, args json.RawMessage) {
 		return
 	}
 
-	var status struct {
-		Command string   `json:"command"`
-		Args    []string `json:"args"`
+	var statusData struct {
+		Command         string   `json:"command"`
+		Args            []string `json:"args"`
+		PendingRequests int      `json:"pending_requests"`
 	}
-	if err := json.Unmarshal(statusResp.Data, &status); err != nil || status.Command == "" {
+	if err := json.Unmarshal(statusResp.Data, &statusData); err != nil || statusData.Command == "" {
 		s.sendToolError(id, fmt.Sprintf("server %s has no command info", serverID))
+		return
+	}
+
+	// Reject restart when requests are in-flight unless force is set
+	if statusData.PendingRequests > 0 && !params.Force {
+		s.sendToolError(id, fmt.Sprintf("server %s has %d pending requests. Use force=true to kill them, or wait for completion.", serverID[:8], statusData.PendingRequests))
 		return
 	}
 
@@ -594,8 +601,8 @@ func (s *Server) toolMuxRestart(id json.RawMessage, args json.RawMessage) {
 	}
 
 	daemonArgs := []string{"--daemon"}
-	daemonArgs = append(daemonArgs, status.Command)
-	daemonArgs = append(daemonArgs, status.Args...)
+	daemonArgs = append(daemonArgs, statusData.Command)
+	daemonArgs = append(daemonArgs, statusData.Args...)
 
 	cmd := exec.Command(exe, daemonArgs...)
 	cmd.Stdin = nil
@@ -609,7 +616,11 @@ func (s *Server) toolMuxRestart(id json.RawMessage, args json.RawMessage) {
 	// Detach — don't wait for the daemon
 	go cmd.Wait()
 
-	s.sendToolResult(id, fmt.Sprintf("restarted: stopped (%s), new daemon PID %d", stopResp.Message, cmd.Process.Pid))
+	warning := ""
+	if params.Force && statusData.PendingRequests > 0 {
+		warning = fmt.Sprintf("WARNING: force restart killed %d pending requests. ", statusData.PendingRequests)
+	}
+	s.sendToolResult(id, fmt.Sprintf("%srestarted: stopped (%s), new daemon PID %d", warning, stopResp.Message, cmd.Process.Pid))
 }
 
 // resolveServerID returns a server ID from either an explicit ID or a name substring match.

--- a/internal/mux/owner.go
+++ b/internal/mux/owner.go
@@ -1589,6 +1589,11 @@ func (o *Owner) ActiveProgressTokens() int {
 	return len(o.progressOwners)
 }
 
+// UpstreamDead returns true if the upstream process has exited.
+func (o *Owner) UpstreamDead() bool {
+	return o.upstreamDead.Load()
+}
+
 // LastActivity returns the unix-nano timestamp of the last activity seen by
 // the owner (inbound upstream message, outbound session→upstream message, or
 // a session connect/disconnect event).

--- a/internal/mux/owner.go
+++ b/internal/mux/owner.go
@@ -1768,6 +1768,7 @@ func (o *Owner) Status() map[string]any {
 
 	// Include inflight request details when requests are pending
 	var inflight []map[string]any
+	var oldestMs int64
 	o.inflightTracker.Range(func(key, value any) bool {
 		req := value.(*InflightRequest)
 		inflight = append(inflight, map[string]any{
@@ -1777,10 +1778,17 @@ func (o *Owner) Status() map[string]any {
 			"started_at":      req.StartTime.UTC().Format(time.RFC3339Nano),
 			"elapsed_seconds": time.Since(req.StartTime).Seconds(),
 		})
+		age := time.Since(req.StartTime).Milliseconds()
+		if age > oldestMs {
+			oldestMs = age
+		}
 		return true
 	})
 	if len(inflight) > 0 {
 		status["inflight"] = inflight
+	}
+	if oldestMs > 0 {
+		status["oldest_request_age_ms"] = oldestMs
 	}
 
 	return status


### PR DESCRIPTION
## Problem

When suture supervisor exhausts restart attempts for an upstream that crashes repeatedly, the owner's IPC listener stayed open. New CC sessions connected to the zombie owner, received cached init/tools responses (appeared healthy), but tools/call requests hung forever because the upstream pipe was dead.

**Root cause:** `supervisorEventHook` logged `Restarting=false` but took no cleanup action. The dead owner remained in the daemon registry with a live IPC socket.

## Fix

**Two-level cleanup:**

1. **Supervisor hook** (`daemon.go`): When `EventServiceTerminate` has `Restarting=false`, parse serverID from service name, find owner in registry, call `Shutdown()` (closes IPC listener + drains sessions), remove from `d.owners` map.

2. **Reaper safety net** (`reaper.go`): New zombie detection in `shouldEvict()` — if `UpstreamDead && Sessions == 0`, evict immediately regardless of idle timeout. Catches cases where supervisor hook misses cleanup.

**Also includes:**
- `Owner.UpstreamDead()` public accessor
- `ParseProgressInterval()` for `x-mux.progressInterval` capability (1-60s range, 6 tests)

## Testing

- All 10 packages pass (`go test ./... -count 1`)
- `go vet ./...` clean
- `go build ./...` clean

## Evidence

Investigation report: `.agent/reports/investigate-first-request-to-shared-aimux-owner-hang-2026-04-13T02-09-10.md`

Fixes: engram issue #54

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Заметки о выпуске

* **Исправления ошибок**
  * Улучшена очистка навсегда упавших сервисов при завершении; удаление записей теперь выполняется асинхронно и безопасно.
  * Логика эвикции учитывает смерть восходящего процесса и немедленно удаляет записи при отсутствии сессий.
  * Перезапуск инструмента отклоняется при ожидающих запросах (если не установлен force); при принудительном перезапуске добавляется предупреждение.

* **Новые возможности**
  * Парсинг интервала прогресса с резервным путём и верхним ограничением (макс 60 с).
  * Статус владельца теперь включает возраст старейшего запроса; добавлен флаг UpstreamDead.

* **Тесты**
  * Добавлен набор тестов для парсинга интервала прогресса.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->