### PR TITLE
feat: add configurable BaseDir to serverid path functions

### DIFF
--- a/cmd/mcp-mux/daemon.go
+++ b/cmd/mcp-mux/daemon.go
@@ -20,7 +20,7 @@ import (
 // `mcp-mux daemon` subcommand. The daemon manages all upstream MCP servers,
 // accepts spawn requests via its control socket, and auto-exits after idle timeout.
 func runGlobalDaemon() {
-	ctlPath := serverid.DaemonControlPath()
+	ctlPath := serverid.DaemonControlPath("")
 
 	// Owner idle timeout: prefer MCP_MUX_OWNER_IDLE, fall back to MCP_MUX_GRACE
 	// (v0.10.x legacy name). Default 10 minutes (was 30s grace in v0.10.x).
@@ -98,7 +98,7 @@ func runGlobalDaemon() {
 // as a detached background process. Returns nil when daemon is ready.
 // Uses a file lock to prevent multiple shims from spawning concurrent daemons.
 func ensureDaemon(logger *log.Logger) error {
-	ctlPath := serverid.DaemonControlPath()
+	ctlPath := serverid.DaemonControlPath("")
 
 	// Fast path: daemon already running (no lock needed)
 	if isDaemonRunning(ctlPath) {
@@ -107,7 +107,7 @@ func ensureDaemon(logger *log.Logger) error {
 
 	// Acquire lock to prevent multiple shims from starting daemon simultaneously.
 	// Lock file is NOT deleted — it persists for coordination across shims.
-	lockPath := serverid.DaemonLockPath()
+	lockPath := serverid.DaemonLockPath("")
 	lock, err := os.OpenFile(lockPath, os.O_CREATE|os.O_WRONLY, 0600)
 	if err != nil {
 		return fmt.Errorf("open lock file: %w", err)
@@ -195,7 +195,7 @@ func startDaemonProcess() error {
 
 // spawnViaDaemon sends a spawn request to the daemon and returns the IPC path and handshake token.
 func spawnViaDaemon(command string, args []string, cwd, mode string, env map[string]string, logger *log.Logger) (string, string, error) {
-	ctlPath := serverid.DaemonControlPath()
+	ctlPath := serverid.DaemonControlPath("")
 
 	// Spawn returns immediately after creating the owner — proactive init runs
 	// in background. 30s timeout covers daemon processing + upstream process start.

--- a/cmd/mcp-mux/main.go
+++ b/cmd/mcp-mux/main.go
@@ -106,8 +106,8 @@ func main() {
 	command := args[0]
 	cmdArgs := args[1:]
 	sid := serverid.GenerateContextKey(mode, command, cmdArgs, nil, cwd)
-	ipcPath := serverid.IPCPath(sid)
-	controlPath := serverid.ControlPath(sid)
+	ipcPath := serverid.IPCPath(sid, "")
+	controlPath := serverid.ControlPath(sid, "")
 
 	// Log to stderr (CC captures) + optionally to file for debugging shim issues.
 	// Set MCP_MUX_SHIM_LOG to a file path to enable shim file logging.
@@ -291,7 +291,7 @@ func runServe() {
 
 func runStop(drainTimeout time.Duration, force bool) {
 	// Try stopping daemon first
-	ctlPath := serverid.DaemonControlPath()
+	ctlPath := serverid.DaemonControlPath("")
 	if isDaemonRunning(ctlPath) {
 		fmt.Fprintln(os.Stderr, "Stopping daemon...")
 		drainMs := int(drainTimeout.Milliseconds())
@@ -479,7 +479,7 @@ func runUpgrade(restart bool) {
 	}
 
 	// Report
-	ctlPath := serverid.DaemonControlPath()
+	ctlPath := serverid.DaemonControlPath("")
 	fmt.Fprintln(os.Stderr, "")
 	fmt.Fprintf(os.Stderr, "Upgrade complete: %s swapped.\n", filepath.Base(exe))
 
@@ -527,7 +527,7 @@ func collectEnv() map[string]string {
 
 func runStatus() {
 	// Try daemon first
-	ctlPath := serverid.DaemonControlPath()
+	ctlPath := serverid.DaemonControlPath("")
 	if isDaemonRunning(ctlPath) {
 		resp, err := control.Send(ctlPath, control.Request{Cmd: "status"})
 		if err == nil && resp.OK && resp.Data != nil {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -448,7 +448,7 @@ func (d *Daemon) Spawn(req control.Request) (string, string, string, error) {
 	d.owners[sid] = placeholder
 	d.mu.Unlock()
 
-	ipcPath := serverid.IPCPath(sid)
+	ipcPath := serverid.IPCPath(sid, "")
 
 	// Compute env diff: only vars that the shim has but daemon doesn't (CC-configured vars).
 	envDiff := diffEnv(req.Env)
@@ -461,7 +461,7 @@ func (d *Daemon) Spawn(req control.Request) (string, string, string, error) {
 	}
 
 	// Build the shared owner config (used by both template and fresh paths).
-	controlPath := serverid.ControlPath(sid)
+	controlPath := serverid.ControlPath(sid, "")
 	ownerCfg := mux.OwnerConfig{
 		Command:        req.Command,
 		Args:           req.Args,

--- a/internal/daemon/snapshot.go
+++ b/internal/daemon/snapshot.go
@@ -169,8 +169,8 @@ func (d *Daemon) loadSnapshot() int {
 	restored := 0
 	for _, ownerSnap := range snap.Owners {
 		sid := ownerSnap.ServerID
-		ipcPath := serverid.IPCPath(sid)
-		controlPath := serverid.ControlPath(sid)
+		ipcPath := serverid.IPCPath(sid, "")
+		controlPath := serverid.ControlPath(sid, "")
 
 		if ownerSnap.Classification == classify.ModeIsolated &&
 			len(ownerSnap.CwdSet) > 1 {

--- a/internal/muxcore/serverid/serverid.go
+++ b/internal/muxcore/serverid/serverid.go
@@ -152,29 +152,42 @@ func GenerateContextKey(mode SharingMode, cmd string, args, env []string, rawCwd
 	return hex.EncodeToString(hash.Sum(nil))[:16]
 }
 
+// resolveBaseDir returns baseDir if non-empty, otherwise os.TempDir().
+func resolveBaseDir(baseDir string) string {
+	if baseDir == "" {
+		return os.TempDir()
+	}
+	return baseDir
+}
+
 // IPCPath returns the platform-specific IPC endpoint path for a given server ID.
-func IPCPath(id string) string {
-	return filepath.Join(os.TempDir(), fmt.Sprintf("mcp-mux-%s.sock", id))
+// When baseDir is empty, os.TempDir() is used.
+func IPCPath(id string, baseDir string) string {
+	return filepath.Join(resolveBaseDir(baseDir), fmt.Sprintf("mcp-mux-%s.sock", id))
 }
 
 // ControlPath returns the control socket path for a given server ID.
-func ControlPath(id string) string {
-	return filepath.Join(os.TempDir(), fmt.Sprintf("mcp-mux-%s.ctl.sock", id))
+// When baseDir is empty, os.TempDir() is used.
+func ControlPath(id string, baseDir string) string {
+	return filepath.Join(resolveBaseDir(baseDir), fmt.Sprintf("mcp-mux-%s.ctl.sock", id))
 }
 
 // LockPath returns the lock file path used for owner election.
-func LockPath(id string) string {
-	return filepath.Join(os.TempDir(), fmt.Sprintf("mcp-mux-%s.lock", id))
+// When baseDir is empty, os.TempDir() is used.
+func LockPath(id string, baseDir string) string {
+	return filepath.Join(resolveBaseDir(baseDir), fmt.Sprintf("mcp-mux-%s.lock", id))
 }
 
 // DaemonControlPath returns the control socket path for the global daemon.
-func DaemonControlPath() string {
-	return filepath.Join(os.TempDir(), "mcp-muxd.ctl.sock")
+// When baseDir is empty, os.TempDir() is used.
+func DaemonControlPath(baseDir string) string {
+	return filepath.Join(resolveBaseDir(baseDir), "mcp-muxd.ctl.sock")
 }
 
 // DaemonLockPath returns the lock file path for daemon startup coordination.
-func DaemonLockPath() string {
-	return filepath.Join(os.TempDir(), "mcp-muxd.lock")
+// When baseDir is empty, os.TempDir() is used.
+func DaemonLockPath(baseDir string) string {
+	return filepath.Join(resolveBaseDir(baseDir), "mcp-muxd.lock")
 }
 
 // DescribeArgs returns a human-readable summary of the command + args

--- a/internal/muxcore/serverid/serverid_test.go
+++ b/internal/muxcore/serverid/serverid_test.go
@@ -44,7 +44,7 @@ func TestComputeEmptyFallback(t *testing.T) {
 }
 
 func TestIPCPath(t *testing.T) {
-	path := IPCPath("abc123def456")
+	path := IPCPath("abc123def456", "")
 	if !strings.HasSuffix(path, ".sock") {
 		t.Errorf("IPCPath = %q, want .sock suffix", path)
 	}
@@ -54,7 +54,7 @@ func TestIPCPath(t *testing.T) {
 }
 
 func TestControlPath(t *testing.T) {
-	path := ControlPath("abc123def456")
+	path := ControlPath("abc123def456", "")
 	if !strings.HasSuffix(path, ".ctl.sock") {
 		t.Errorf("ControlPath = %q, want .ctl.sock suffix", path)
 	}
@@ -64,9 +64,50 @@ func TestControlPath(t *testing.T) {
 }
 
 func TestLockPath(t *testing.T) {
-	path := LockPath("test123")
+	path := LockPath("test123", "")
 	if !strings.Contains(path, "mcp-mux-test123.lock") {
 		t.Errorf("LockPath = %q, missing expected pattern", path)
+	}
+}
+
+func TestIPCPath_EmptyBaseDir(t *testing.T) {
+	path := IPCPath("abc123", "")
+	tmpDir := os.TempDir()
+	if filepath.Dir(path) != tmpDir {
+		t.Errorf("IPCPath with empty baseDir: got dir %q, want os.TempDir() %q", filepath.Dir(path), tmpDir)
+	}
+}
+
+func TestIPCPath_CustomBaseDir(t *testing.T) {
+	customDir := t.TempDir()
+	path := IPCPath("abc123", customDir)
+	if filepath.Dir(path) != customDir {
+		t.Errorf("IPCPath with custom baseDir: got dir %q, want %q", filepath.Dir(path), customDir)
+	}
+	if !strings.Contains(path, "mcp-mux-abc123.sock") {
+		t.Errorf("IPCPath = %q, missing expected filename", path)
+	}
+}
+
+func TestDaemonControlPath_CustomBaseDir(t *testing.T) {
+	customDir := t.TempDir()
+	path := DaemonControlPath(customDir)
+	if filepath.Dir(path) != customDir {
+		t.Errorf("DaemonControlPath with custom baseDir: got dir %q, want %q", filepath.Dir(path), customDir)
+	}
+	if filepath.Base(path) != "mcp-muxd.ctl.sock" {
+		t.Errorf("DaemonControlPath = %q, unexpected filename", path)
+	}
+}
+
+func TestDaemonLockPath_CustomBaseDir(t *testing.T) {
+	customDir := t.TempDir()
+	path := DaemonLockPath(customDir)
+	if filepath.Dir(path) != customDir {
+		t.Errorf("DaemonLockPath with custom baseDir: got dir %q, want %q", filepath.Dir(path), customDir)
+	}
+	if filepath.Base(path) != "mcp-muxd.lock" {
+		t.Errorf("DaemonLockPath = %q, unexpected filename", path)
 	}
 }
 

--- a/testdata/smoke_isolated.go
+++ b/testdata/smoke_isolated.go
@@ -58,7 +58,7 @@ func main() {
 		fmt.Printf("cwd2: %s (isolation check)\n", cwd2)
 	}
 
-	ctlPath := serverid.DaemonControlPath()
+	ctlPath := serverid.DaemonControlPath("")
 	failures := 0
 
 	// ── TEST 1: Spawn via daemon ──


### PR DESCRIPTION
## Summary

Adds configurable `baseDir` parameter to all path functions in `internal/muxcore/serverid/`:
- `IPCPath(id, baseDir)`, `ControlPath(id, baseDir)`, `LockPath(id, baseDir)`
- `DaemonControlPath(baseDir)`, `DaemonLockPath(baseDir)`

When `baseDir` is empty string, falls back to `os.TempDir()` (preserving existing behavior).

This enables muxcore consumers to specify custom socket directories when embedding the library.

## Changes
- `serverid.go`: `resolveBaseDir` helper + updated signatures
- 5 caller files updated to pass `""` (no behavior change)
- 4 new tests for custom BaseDir paths

## Spec
`.agent/specs/muxcore-library/tasks.md` — T007 (Phase 1 gate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **Refactor**
  * Обновлена внутренняя система управления путями для работы с демоном. Система теперь более гибкая в определении расположения файлов управления и блокировки, что улучшает надёжность взаимодействия компонентов приложения.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->