### PR TITLE
feat: inject _meta into requests for in-process Handler mode

### DIFF
--- a/muxcore/owner/owner.go
+++ b/muxcore/owner/owner.go
@@ -719,11 +719,14 @@ func (o *Owner) handleDownstreamMessage(s *Session, msg *jsonrpc.Message) error 
 			o.captureInitFingerprint(msg.Raw)
 		}
 
-		// Inject _meta.muxSessionId, _meta.muxCwd, and _meta.muxEnv for session-aware servers
+		// Inject _meta.muxSessionId, _meta.muxCwd, and _meta.muxEnv when the upstream
+		// needs to distinguish between CC sessions. Two cases:
+		// 1. session-aware: upstream declared x-mux.sharing: session-aware
+		// 2. in-process handler: single handler serves all CC sessions, always needs session identity
 		o.mu.RLock()
-		isSessionAware := o.autoClassification == classify.ModeSessionAware
+		needsMeta := o.autoClassification == classify.ModeSessionAware || o.handlerFunc != nil
 		o.mu.RUnlock()
-		if isSessionAware {
+		if needsMeta {
 			injected, err := jsonrpc.InjectMeta(remapped, "muxSessionId", s.MuxSessionID)
 			if err != nil {
 				o.logger.Printf("session %d: failed to inject muxSessionId: %v", s.ID, err)


### PR DESCRIPTION
## Problem

In-process handlers (muxcore engine consumers like aimux) serve all CC sessions 
through a single handler goroutine. Previously, `_meta` injection (`muxSessionId`, 
`muxCwd`, `muxEnv`) was only enabled for servers declaring `x-mux.sharing: session-aware`. 
In-process handlers had no way to distinguish which CC session sent a given request.

## Fix

Enable `_meta` injection for both:
1. **session-aware servers** (existing behavior, unchanged)
2. **in-process handlers** (`handlerFunc != nil`)

The handler reads session context from `params._meta` in each JSON-RPC request:
- `_meta.muxSessionId` — stable CC session identifier
- `_meta.muxCwd` — CC session working directory  
- `_meta.muxEnv` — per-session env diff (API keys, config paths)

## Impact for aimux

With this change, aimux can:
- Group jobs/sessions by CC session identity
- Route CWD-dependent operations correctly
- Implement per-CC-session rate limiting
- Support "cancel all my jobs" semantics

## One-line change

`needsMeta := isSessionAware` → `needsMeta := isSessionAware || o.handlerFunc != nil`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **Исправления ошибок**
  * Улучшена обработка метаданных сессии для встроенных обработчиков запросов.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->