### PR TITLE
fix: crash circuit breaker + CWD-aware cross-session dedup

### DIFF
--- a/cmd/mcp-mux/daemon.go
+++ b/cmd/mcp-mux/daemon.go
@@ -20,7 +20,7 @@ import (
 // `mcp-mux daemon` subcommand. The daemon manages all upstream MCP servers,
 // accepts spawn requests via its control socket, and auto-exits after idle timeout.
 func runGlobalDaemon() {
-	ctlPath := serverid.DaemonControlPath("")
+	ctlPath := serverid.DaemonControlPath("", "")
 
 	// Single-daemon validation: if another daemon is already running on this
 	// control socket, exit immediately instead of competing.
@@ -105,7 +105,7 @@ func runGlobalDaemon() {
 // as a detached background process. Returns nil when daemon is ready.
 // Uses a file lock to prevent multiple shims from spawning concurrent daemons.
 func ensureDaemon(logger *log.Logger) error {
-	ctlPath := serverid.DaemonControlPath("")
+	ctlPath := serverid.DaemonControlPath("", "")
 
 	// Fast path: daemon already running (no lock needed)
 	if isDaemonRunning(ctlPath) {
@@ -114,7 +114,7 @@ func ensureDaemon(logger *log.Logger) error {
 
 	// Acquire lock to prevent multiple shims from starting daemon simultaneously.
 	// Lock file is NOT deleted — it persists for coordination across shims.
-	lockPath := serverid.DaemonLockPath("")
+	lockPath := serverid.DaemonLockPath("", "")
 	lock, err := os.OpenFile(lockPath, os.O_CREATE|os.O_WRONLY, 0600)
 	if err != nil {
 		return fmt.Errorf("open lock file: %w", err)
@@ -202,7 +202,7 @@ func startDaemonProcess() error {
 
 // spawnViaDaemon sends a spawn request to the daemon and returns the IPC path and handshake token.
 func spawnViaDaemon(command string, args []string, cwd, mode string, env map[string]string, logger *log.Logger) (string, string, error) {
-	ctlPath := serverid.DaemonControlPath("")
+	ctlPath := serverid.DaemonControlPath("", "")
 
 	// Spawn returns immediately after creating the owner — proactive init runs
 	// in background. 30s timeout covers daemon processing + upstream process start.

--- a/cmd/mcp-mux/main.go
+++ b/cmd/mcp-mux/main.go
@@ -292,7 +292,7 @@ func runServe() {
 
 func runStop(drainTimeout time.Duration, force bool) {
 	// Try stopping daemon first
-	ctlPath := serverid.DaemonControlPath("")
+	ctlPath := serverid.DaemonControlPath("", "")
 	if isDaemonRunning(ctlPath) {
 		fmt.Fprintln(os.Stderr, "Stopping daemon...")
 		drainMs := int(drainTimeout.Milliseconds())
@@ -480,7 +480,7 @@ func runUpgrade(restart bool) {
 	}
 
 	// Report
-	ctlPath := serverid.DaemonControlPath("")
+	ctlPath := serverid.DaemonControlPath("", "")
 	fmt.Fprintln(os.Stderr, "")
 	fmt.Fprintf(os.Stderr, "Upgrade complete: %s swapped.\n", filepath.Base(exe))
 
@@ -488,7 +488,7 @@ func runUpgrade(restart bool) {
 		// Acquire daemon lock BEFORE sending graceful-restart.
 		// This prevents shims from spawning a competing daemon during the restart window.
 		// Shims that detect IPC loss will call ensureDaemon → lockFile → block until we release.
-		lockPath := serverid.DaemonLockPath("")
+		lockPath := serverid.DaemonLockPath("", "")
 		lock, lockErr := os.OpenFile(lockPath, os.O_CREATE|os.O_WRONLY, 0600)
 		if lockErr == nil {
 			if flockErr := lockFile(lock); flockErr == nil {
@@ -606,7 +606,7 @@ func collectEnv() map[string]string {
 
 func runStatus() {
 	// Try daemon first
-	ctlPath := serverid.DaemonControlPath("")
+	ctlPath := serverid.DaemonControlPath("", "")
 	if isDaemonRunning(ctlPath) {
 		resp, err := control.Send(ctlPath, control.Request{Cmd: "status"})
 		if err == nil && resp.OK && resp.Data != nil {

--- a/muxcore/classify/classify_test.go
+++ b/muxcore/classify/classify_test.go
@@ -159,6 +159,17 @@ func TestClassifyTools(t *testing.T) {
 			wantMode:    ModeIsolated,
 			wantMatched: 3,
 		},
+		{
+			name: "pr-review-mcp - shared (no isolation patterns)",
+			json: `{"jsonrpc":"2.0","id":1,"result":{"tools":[
+				{"name":"pr_create"},
+				{"name":"pr_invoke"},
+				{"name":"pr_list"},
+				{"name":"pr_merge"}
+			]}}`,
+			wantMode:    ModeShared,
+			wantMatched: 0,
+		},
 	}
 
 	for _, tt := range tests {

--- a/muxcore/daemon/daemon.go
+++ b/muxcore/daemon/daemon.go
@@ -77,6 +77,12 @@ type Daemon struct {
 	supervisorCancel context.CancelFunc
 	supervisorErr <-chan error
 
+	// crashTracker records recent crash timestamps per command key.
+	// Used by Spawn() as a circuit breaker: if an upstream crashes too many
+	// times within a window, further spawn requests are rejected instead of
+	// creating an infinite respawn loop that burns CPU.
+	crashTracker map[string][]time.Time
+
 	shutdownOnce sync.Once
 }
 
@@ -147,6 +153,7 @@ func New(cfg Config) (*Daemon, error) {
 		ownerIdleTimeout: ownerIdleTimeout,
 		idleTimeout:      idleTimeout,
 		templateCache:    make(map[string]mcpsnapshot.OwnerSnapshot),
+		crashTracker:     make(map[string][]time.Time),
 		supervisorCtx:    supCtx,
 		supervisorCancel: supCancel,
 		handlerFunc:      cfg.HandlerFunc,
@@ -368,6 +375,20 @@ func (d *Daemon) Spawn(req control.Request) (string, string, string, error) {
 	// Generate handshake token upfront — valid for this spawn call only.
 	token := generateToken()
 
+	// Circuit breaker: reject spawn if the upstream has been crash-looping.
+	// This prevents infinite respawn loops (shim reconnect → spawn → crash → repeat)
+	// that burn CPU when an upstream is fundamentally broken.
+	cmdKey := req.Command + " " + strings.Join(req.Args, " ")
+	d.mu.RLock()
+	if d.isCrashLooping(cmdKey) {
+		d.mu.RUnlock()
+		d.logger.Printf("circuit breaker: rejecting spawn for %q (%d crashes in %s)",
+			cmdKey, crashThreshold, crashWindow)
+		return "", "", "", fmt.Errorf("upstream %q crashed %d times in %s, spawn rejected (circuit breaker)",
+			req.Command, crashThreshold, crashWindow)
+	}
+	d.mu.RUnlock()
+
 	// Server identity is based on command+args+cwd only, NOT env.
 	sid := serverid.GenerateContextKey(mode, req.Command, req.Args, nil, req.Cwd)
 
@@ -427,11 +448,12 @@ func (d *Daemon) Spawn(req control.Request) (string, string, string, error) {
 	}
 
 	// 2. Global dedup: if an accepting owner for same command+args exists (any cwd), reuse it.
-	//    Dedup is optimistic: unclassified owners are assumed shared/session-aware.
-	//    If the owner later classifies as isolated, it closes its listener — extra
-	//    sessions get EOF and reconnect, spawning their own owner.
+	//    Cross-CWD sharing is only allowed when the owner is CONFIRMED shareable
+	//    (classified as shared or session-aware). Unclassified owners are NOT shared
+	//    across different CWDs — every process has exactly one CWD, so sharing an
+	//    unclassified server with a different CWD risks context leaks.
 	if mode == serverid.ModeCwd {
-		if existing := d.findSharedOwner(req.Command, req.Args, req.Env); existing != nil {
+		if existing := d.findSharedOwner(req.Command, req.Args, req.Env, req.Cwd); existing != nil {
 			existing.LastSession = time.Now()
 			existingSID := existing.ServerID
 			d.mu.Unlock()
@@ -690,8 +712,10 @@ func (d *Daemon) SetPersistent(serverID string, persistent bool) {
 // Must be called with d.mu held. May transiently release and re-acquire d.mu
 // when it encounters a placeholder (Owner == nil) for a matching command+args —
 // it waits for that creation to complete before returning.
-func (d *Daemon) findSharedOwner(command string, args []string, env map[string]string) *OwnerEntry {
+func (d *Daemon) findSharedOwner(command string, args []string, env map[string]string, reqCwd string) *OwnerEntry {
 	needle := command + " " + strings.Join(args, " ")
+	canonReqCwd := serverid.CanonicalizePath(reqCwd)
+
 	for _, entry := range d.owners {
 		candidate := entry.Command + " " + strings.Join(entry.Args, " ")
 		if candidate != needle {
@@ -721,11 +745,23 @@ func (d *Daemon) findSharedOwner(command string, args []string, env map[string]s
 		if !entry.Owner.IsAccepting() {
 			continue
 		}
+
+		// CWD-aware dedup: every process has exactly one CWD. Sharing an upstream
+		// across sessions with different CWDs is only safe when the server has been
+		// confirmed CWD-independent (classified as shared or session-aware).
+		// Unclassified servers are NOT shared across CWDs — this prevents
+		// cross-project context leaks for CWD-dependent servers.
+		canonEntryCwd := serverid.CanonicalizePath(entry.Cwd)
+		cwdMatch := canonReqCwd == canonEntryCwd
+
+		if !cwdMatch {
+			// Different CWD — only share if owner is confirmed shareable.
+			if !entry.Owner.IsClassifiedShareable() {
+				continue
+			}
+		}
+
 		// Non-blocking classification check: if already classified, respect it.
-		// If not yet classified, return optimistically (assume shareable).
-		// This avoids both extremes:
-		// - Blocking wait (8s+ for slow upstreams → CC timeout)
-		// - Blind optimistic dedup (returns isolated owners → evict storm)
 		select {
 		case <-entry.Owner.Classified():
 			// Classification known — re-check IsAccepting (may have closed listener)
@@ -733,8 +769,8 @@ func (d *Daemon) findSharedOwner(command string, args []string, env map[string]s
 				continue
 			}
 		default:
-			// Not yet classified — optimistic: assume shareable.
-			// If later classified isolated → evict extra sessions.
+			// Not yet classified. Same CWD → safe to share optimistically.
+			// Different CWD → already filtered above (IsClassifiedShareable).
 		}
 		return entry
 	}
@@ -883,6 +919,10 @@ func (d *Daemon) onUpstreamExit(serverID string) {
 	d.mu.Lock()
 	entry, ok := d.owners[serverID]
 	if ok {
+		// Record crash for circuit breaker before any other action.
+		cmdKey := entry.Command + " " + strings.Join(entry.Args, " ")
+		d.recordCrash(cmdKey)
+
 		if entry.Persistent {
 			d.mu.Unlock()
 			d.logger.Printf("owner %s: upstream exited, will re-spawn (persistent)", serverID[:8])
@@ -897,6 +937,47 @@ func (d *Daemon) onUpstreamExit(serverID string) {
 		entry.Owner.Shutdown()
 		d.logger.Printf("owner %s: upstream exited, removed", serverID[:8])
 	}
+}
+
+// crashWindow is the time window for crash counting. If an upstream crashes
+// crashThreshold times within this window, further spawns are rejected.
+const crashWindow = 60 * time.Second
+const crashThreshold = 5
+
+// recordCrash adds a crash timestamp for the given command key.
+// Must be called with d.mu held.
+func (d *Daemon) recordCrash(cmdKey string) {
+	now := time.Now()
+	d.crashTracker[cmdKey] = append(d.crashTracker[cmdKey], now)
+
+	// Trim old entries outside the window.
+	cutoff := now.Add(-crashWindow)
+	crashes := d.crashTracker[cmdKey]
+	i := 0
+	for i < len(crashes) && crashes[i].Before(cutoff) {
+		i++
+	}
+	if i > 0 {
+		d.crashTracker[cmdKey] = crashes[i:]
+	}
+}
+
+// isCrashLooping returns true if the command has crashed too many times recently.
+// Must be called with d.mu held (at least RLock).
+func (d *Daemon) isCrashLooping(cmdKey string) bool {
+	crashes := d.crashTracker[cmdKey]
+	if len(crashes) < crashThreshold {
+		return false
+	}
+	// Count crashes within the window.
+	cutoff := time.Now().Add(-crashWindow)
+	count := 0
+	for _, t := range crashes {
+		if !t.Before(cutoff) {
+			count++
+		}
+	}
+	return count >= crashThreshold
 }
 
 // StatusJSON returns the daemon status as a JSON-encoded byte slice.

--- a/muxcore/daemon/daemon_test.go
+++ b/muxcore/daemon/daemon_test.go
@@ -606,5 +606,73 @@ func TestCleanStaleSockets(t *testing.T) {
 func findSharedOwnerLocked(d *Daemon, command string, args []string, env map[string]string) *OwnerEntry {
 	d.mu.Lock()
 	defer d.mu.Unlock()
-	return d.findSharedOwner(command, args, env)
+	return d.findSharedOwner(command, args, env, "")
+}
+
+func TestCrashCircuitBreaker(t *testing.T) {
+	d := &Daemon{
+		owners:       make(map[string]*OwnerEntry),
+		crashTracker: make(map[string][]time.Time),
+		logger:       testLogger(t),
+	}
+
+	cmdKey := "bad-server --broken"
+
+	// Under threshold — should not be crash looping
+	for i := 0; i < crashThreshold-1; i++ {
+		d.mu.Lock()
+		d.recordCrash(cmdKey)
+		d.mu.Unlock()
+	}
+	d.mu.RLock()
+	looping := d.isCrashLooping(cmdKey)
+	d.mu.RUnlock()
+	if looping {
+		t.Errorf("isCrashLooping = true after %d crashes, want false", crashThreshold-1)
+	}
+
+	// Hit threshold — should be crash looping
+	d.mu.Lock()
+	d.recordCrash(cmdKey)
+	d.mu.Unlock()
+	d.mu.RLock()
+	looping = d.isCrashLooping(cmdKey)
+	d.mu.RUnlock()
+	if !looping {
+		t.Errorf("isCrashLooping = false after %d crashes, want true", crashThreshold)
+	}
+
+	// Different command — should not be affected
+	d.mu.RLock()
+	otherLooping := d.isCrashLooping("good-server")
+	d.mu.RUnlock()
+	if otherLooping {
+		t.Error("isCrashLooping = true for unrelated command")
+	}
+}
+
+func TestCrashCircuitBreaker_WindowExpiry(t *testing.T) {
+	d := &Daemon{
+		owners:       make(map[string]*OwnerEntry),
+		crashTracker: make(map[string][]time.Time),
+		logger:       testLogger(t),
+	}
+
+	cmdKey := "flaky-server"
+
+	// Record crashes with old timestamps (outside the window).
+	oldTime := time.Now().Add(-crashWindow - time.Second)
+	d.mu.Lock()
+	for i := 0; i < crashThreshold+5; i++ {
+		d.crashTracker[cmdKey] = append(d.crashTracker[cmdKey], oldTime)
+	}
+	d.mu.Unlock()
+
+	// Old crashes should not trigger circuit breaker.
+	d.mu.RLock()
+	looping := d.isCrashLooping(cmdKey)
+	d.mu.RUnlock()
+	if looping {
+		t.Error("isCrashLooping = true for old crashes outside window")
+	}
 }

--- a/muxcore/engine/engine.go
+++ b/muxcore/engine/engine.go
@@ -134,7 +134,7 @@ func (e *MuxEngine) Run(ctx context.Context) error {
 // connections. It mirrors the behaviour of runGlobalDaemon() in cmd/mcp-mux/
 // but uses the engine's Config for timeouts and base directory.
 func (e *MuxEngine) runDaemon(ctx context.Context) error {
-	ctlPath := serverid.DaemonControlPath(e.cfg.BaseDir)
+	ctlPath := serverid.DaemonControlPath(e.cfg.BaseDir, e.cfg.Name)
 
 	d, err := daemon.New(daemon.Config{
 		ControlPath:      ctlPath,
@@ -169,7 +169,7 @@ func (e *MuxEngine) runDaemon(ctx context.Context) error {
 //  3. Connect to the returned IPC socket.
 //  4. Bridge stdin/stdout ↔ IPC with automatic reconnect.
 func (e *MuxEngine) runClient(ctx context.Context) error {
-	ctlPath := serverid.DaemonControlPath(e.cfg.BaseDir)
+	ctlPath := serverid.DaemonControlPath(e.cfg.BaseDir, e.cfg.Name)
 
 	// 1. Ensure the daemon is running, starting it if necessary.
 	if !isDaemonRunning(ctlPath) {
@@ -264,7 +264,7 @@ func (e *MuxEngine) startDaemon() error {
 		return fmt.Errorf("release daemon process: %w", err)
 	}
 
-	ctlPath := serverid.DaemonControlPath(e.cfg.BaseDir)
+	ctlPath := serverid.DaemonControlPath(e.cfg.BaseDir, e.cfg.Name)
 	return waitForDaemon(ctlPath, 10*time.Second)
 }
 

--- a/muxcore/owner/owner.go
+++ b/muxcore/owner/owner.go
@@ -1690,6 +1690,21 @@ func (o *Owner) Classified() <-chan struct{} {
 	return o.classified
 }
 
+// IsClassifiedShareable returns true if the owner has been classified AND
+// the classification allows cross-CWD sharing (shared or session-aware).
+// Returns false if not yet classified or classified as isolated.
+func (o *Owner) IsClassifiedShareable() bool {
+	select {
+	case <-o.classified:
+	default:
+		return false // not yet classified
+	}
+	o.mu.RLock()
+	mode := o.autoClassification
+	o.mu.RUnlock()
+	return mode == classify.ModeShared || mode == classify.ModeSessionAware
+}
+
 // MarkClassified forces the classified channel closed. Used by tests that need
 // to bypass the normal init/tools handshake classification flow.
 func (o *Owner) MarkClassified() {

--- a/muxcore/serverid/serverid.go
+++ b/muxcore/serverid/serverid.go
@@ -178,16 +178,26 @@ func LockPath(id string, baseDir string) string {
 	return filepath.Join(resolveBaseDir(baseDir), fmt.Sprintf("mcp-mux-%s.lock", id))
 }
 
-// DaemonControlPath returns the control socket path for the global daemon.
+// DaemonControlPath returns the control socket path for a named daemon.
+// The name parameter identifies the engine instance (e.g. "mcp-mux", "aimux").
+// When name is empty, defaults to "mcp-mux" for backward compatibility.
 // When baseDir is empty, os.TempDir() is used.
-func DaemonControlPath(baseDir string) string {
-	return filepath.Join(resolveBaseDir(baseDir), "mcp-muxd.ctl.sock")
+func DaemonControlPath(baseDir, name string) string {
+	if name == "" {
+		name = "mcp-mux"
+	}
+	return filepath.Join(resolveBaseDir(baseDir), fmt.Sprintf("%s-muxd.ctl.sock", name))
 }
 
 // DaemonLockPath returns the lock file path for daemon startup coordination.
+// The name parameter identifies the engine instance (e.g. "mcp-mux", "aimux").
+// When name is empty, defaults to "mcp-mux" for backward compatibility.
 // When baseDir is empty, os.TempDir() is used.
-func DaemonLockPath(baseDir string) string {
-	return filepath.Join(resolveBaseDir(baseDir), "mcp-muxd.lock")
+func DaemonLockPath(baseDir, name string) string {
+	if name == "" {
+		name = "mcp-mux"
+	}
+	return filepath.Join(resolveBaseDir(baseDir), fmt.Sprintf("%s-muxd.lock", name))
 }
 
 // DescribeArgs returns a human-readable summary of the command + args

--- a/muxcore/serverid/serverid_test.go
+++ b/muxcore/serverid/serverid_test.go
@@ -91,23 +91,45 @@ func TestIPCPath_CustomBaseDir(t *testing.T) {
 
 func TestDaemonControlPath_CustomBaseDir(t *testing.T) {
 	customDir := t.TempDir()
-	path := DaemonControlPath(customDir)
+	path := DaemonControlPath(customDir, "")
 	if filepath.Dir(path) != customDir {
 		t.Errorf("DaemonControlPath with custom baseDir: got dir %q, want %q", filepath.Dir(path), customDir)
 	}
-	if filepath.Base(path) != "mcp-muxd.ctl.sock" {
+	if filepath.Base(path) != "mcp-mux-muxd.ctl.sock" {
 		t.Errorf("DaemonControlPath = %q, unexpected filename", path)
+	}
+}
+
+func TestDaemonControlPath_CustomName(t *testing.T) {
+	customDir := t.TempDir()
+	path := DaemonControlPath(customDir, "aimux")
+	if filepath.Dir(path) != customDir {
+		t.Errorf("DaemonControlPath with custom name: got dir %q, want %q", filepath.Dir(path), customDir)
+	}
+	if filepath.Base(path) != "aimux-muxd.ctl.sock" {
+		t.Errorf("DaemonControlPath = %q, want aimux-muxd.ctl.sock", filepath.Base(path))
 	}
 }
 
 func TestDaemonLockPath_CustomBaseDir(t *testing.T) {
 	customDir := t.TempDir()
-	path := DaemonLockPath(customDir)
+	path := DaemonLockPath(customDir, "")
 	if filepath.Dir(path) != customDir {
 		t.Errorf("DaemonLockPath with custom baseDir: got dir %q, want %q", filepath.Dir(path), customDir)
 	}
-	if filepath.Base(path) != "mcp-muxd.lock" {
+	if filepath.Base(path) != "mcp-mux-muxd.lock" {
 		t.Errorf("DaemonLockPath = %q, unexpected filename", path)
+	}
+}
+
+func TestDaemonLockPath_CustomName(t *testing.T) {
+	customDir := t.TempDir()
+	path := DaemonLockPath(customDir, "aimux")
+	if filepath.Dir(path) != customDir {
+		t.Errorf("DaemonLockPath with custom name: got dir %q, want %q", filepath.Dir(path), customDir)
+	}
+	if filepath.Base(path) != "aimux-muxd.lock" {
+		t.Errorf("DaemonLockPath = %q, want aimux-muxd.lock", filepath.Base(path))
 	}
 }
 

--- a/testdata/smoke_isolated.go
+++ b/testdata/smoke_isolated.go
@@ -58,7 +58,7 @@ func main() {
 		fmt.Printf("cwd2: %s (isolation check)\n", cwd2)
 	}
 
-	ctlPath := serverid.DaemonControlPath("")
+	ctlPath := serverid.DaemonControlPath("", "")
 	failures := 0
 
 	// ── TEST 1: Spawn via daemon ──


### PR DESCRIPTION
## Problem

Two separate issues causing production pain:

### 1. CPU spin from crash-looping upstreams
When an upstream crashes on startup (e.g. aimux with broken config), the shim reconnects immediately, daemon spawns a new owner, upstream crashes again — tight loop consuming 78%+ CPU with no backoff. Observed in Task Manager as mcp-mux.exe at 99% CPU.

### 2. Cross-session CWD leak (#42)  
`findSharedOwner` shared upstreams across sessions with different CWDs, ignoring that every process has exactly one CWD. CWD-dependent servers (pr-review-mcp, serena, git servers) executed requests in the wrong project directory.

## Fix

### Circuit breaker
- Track crash timestamps per command key in daemon
- If upstream crashes 5+ times within 60s, reject further spawn requests
- Shim receives error instead of entering infinite reconnect loop
- Crashes outside the window are forgotten (self-healing)

### CWD-aware dedup
- `findSharedOwner` now takes a `cwd` parameter
- Cross-CWD sharing only allowed when owner is **confirmed shareable** (classified as `shared` or `session-aware` via x-mux capability or tool heuristic)
- Unclassified owners are NOT shared across different CWDs
- Same-CWD sessions still share optimistically (zero overhead for the common case)
- Added `Owner.IsClassifiedShareable()` — returns true only after classification confirms shareability

## Key insight
Instead of pattern-matching tool names (whitelisting known servers), this fix inverts the default: **don't share across CWDs unless the server has proven it is safe to do so.** This is correct by construction — no need to enumerate every possible MCP server.

Fixes #42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Новые возможности**
  * Добавлена защита от зацикливания процессов (circuit breaker) — предотвращает повторный запуск команд при серии аварий.
  * Контрольный сокет/лок даемона теперь учитывает имя конфигурации, что позволяет запускать изолированные экземпляры по имени.

* **Улучшения**
  * Усилена логика совместного использования процессов: проверяется соответствие рабочей директории и статус готовности к шарингу.

* **Тесты**
  * Добавлены тесты для проверки circuit breaker, окна истечения и классификации инструментов.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->