### PR TITLE
feat: synthetic progress reporter for long-running MCP tool calls

### DIFF
--- a/internal/mux/coverage_test.go
+++ b/internal/mux/coverage_test.go
@@ -267,6 +267,8 @@ func newMinimalOwner() *Owner {
 		progressOwners:         make(map[string]int),
 		progressTokenRequestID: make(map[string]string),
 		requestToTokens:        make(map[string][]string),
+		lastRealProgress:       make(map[string]time.Time),
+		determinateTokens:      make(map[string]bool),
 		sessionMgr:             NewSessionManager(),
 		ipcPath:                "/tmp/test.sock",
 		command:                "echo",

--- a/internal/mux/owner.go
+++ b/internal/mux/owner.go
@@ -114,9 +114,9 @@ type Owner struct {
 	timedOutIDs      sync.Map    // remapped request ID (string) -> struct{} — watchdog-claimed IDs, late upstream responses are dropped
 	pendingRequests  atomic.Int64
 	drainTimeout     time.Duration // from x-mux.drainTimeout capability; 0 = use default
-	toolTimeoutNs    atomic.Int64  // from x-mux.toolTimeout capability; stored as nanoseconds for atomic access
-	idleTimeoutNs    atomic.Int64  // from x-mux.idleTimeout capability; 0 = use daemon default
-	progressInterval time.Duration // from x-mux.progressInterval capability; 0 = use default (5s)
+	toolTimeoutNs      atomic.Int64 // from x-mux.toolTimeout capability; stored as nanoseconds for atomic access
+	idleTimeoutNs      atomic.Int64 // from x-mux.idleTimeout capability; 0 = use daemon default
+	progressIntervalNs atomic.Int64 // from x-mux.progressInterval capability; stored as nanoseconds; 0 = use default (5s)
 	lastActivityNs   atomic.Int64  // unix-nano of last inbound/outbound MCP message or session change
 	busyMu           sync.Mutex
 	busyDeclarations map[string]busyDeclaration // busy_id → declaration (long-running work signal)
@@ -225,11 +225,11 @@ func NewOwnerFromSnapshot(cfg OwnerConfig, snap OwnerSnapshot) (*Owner, error) {
 		progressOwners:         make(map[string]int),
 		progressTokenRequestID: make(map[string]string),
 		requestToTokens:        make(map[string][]string),
-		progressInterval:       5 * time.Second,
 		startTime:              time.Now(),
 		listenerDone:           make(chan struct{}),
 		done:                   make(chan struct{}),
 	}
+	o.progressIntervalNs.Store(int64(5 * time.Second))
 
 	// Pre-populate caches from snapshot
 	if snap.CachedInit != "" {
@@ -384,11 +384,11 @@ func NewOwner(cfg OwnerConfig) (*Owner, error) {
 		progressOwners:         make(map[string]int),
 		progressTokenRequestID: make(map[string]string),
 		requestToTokens:        make(map[string][]string),
-		progressInterval:       5 * time.Second,
 		startTime:              time.Now(),
 		listenerDone:           make(chan struct{}),
 		done:                   make(chan struct{}),
 	}
+	o.progressIntervalNs.Store(int64(5 * time.Second))
 
 	// Start control plane if configured
 	if cfg.ControlPath != "" {
@@ -1937,7 +1937,7 @@ func (o *Owner) cacheResponse(method string, raw []byte) {
 		o.parseToolTimeout(cached)
 		o.parseIdleTimeout(cached)
 		if sec := classify.ParseProgressInterval(cached); sec > 0 {
-			o.progressInterval = time.Duration(sec) * time.Second
+			o.progressIntervalNs.Store(int64(time.Duration(sec) * time.Second))
 			o.logger.Printf("using x-mux.progressInterval: %ds", sec)
 		}
 	}

--- a/internal/mux/owner.go
+++ b/internal/mux/owner.go
@@ -116,6 +116,7 @@ type Owner struct {
 	drainTimeout     time.Duration // from x-mux.drainTimeout capability; 0 = use default
 	toolTimeoutNs    atomic.Int64  // from x-mux.toolTimeout capability; stored as nanoseconds for atomic access
 	idleTimeoutNs    atomic.Int64  // from x-mux.idleTimeout capability; 0 = use daemon default
+	progressInterval time.Duration // from x-mux.progressInterval capability; 0 = use default (5s)
 	lastActivityNs   atomic.Int64  // unix-nano of last inbound/outbound MCP message or session change
 	busyMu           sync.Mutex
 	busyDeclarations map[string]busyDeclaration // busy_id → declaration (long-running work signal)
@@ -224,6 +225,7 @@ func NewOwnerFromSnapshot(cfg OwnerConfig, snap OwnerSnapshot) (*Owner, error) {
 		progressOwners:         make(map[string]int),
 		progressTokenRequestID: make(map[string]string),
 		requestToTokens:        make(map[string][]string),
+		progressInterval:       5 * time.Second,
 		startTime:              time.Now(),
 		listenerDone:           make(chan struct{}),
 		done:                   make(chan struct{}),
@@ -273,6 +275,9 @@ func NewOwnerFromSnapshot(cfg OwnerConfig, snap OwnerSnapshot) (*Owner, error) {
 
 	// Start accepting IPC connections (sessions get cached replay immediately)
 	go o.acceptLoop()
+
+	// Start synthetic progress reporter
+	go o.runProgressReporter(doneContext(o.done))
 
 	logger.Printf("owner restored from snapshot (cached: init=%v tools=%v prompts=%v resources=%v)",
 		o.initDone, o.toolList != nil, o.promptList != nil, o.resourceList != nil)
@@ -379,6 +384,7 @@ func NewOwner(cfg OwnerConfig) (*Owner, error) {
 		progressOwners:         make(map[string]int),
 		progressTokenRequestID: make(map[string]string),
 		requestToTokens:        make(map[string][]string),
+		progressInterval:       5 * time.Second,
 		startTime:              time.Now(),
 		listenerDone:           make(chan struct{}),
 		done:                   make(chan struct{}),
@@ -405,6 +411,9 @@ func NewOwner(cfg OwnerConfig) (*Owner, error) {
 
 	// Start accepting IPC connections
 	go o.acceptLoop()
+
+	// Start synthetic progress reporter
+	go o.runProgressReporter(doneContext(o.done))
 
 	// Monitor upstream exit
 	go func() {
@@ -1927,6 +1936,10 @@ func (o *Owner) cacheResponse(method string, raw []byte) {
 		o.parseDrainTimeout(cached)
 		o.parseToolTimeout(cached)
 		o.parseIdleTimeout(cached)
+		if sec := classify.ParseProgressInterval(cached); sec > 0 {
+			o.progressInterval = time.Duration(sec) * time.Second
+			o.logger.Printf("using x-mux.progressInterval: %ds", sec)
+		}
 	}
 	if method == "tools/list" {
 		o.classifyFromToolList(cached)

--- a/internal/mux/owner.go
+++ b/internal/mux/owner.go
@@ -108,6 +108,10 @@ type Owner struct {
 	progressTokenRequestID map[string]string   // progressToken → remapped request ID that registered it
 	requestToTokens        map[string][]string // remapped request ID → list of progress tokens
 
+	progressMu        sync.Mutex
+	lastRealProgress  map[string]time.Time // progressToken → last time real progress was received
+	determinateTokens map[string]bool      // progressToken → true when real progress included a total field
+
 	upstreamDead     atomic.Bool // set when upstream exits; prevents sending to dead pipe
 	methodTags       sync.Map    // remapped request ID (string) -> method name
 	inflightTracker  sync.Map    // remapped request ID (string) -> *InflightRequest
@@ -225,6 +229,8 @@ func NewOwnerFromSnapshot(cfg OwnerConfig, snap OwnerSnapshot) (*Owner, error) {
 		progressOwners:         make(map[string]int),
 		progressTokenRequestID: make(map[string]string),
 		requestToTokens:        make(map[string][]string),
+		lastRealProgress:       make(map[string]time.Time),
+		determinateTokens:      make(map[string]bool),
 		startTime:              time.Now(),
 		listenerDone:           make(chan struct{}),
 		done:                   make(chan struct{}),
@@ -384,6 +390,8 @@ func NewOwner(cfg OwnerConfig) (*Owner, error) {
 		progressOwners:         make(map[string]int),
 		progressTokenRequestID: make(map[string]string),
 		requestToTokens:        make(map[string][]string),
+		lastRealProgress:       make(map[string]time.Time),
+		determinateTokens:      make(map[string]bool),
 		startTime:              time.Now(),
 		listenerDone:           make(chan struct{}),
 		done:                   make(chan struct{}),
@@ -1016,6 +1024,7 @@ func (o *Owner) routeProgressNotification(raw []byte) error {
 	var notif struct {
 		Params struct {
 			ProgressToken json.RawMessage `json:"progressToken"`
+			Total         *float64        `json:"total"`
 		} `json:"params"`
 	}
 	if err := json.Unmarshal(raw, &notif); err != nil {
@@ -1036,7 +1045,13 @@ func (o *Owner) routeProgressNotification(raw []byte) error {
 		return fmt.Errorf("no owner for progressToken %s", token)
 	}
 
-	return session.WriteRaw(raw)
+	if err := session.WriteRaw(raw); err != nil {
+		return err
+	}
+
+	// Record that real progress arrived so the synthetic reporter can back off.
+	o.recordRealProgress(token, notif.Params.Total != nil)
+	return nil
 }
 
 // trackProgressToken extracts _meta.progressToken from a request and records
@@ -1075,12 +1090,23 @@ func (o *Owner) trackProgressToken(sessionID int, requestID string, raw []byte) 
 // This variant acquires the lock itself (safe to call from any goroutine).
 func (o *Owner) clearProgressTokensForRequest(requestID string) {
 	o.mu.Lock()
-	defer o.mu.Unlock()
-	for _, token := range o.requestToTokens[requestID] {
+	tokens := o.requestToTokens[requestID]
+	for _, token := range tokens {
 		delete(o.progressOwners, token)
 		delete(o.progressTokenRequestID, token)
 	}
 	delete(o.requestToTokens, requestID)
+	o.mu.Unlock()
+
+	// Clean up dedup maps under their own mutex to avoid lock inversion.
+	if len(tokens) > 0 {
+		o.progressMu.Lock()
+		for _, token := range tokens {
+			delete(o.lastRealProgress, token)
+			delete(o.determinateTokens, token)
+		}
+		o.progressMu.Unlock()
+	}
 }
 
 // sendRootsListChanged notifies the upstream that roots have changed.

--- a/internal/mux/progress_reporter.go
+++ b/internal/mux/progress_reporter.go
@@ -46,6 +46,18 @@ func buildSyntheticProgress(token string, toolOrMethod string, elapsedSeconds in
 	return data
 }
 
+// recordRealProgress notes that a real upstream progress notification was received
+// for the given token. If hasTotalField is true the token is marked determinate
+// and synthetic progress is permanently suppressed for it.
+func (o *Owner) recordRealProgress(token string, hasTotalField bool) {
+	o.progressMu.Lock()
+	defer o.progressMu.Unlock()
+	o.lastRealProgress[token] = time.Now()
+	if hasTotalField {
+		o.determinateTokens[token] = true
+	}
+}
+
 // loadProgressInterval reads the current interval from the atomic field with a
 // fallback to 5 s when the stored value is zero or negative.
 func (o *Owner) loadProgressInterval() time.Duration {
@@ -119,6 +131,23 @@ func (o *Owner) emitSyntheticProgress(interval time.Duration) {
 		}
 
 		for _, token := range tokens {
+			// Dedup: skip if real progress is active for this token.
+			o.progressMu.Lock()
+			isDeterminate := o.determinateTokens[token]
+			lastReal, hasReal := o.lastRealProgress[token]
+			o.progressMu.Unlock()
+
+			if isDeterminate {
+				// Real progress with a total field was received — never override a
+				// determinate progress bar with synthetic indeterminate ticks.
+				continue
+			}
+			if hasReal && now.Sub(lastReal) < interval {
+				// Real progress arrived within this interval — back off and let
+				// the upstream-driven bar drive the UI.
+				continue
+			}
+
 			data := buildSyntheticProgress(token, toolOrMethod, elapsedSec)
 			if err := session.WriteRaw(data); err != nil {
 				o.logger.Printf("session %d: synthetic progress write error: %v", req.SessionID, err)

--- a/internal/mux/progress_reporter.go
+++ b/internal/mux/progress_reporter.go
@@ -19,7 +19,10 @@ func doneContext(done <-chan struct{}) context.Context {
 }
 
 // buildSyntheticProgress builds JSON-RPC notification bytes for synthetic progress.
-// token: from CC's SDK (tracked in requestToTokens)
+// token: JSON-encoded progress token from CC's SDK (tracked in requestToTokens); stored
+//
+//	as raw JSON so numeric and string tokens are both preserved without re-quoting.
+//
 // toolOrMethod: tool name (e.g. "tavily_search") or method (e.g. "tools/call")
 // elapsedSeconds: seconds since request start, used as monotonically increasing progress counter
 func buildSyntheticProgress(token string, toolOrMethod string, elapsedSeconds int) []byte {
@@ -27,15 +30,15 @@ func buildSyntheticProgress(token string, toolOrMethod string, elapsedSeconds in
 		JSONRPC string `json:"jsonrpc"`
 		Method  string `json:"method"`
 		Params  struct {
-			ProgressToken string `json:"progressToken"`
-			Progress      int    `json:"progress"`
-			Message       string `json:"message,omitempty"`
+			ProgressToken json.RawMessage `json:"progressToken"`
+			Progress      int             `json:"progress"`
+			Message       string          `json:"message,omitempty"`
 		} `json:"params"`
 	}{
 		JSONRPC: "2.0",
 		Method:  "notifications/progress",
 	}
-	msg.Params.ProgressToken = token
+	msg.Params.ProgressToken = json.RawMessage(token)
 	msg.Params.Progress = elapsedSeconds
 	msg.Params.Message = fmt.Sprintf("%s: %ds elapsed", toolOrMethod, elapsedSeconds)
 
@@ -43,13 +46,22 @@ func buildSyntheticProgress(token string, toolOrMethod string, elapsedSeconds in
 	return data
 }
 
+// loadProgressInterval reads the current interval from the atomic field with a
+// fallback to 5 s when the stored value is zero or negative.
+func (o *Owner) loadProgressInterval() time.Duration {
+	ns := o.progressIntervalNs.Load()
+	if ns <= 0 {
+		return 5 * time.Second
+	}
+	return time.Duration(ns)
+}
+
 // runProgressReporter scans inflightTracker every interval and sends synthetic
 // notifications/progress for long-running requests without recent real progress.
+// The ticker is reset whenever the configured interval changes so that updates
+// from the initialize response take effect without restarting the goroutine.
 func (o *Owner) runProgressReporter(ctx context.Context) {
-	interval := o.progressInterval
-	if interval <= 0 {
-		interval = 5 * time.Second
-	}
+	interval := o.loadProgressInterval()
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
@@ -58,6 +70,11 @@ func (o *Owner) runProgressReporter(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
+			current := o.loadProgressInterval()
+			if current != interval {
+				interval = current
+				ticker.Reset(interval)
+			}
 			o.emitSyntheticProgress(interval)
 		}
 	}

--- a/internal/mux/progress_reporter.go
+++ b/internal/mux/progress_reporter.go
@@ -1,0 +1,113 @@
+package mux
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// doneContext wraps a done channel into a context.Context.
+// The returned context is cancelled when the channel is closed.
+func doneContext(done <-chan struct{}) context.Context {
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		<-done
+		cancel()
+	}()
+	return ctx
+}
+
+// buildSyntheticProgress builds JSON-RPC notification bytes for synthetic progress.
+// token: from CC's SDK (tracked in requestToTokens)
+// toolOrMethod: tool name (e.g. "tavily_search") or method (e.g. "tools/call")
+// elapsedSeconds: seconds since request start, used as monotonically increasing progress counter
+func buildSyntheticProgress(token string, toolOrMethod string, elapsedSeconds int) []byte {
+	msg := struct {
+		JSONRPC string `json:"jsonrpc"`
+		Method  string `json:"method"`
+		Params  struct {
+			ProgressToken string `json:"progressToken"`
+			Progress      int    `json:"progress"`
+			Message       string `json:"message,omitempty"`
+		} `json:"params"`
+	}{
+		JSONRPC: "2.0",
+		Method:  "notifications/progress",
+	}
+	msg.Params.ProgressToken = token
+	msg.Params.Progress = elapsedSeconds
+	msg.Params.Message = fmt.Sprintf("%s: %ds elapsed", toolOrMethod, elapsedSeconds)
+
+	data, _ := json.Marshal(msg)
+	return data
+}
+
+// runProgressReporter scans inflightTracker every interval and sends synthetic
+// notifications/progress for long-running requests without recent real progress.
+func (o *Owner) runProgressReporter(ctx context.Context) {
+	interval := o.progressInterval
+	if interval <= 0 {
+		interval = 5 * time.Second
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			o.emitSyntheticProgress(interval)
+		}
+	}
+}
+
+// emitSyntheticProgress scans inflight requests and sends synthetic notifications
+// for any that have been running longer than the reporting interval.
+func (o *Owner) emitSyntheticProgress(interval time.Duration) {
+	now := time.Now()
+
+	o.inflightTracker.Range(func(key, value any) bool {
+		reqID := key.(string)
+		req := value.(*InflightRequest)
+
+		elapsed := now.Sub(req.StartTime)
+		if elapsed < interval {
+			return true // too young, skip
+		}
+
+		// Look up progress tokens for this request
+		o.mu.RLock()
+		tokens := o.requestToTokens[reqID]
+		o.mu.RUnlock()
+
+		if len(tokens) == 0 {
+			return true // no progress token, can't send notification
+		}
+
+		elapsedSec := int(elapsed.Seconds())
+		toolOrMethod := req.Tool
+		if toolOrMethod == "" {
+			toolOrMethod = req.Method
+		}
+
+		// Send to the owning session
+		o.mu.RLock()
+		session, ok := o.sessions[req.SessionID]
+		o.mu.RUnlock()
+
+		if !ok {
+			return true // session gone
+		}
+
+		for _, token := range tokens {
+			data := buildSyntheticProgress(token, toolOrMethod, elapsedSec)
+			if err := session.WriteRaw(data); err != nil {
+				o.logger.Printf("session %d: synthetic progress write error: %v", req.SessionID, err)
+			}
+		}
+
+		return true
+	})
+}

--- a/internal/mux/progress_reporter_test.go
+++ b/internal/mux/progress_reporter_test.go
@@ -1,0 +1,170 @@
+package mux
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// buildSyntheticProgress — unit tests
+// ---------------------------------------------------------------------------
+
+func TestBuildSyntheticProgress_WithTool(t *testing.T) {
+	data := buildSyntheticProgress(`"tok-1"`, "tavily_search", 10)
+	if data == nil {
+		t.Fatal("expected non-nil bytes")
+	}
+
+	var msg struct {
+		JSONRPC string `json:"jsonrpc"`
+		Method  string `json:"method"`
+		Params  struct {
+			ProgressToken string `json:"progressToken"`
+			Progress      int    `json:"progress"`
+			Message       string `json:"message"`
+		} `json:"params"`
+	}
+	if err := json.Unmarshal(data, &msg); err != nil {
+		t.Fatalf("unmarshal: %v\ndata: %s", err, data)
+	}
+
+	if msg.JSONRPC != "2.0" {
+		t.Errorf("jsonrpc: got %q, want %q", msg.JSONRPC, "2.0")
+	}
+	if msg.Method != "notifications/progress" {
+		t.Errorf("method: got %q, want %q", msg.Method, "notifications/progress")
+	}
+	if msg.Params.ProgressToken != `"tok-1"` {
+		t.Errorf("progressToken: got %q, want %q", msg.Params.ProgressToken, `"tok-1"`)
+	}
+	if msg.Params.Progress != 10 {
+		t.Errorf("progress: got %d, want 10", msg.Params.Progress)
+	}
+	if !strings.Contains(msg.Params.Message, "tavily_search") {
+		t.Errorf("message missing tool name: %q", msg.Params.Message)
+	}
+	if !strings.Contains(msg.Params.Message, "10s") {
+		t.Errorf("message missing elapsed: %q", msg.Params.Message)
+	}
+}
+
+func TestBuildSyntheticProgress_WithoutTool(t *testing.T) {
+	// When Tool is empty, Method is used as the label.
+	data := buildSyntheticProgress(`"tok-2"`, "tools/call", 5)
+	if !bytes.Contains(data, []byte("tools/call")) {
+		t.Errorf("expected message to contain method name; got: %s", data)
+	}
+}
+
+func TestBuildSyntheticProgress_LongElapsed(t *testing.T) {
+	data := buildSyntheticProgress(`"tok-3"`, "slow_tool", 3661)
+	var msg struct {
+		Params struct {
+			Progress int    `json:"progress"`
+			Message  string `json:"message"`
+		} `json:"params"`
+	}
+	if err := json.Unmarshal(data, &msg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if msg.Params.Progress != 3661 {
+		t.Errorf("progress: got %d, want 3661", msg.Params.Progress)
+	}
+	if !strings.Contains(msg.Params.Message, "3661s") {
+		t.Errorf("message should contain elapsed seconds: %q", msg.Params.Message)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// emitSyntheticProgress — integration-style tests using a real Owner
+// ---------------------------------------------------------------------------
+
+// buildTestOwnerWithSession creates a minimal Owner with one live session backed
+// by a bytes.Buffer, and seeds one inflight request with a progress token.
+// Returns the owner, the session, and the buffer receiving writes.
+func buildTestOwnerWithSession(startedAgo time.Duration) (*Owner, *Session, *bytes.Buffer) {
+	o := newMinimalOwner()
+
+	// Create a session backed by a buffer so we can inspect writes.
+	var buf bytes.Buffer
+	s := NewSession(strings.NewReader(""), &buf)
+
+	o.mu.Lock()
+	o.sessions[s.ID] = s
+	o.mu.Unlock()
+
+	const reqID = `"req-progress-001"`
+	const token = `"tok-progress-001"`
+
+	// Seed inflight request with the desired start time.
+	req := &InflightRequest{
+		Method:    "tools/call",
+		Tool:      "slow_tool",
+		SessionID: s.ID,
+		StartTime: time.Now().Add(-startedAgo),
+	}
+	o.inflightTracker.Store(reqID, req)
+
+	// Seed progress token mapping.
+	o.mu.Lock()
+	o.progressOwners[token] = s.ID
+	o.progressTokenRequestID[token] = reqID
+	o.requestToTokens[reqID] = []string{token}
+	o.mu.Unlock()
+
+	return o, s, &buf
+}
+
+func TestProgressReporter_EmitsAfterThreshold(t *testing.T) {
+	// Request has been running 10 seconds — well above the 5s interval.
+	o, _, buf := buildTestOwnerWithSession(10 * time.Second)
+
+	o.emitSyntheticProgress(5 * time.Second)
+
+	written := buf.String()
+	if written == "" {
+		t.Fatal("expected synthetic progress notification to be written, got nothing")
+	}
+	if !strings.Contains(written, "notifications/progress") {
+		t.Errorf("written data missing notifications/progress: %q", written)
+	}
+	if !strings.Contains(written, "slow_tool") {
+		t.Errorf("written data missing tool name: %q", written)
+	}
+}
+
+func TestProgressReporter_NoEmitWhenYoung(t *testing.T) {
+	// Request started only 1 second ago — below the 5s interval.
+	o, _, buf := buildTestOwnerWithSession(1 * time.Second)
+
+	o.emitSyntheticProgress(5 * time.Second)
+
+	if buf.Len() > 0 {
+		t.Errorf("expected no emission for young request, got: %q", buf.String())
+	}
+}
+
+func TestProgressReporter_StopsOnCancel(t *testing.T) {
+	o := newMinimalOwner()
+	o.progressInterval = 50 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		o.runProgressReporter(ctx)
+		close(done)
+	}()
+
+	cancel()
+
+	select {
+	case <-done:
+		// goroutine exited cleanly
+	case <-time.After(2 * time.Second):
+		t.Fatal("runProgressReporter did not stop after context cancellation")
+	}
+}

--- a/internal/mux/progress_reporter_test.go
+++ b/internal/mux/progress_reporter_test.go
@@ -168,3 +168,147 @@ func TestProgressReporter_StopsOnCancel(t *testing.T) {
 		t.Fatal("runProgressReporter did not stop after context cancellation")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Dedup tests — Phase 3
+// ---------------------------------------------------------------------------
+
+// buildDedupOwner builds an Owner with one session and exactly one inflight request
+// seeded 10 s ago. The request has a single progress token. Returns the owner, the
+// buffer receiving writes from that session, and the token string.
+func buildDedupOwner(t *testing.T) (*Owner, *bytes.Buffer, string) {
+	t.Helper()
+	const reqID = `"req-dedup-001"`
+	const token = `"tok-dedup-001"`
+
+	o := newMinimalOwner()
+
+	var buf bytes.Buffer
+	s := NewSession(strings.NewReader(""), &buf)
+
+	o.mu.Lock()
+	o.sessions[s.ID] = s
+	o.progressOwners[token] = s.ID
+	o.progressTokenRequestID[token] = reqID
+	o.requestToTokens[reqID] = []string{token}
+	o.mu.Unlock()
+
+	req := &InflightRequest{
+		Method:    "tools/call",
+		Tool:      "slow_tool",
+		SessionID: s.ID,
+		StartTime: time.Now().Add(-10 * time.Second),
+	}
+	o.inflightTracker.Store(reqID, req)
+
+	return o, &buf, token
+}
+
+// TestDedup_RealProgressSuppressesSynthetic verifies that when real progress was
+// received within the current interval, emitSyntheticProgress skips that token.
+func TestDedup_RealProgressSuppressesSynthetic(t *testing.T) {
+	o, buf, token := buildDedupOwner(t)
+
+	// Record real progress just now — within any reasonable interval.
+	o.recordRealProgress(token, false)
+
+	o.emitSyntheticProgress(5 * time.Second)
+
+	if buf.Len() > 0 {
+		t.Errorf("expected no synthetic emission when real progress active for %s; got: %q",
+			token, buf.String())
+	}
+}
+
+// TestDedup_SyntheticResumesAfterSilence verifies that when real progress is older
+// than one interval, synthetic progress resumes.
+func TestDedup_SyntheticResumesAfterSilence(t *testing.T) {
+	o, buf, token := buildDedupOwner(t)
+
+	// Record real progress that is 10 seconds in the past — older than the 5s interval.
+	o.progressMu.Lock()
+	o.lastRealProgress[token] = time.Now().Add(-10 * time.Second)
+	o.progressMu.Unlock()
+
+	o.emitSyntheticProgress(5 * time.Second)
+
+	if buf.Len() == 0 {
+		t.Error("expected synthetic emission to resume after real progress went silent")
+	}
+	if !strings.Contains(buf.String(), "notifications/progress") {
+		t.Errorf("written data missing notifications/progress: %q", buf.String())
+	}
+}
+
+// TestDedup_DeterminatePermanentlySuppresses verifies that once real progress with
+// a total field is recorded, synthetic progress is never emitted for that token —
+// even after the interval has elapsed.
+func TestDedup_DeterminatePermanentlySuppresses(t *testing.T) {
+	o, buf, token := buildDedupOwner(t)
+
+	// Record real progress with hasTotalField=true (determinate bar).
+	o.recordRealProgress(token, true)
+
+	// Push lastRealProgress far into the past so the "within interval" guard alone
+	// would not suppress — only determinateTokens must suppress.
+	o.progressMu.Lock()
+	o.lastRealProgress[token] = time.Now().Add(-1 * time.Hour)
+	o.progressMu.Unlock()
+
+	o.emitSyntheticProgress(5 * time.Second)
+
+	if buf.Len() > 0 {
+		t.Errorf("expected no synthetic emission for determinate token; got: %q", buf.String())
+	}
+}
+
+// TestDedup_CleanupOnRequestComplete verifies that clearProgressTokensForRequest
+// removes entries from lastRealProgress and determinateTokens.
+func TestDedup_CleanupOnRequestComplete(t *testing.T) {
+	const reqID = `"req-cleanup-001"`
+	const token = `"tok-cleanup-001"`
+
+	o := newMinimalOwner()
+
+	o.mu.Lock()
+	o.progressOwners[token] = 1
+	o.progressTokenRequestID[token] = reqID
+	o.requestToTokens[reqID] = []string{token}
+	o.mu.Unlock()
+
+	o.progressMu.Lock()
+	o.lastRealProgress[token] = time.Now()
+	o.determinateTokens[token] = true
+	o.progressMu.Unlock()
+
+	o.clearProgressTokensForRequest(reqID)
+
+	o.progressMu.Lock()
+	_, hasLast := o.lastRealProgress[token]
+	_, hasDet := o.determinateTokens[token]
+	o.progressMu.Unlock()
+
+	if hasLast {
+		t.Errorf("lastRealProgress[%s] not cleaned up after clearProgressTokensForRequest", token)
+	}
+	if hasDet {
+		t.Errorf("determinateTokens[%s] not cleaned up after clearProgressTokensForRequest", token)
+	}
+
+	// Also verify the main progress maps were cleaned up.
+	o.mu.RLock()
+	_, hasOwner := o.progressOwners[token]
+	_, hasReqID := o.progressTokenRequestID[token]
+	_, hasTokens := o.requestToTokens[reqID]
+	o.mu.RUnlock()
+
+	if hasOwner {
+		t.Errorf("progressOwners[%s] not cleaned up", token)
+	}
+	if hasReqID {
+		t.Errorf("progressTokenRequestID[%s] not cleaned up", token)
+	}
+	if hasTokens {
+		t.Errorf("requestToTokens[%s] not cleaned up", reqID)
+	}
+}

--- a/internal/mux/progress_reporter_test.go
+++ b/internal/mux/progress_reporter_test.go
@@ -38,8 +38,8 @@ func TestBuildSyntheticProgress_WithTool(t *testing.T) {
 	if msg.Method != "notifications/progress" {
 		t.Errorf("method: got %q, want %q", msg.Method, "notifications/progress")
 	}
-	if msg.Params.ProgressToken != `"tok-1"` {
-		t.Errorf("progressToken: got %q, want %q", msg.Params.ProgressToken, `"tok-1"`)
+	if msg.Params.ProgressToken != "tok-1" {
+		t.Errorf("progressToken: got %q, want %q", msg.Params.ProgressToken, "tok-1")
 	}
 	if msg.Params.Progress != 10 {
 		t.Errorf("progress: got %d, want 10", msg.Params.Progress)
@@ -150,7 +150,7 @@ func TestProgressReporter_NoEmitWhenYoung(t *testing.T) {
 
 func TestProgressReporter_StopsOnCancel(t *testing.T) {
 	o := newMinimalOwner()
-	o.progressInterval = 50 * time.Millisecond
+	o.progressIntervalNs.Store(int64(50 * time.Millisecond))
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})

--- a/internal/mux/progress_reporter_test.go
+++ b/internal/mux/progress_reporter_test.go
@@ -262,6 +262,34 @@ func TestDedup_DeterminatePermanentlySuppresses(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// T013 — configurable progressInterval tests (Phase 4)
+// ---------------------------------------------------------------------------
+
+// TestProgressInterval_CustomValue verifies that loadProgressInterval returns
+// the interval stored in progressIntervalNs when it is explicitly set.
+func TestProgressInterval_CustomValue(t *testing.T) {
+	o := newMinimalOwner()
+	o.progressIntervalNs.Store(int64(10 * time.Second))
+
+	got := o.loadProgressInterval()
+	if got != 10*time.Second {
+		t.Errorf("loadProgressInterval() = %v, want %v", got, 10*time.Second)
+	}
+}
+
+// TestProgressInterval_DefaultWhenAbsent verifies that loadProgressInterval
+// returns the 5 s default when no interval has been stored (zero value).
+func TestProgressInterval_DefaultWhenAbsent(t *testing.T) {
+	o := newMinimalOwner()
+	// progressIntervalNs is zero-valued — default fallback must apply.
+
+	got := o.loadProgressInterval()
+	if got != 5*time.Second {
+		t.Errorf("loadProgressInterval() = %v, want %v", got, 5*time.Second)
+	}
+}
+
 // TestDedup_CleanupOnRequestComplete verifies that clearProgressTokensForRequest
 // removes entries from lastRealProgress and determinateTokens.
 func TestDedup_CleanupOnRequestComplete(t *testing.T) {


### PR DESCRIPTION
## Summary

Implements Phase 2 of the Synthetic Progress Reporter (T003-T006). When a `tools/call` request takes longer than the configured interval (default 5s), mcp-mux now sends synthetic `notifications/progress` to the requesting CC session with the tool name and elapsed time (e.g. `"tavily_search: 15s elapsed"`).

## Changes

### New: `internal/mux/progress_reporter.go`
- `buildSyntheticProgress()` — constructs valid JSON-RPC notification bytes
- `runProgressReporter()` — goroutine that ticks every `progressInterval`, scans `inflightTracker`, sends synthetic progress to correct session
- `emitSyntheticProgress()` — helper to write notification via `session.WriteRaw`

### Modified: `internal/mux/owner.go`
- Added `progressInterval` field (default 5s) to Owner struct
- Parses `x-mux.progressInterval` from cached init response via `ParseProgressInterval`
- Starts reporter goroutine in both `NewOwner` and `NewOwnerFromSnapshot` constructors

### New: `internal/mux/progress_reporter_test.go`
- 6 test cases: WithTool, WithoutTool, LongElapsed, EmitsAfterThreshold, NoEmitWhenYoung, StopsOnCancel

## Spec
`.agent/specs/synthetic-progress-reporter/` — Phase 2 (T003-T006, G002)

## Phase 1 (T001-T002) was shipped in v0.11.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Новые возможности

* **Новые функции**
  * Добавлены автоматические уведомления о прогрессе для длительных операций.
  * Реализована возможность конфигурирования интервала отправки уведомлений (по умолчанию 5 секунд).
  * Добавлена поддержка переопределения интервала прогресса через параметры сервера.
  * Уведомления о прогрессе теперь отображают прошедшее время в секундах.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->