### PR TITLE
fix: resolve data race in coverage_test and socket path length on macOS

### DIFF
--- a/internal/daemon/supervisor_test.go
+++ b/internal/daemon/supervisor_test.go
@@ -17,8 +17,16 @@ import (
 // TestDaemonSupervisorInitialized verifies that the daemon creates a supervisor
 // during New() and that it's reachable via the exported fields.
 func TestDaemonSupervisorInitialized(t *testing.T) {
-	tmpDir := t.TempDir()
-	ctlPath := tmpDir + "/daemon.ctl.sock"
+	// Use os.CreateTemp for a short path — t.TempDir() on macOS exceeds
+	// the 108-byte Unix socket path limit.
+	f, err := os.CreateTemp("", "daemon-ctl-*.sock")
+	if err != nil {
+		t.Fatalf("create temp socket path: %v", err)
+	}
+	ctlPath := f.Name()
+	f.Close()
+	os.Remove(ctlPath)
+	t.Cleanup(func() { os.Remove(ctlPath) })
 
 	d, err := New(Config{
 		ControlPath:  ctlPath,

--- a/internal/mux/coverage_test.go
+++ b/internal/mux/coverage_test.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -15,6 +16,25 @@ import (
 	"github.com/thebtf/mcp-mux/internal/jsonrpc"
 	"github.com/thebtf/mcp-mux/internal/serverid"
 )
+
+// safeBuf is a thread-safe bytes.Buffer for use in tests where concurrent
+// goroutines (e.g. drainNotifications) may write while the test reads.
+type safeBuf struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *safeBuf) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *safeBuf) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
 
 // ---------------------------------------------------------------------------
 // pathToFileURI
@@ -778,7 +798,7 @@ func TestRouteProgressNotification_Routed(t *testing.T) {
 	defer owner.Shutdown()
 
 	// Create a session and register it
-	var buf bytes.Buffer
+	var buf safeBuf
 	s := NewSession(strings.NewReader(""), &buf)
 
 	owner.mu.Lock()
@@ -791,8 +811,9 @@ func TestRouteProgressNotification_Routed(t *testing.T) {
 		t.Errorf("routeProgressNotification: %v", err)
 	}
 
-	if !strings.Contains(buf.String(), "tok-1") {
-		t.Errorf("expected progress notification routed to session, got: %s", buf.String())
+	got := buf.String()
+	if !strings.Contains(got, "tok-1") {
+		t.Errorf("expected progress notification routed to session, got: %s", got)
 	}
 }
 
@@ -1158,7 +1179,7 @@ func TestDrainInflightRequests_SendsError(t *testing.T) {
 	o.sessionMgr = NewSessionManager()
 
 	// Create a session backed by a buffer so we can inspect what's written to it
-	var buf bytes.Buffer
+	var buf safeBuf
 	s := NewSession(strings.NewReader(""), &buf)
 
 	// Register the session
@@ -1201,7 +1222,7 @@ func TestRouteToLastActiveSession_RoutesToActiveSession(t *testing.T) {
 	o.sessionMgr = NewSessionManager()
 
 	// Create a session backed by a buffer
-	var buf bytes.Buffer
+	var buf safeBuf
 	s := NewSession(strings.NewReader(""), &buf)
 
 	o.mu.Lock()
@@ -1228,8 +1249,9 @@ func TestRouteToLastActiveSession_RoutesToActiveSession(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 
 	// Session should have received the message
-	if !strings.Contains(buf.String(), "roots/list") {
-		t.Errorf("routeToLastActiveSession: session did not receive message; got: %s", buf.String())
+	got := buf.String()
+	if !strings.Contains(got, "roots/list") {
+		t.Errorf("routeToLastActiveSession: session did not receive message; got: %s", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes two pre-existing CI failures detected under `-race` flag:

### 1. Data race in coverage_test.go
- `TestRouteToLastActiveSession_RoutesToActiveSession` — `bytes.Buffer` shared between session goroutine (writes) and test assertion (reads)
- `TestDrainInflightRequests_SendsError` — same pattern
- `TestRouteProgressNotification_Routed` — same pattern
- **Fix:** `safeBuf` wrapper with mutex-protected `Write()` and `String()`

### 2. Socket path too long on macOS  
- `TestDaemonSupervisorInitialized` — `t.TempDir()` on macOS creates paths exceeding the 108-byte Unix socket limit
- **Fix:** Use `os.CreateTemp` for shorter paths (matches pattern in `mux_test.go` and `daemon_test.go`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Улучшена обработка путей сокетов управления для соответствия ограничениям длины пути на macOS.
* Исправлены условия гонки при одновременных операциях записи в буфер.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->