### PR TITLE
fix(owner): support SessionHandler-only NewOwner without upstream

### DIFF
--- a/muxcore/owner/owner.go
+++ b/muxcore/owner/owner.go
@@ -442,9 +442,13 @@ func NewOwner(cfg OwnerConfig) (*Owner, error) {
 		logger = log.Default()
 	}
 
-	// Spawn upstream — either in-process handler or subprocess.
+	// Spawn upstream — either in-process handler, subprocess, or neither (SessionHandler-only).
 	var proc *upstream.Process
-	if cfg.HandlerFunc != nil {
+	if cfg.SessionHandler != nil && cfg.HandlerFunc == nil {
+		// SessionHandler-only: no upstream process needed.
+		// Requests dispatch directly via dispatchToSessionHandler.
+		logger.Printf("owner: SessionHandler-only mode (no upstream process)")
+	} else if cfg.HandlerFunc != nil {
 		proc = upstream.NewProcessFromHandler(context.Background(), cfg.HandlerFunc)
 		logger.Printf("owner: started in-process handler (no subprocess)")
 	} else {
@@ -458,7 +462,9 @@ func NewOwner(cfg OwnerConfig) (*Owner, error) {
 	// Start IPC listener
 	ln, err := ipc.Listen(cfg.IPCPath)
 	if err != nil {
-		proc.Close()
+		if proc != nil {
+			proc.Close()
+		}
 		return nil, fmt.Errorf("owner: listen %s: %w", cfg.IPCPath, err)
 	}
 
@@ -518,7 +524,10 @@ func NewOwner(cfg OwnerConfig) (*Owner, error) {
 	// Send proactive initialize to upstream so init response is cached
 	// before any session connects. Without this, Daemon.Spawn blocks on
 	// InitReady() but init requires a session to send the request — deadlock.
-	go o.sendProactiveInit()
+	// SessionHandler-only owners have no upstream, so skip the proactive init.
+	if proc != nil {
+		go o.sendProactiveInit()
+	}
 
 	// Start accepting IPC connections
 	go o.acceptLoop()
@@ -526,22 +535,24 @@ func NewOwner(cfg OwnerConfig) (*Owner, error) {
 	// Start synthetic progress reporter
 	go o.runProgressReporter(doneContext(o.done))
 
-	// Monitor upstream exit
-	go func() {
-		<-proc.Done
-		logger.Printf("upstream exited: %v", proc.ExitErr)
-		// Signal init-ready so Daemon.Spawn doesn't block forever on crashed upstream
-		o.initReadyOnce.Do(func() {
-			if o.initReady != nil {
-				close(o.initReady)
+	// Monitor upstream exit (skip in SessionHandler-only mode — proc is nil)
+	if proc != nil {
+		go func() {
+			<-proc.Done
+			logger.Printf("upstream exited: %v", proc.ExitErr)
+			// Signal init-ready so Daemon.Spawn doesn't block forever on crashed upstream
+			o.initReadyOnce.Do(func() {
+				if o.initReady != nil {
+					close(o.initReady)
+				}
+			})
+			if o.onUpstreamExit != nil {
+				o.onUpstreamExit(o.serverID)
+			} else {
+				o.Shutdown()
 			}
-		})
-		if o.onUpstreamExit != nil {
-			o.onUpstreamExit(o.serverID)
-		} else {
-			o.Shutdown()
-		}
-	}()
+		}()
+	}
 
 	return o, nil
 }
@@ -729,15 +740,17 @@ func (o *Owner) handleDownstreamMessage(s *Session, msg *jsonrpc.Message) error 
 			}
 		}
 
-		// Fail fast if upstream is dead or not yet spawned (snapshot owner without cache hit)
+		// SessionHandler dispatch: structured path without pipe/remap/_meta.
+		// Must come BEFORE the upstream nil check so SessionHandler-only owners
+		// (where o.upstream == nil by design) can serve requests normally.
+		if o.sessionHandler != nil {
+			return o.dispatchToSessionHandler(s, msg)
+		}
+
+		// Fail fast if upstream is dead or not yet spawned (pipe-based mode only)
 		if o.upstream == nil || o.upstreamDead.Load() {
 			errResp := fmt.Sprintf(`{"jsonrpc":"2.0","id":%s,"error":{"code":-32603,"message":"upstream process exited"}}`, string(msg.ID))
 			return s.WriteRaw([]byte(errResp))
-		}
-
-		// SessionHandler dispatch: structured path without pipe/remap/_meta
-		if o.sessionHandler != nil {
-			return o.dispatchToSessionHandler(s, msg)
 		}
 
 		// Track pending requests
@@ -947,6 +960,9 @@ func (o *Owner) sendProactiveInit() {
 
 // readUpstream reads responses from the upstream and routes them to the correct session.
 func (o *Owner) readUpstream() {
+	if o.upstream == nil {
+		return // SessionHandler-only mode — no upstream to read
+	}
 	defer func() {
 		o.upstreamDead.Store(true)
 		o.drainInflightRequests() // send error responses for all pending requests
@@ -1711,6 +1727,18 @@ var closedChan = func() chan struct{} {
 // non-deterministically return nil instead of the expected error/ErrDoNotRestart,
 // making restart/backoff policies unreliable.
 func (o *Owner) Serve(ctx context.Context) error {
+	// SessionHandler-only: no upstream process to monitor.
+	// Block until ctx is cancelled or Shutdown is called, then return cleanly.
+	if o.sessionHandler != nil && o.upstream == nil {
+		select {
+		case <-ctx.Done():
+			o.Shutdown()
+			return ctx.Err()
+		case <-o.done:
+			return nil
+		}
+	}
+
 	for {
 		// Snapshot the current dead/pending channel under a single lock read.
 		// If backgroundSpawnCh is non-nil, upstreamDeadCh returns it (blocking Serve
@@ -1970,6 +1998,10 @@ func (o *Owner) touchActivity() {
 // writeUpstream is the single choke point for sending a line to upstream
 // stdin. Wrapping upstream.WriteLine lets us touch activity on every
 // outbound message without scattering the call across 15+ sites.
+//
+// SessionHandler-only owners never call writeUpstream — requests dispatch
+// directly via dispatchToSessionHandler, and notification forwarding
+// returns early when o.upstream == nil.
 func (o *Owner) writeUpstream(data []byte) error {
 	o.touchActivity()
 	return o.upstream.WriteLine(data)

--- a/muxcore/owner/owner_test.go
+++ b/muxcore/owner/owner_test.go
@@ -1,0 +1,179 @@
+package owner
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	muxcore "github.com/thebtf/mcp-mux/muxcore"
+)
+
+// ---------------------------------------------------------------------------
+// T008: TestNewOwner_SessionHandlerOnly_NoUpstream
+// ---------------------------------------------------------------------------
+
+// TestNewOwner_SessionHandlerOnly_NoUpstream verifies that NewOwner succeeds
+// when only SessionHandler is set (no HandlerFunc, no Command), that the owner
+// is created without an upstream process, that a session can dispatch a request
+// to the handler, and that OnProjectConnect fires for lifecycle-aware handlers.
+func TestNewOwner_SessionHandlerOnly_NoUpstream(t *testing.T) {
+	ipcPath := testIPCPath(t)
+
+	// Use the mockLifecycleHandler from dispatch_test.go — it implements both
+	// SessionHandler and ProjectLifecycle (OnProjectConnect / OnProjectDisconnect).
+	handler := &mockLifecycleHandler{}
+
+	o, err := NewOwner(OwnerConfig{
+		IPCPath:        ipcPath,
+		SessionHandler: handler,
+		ServerID:       "test-session-handler-only",
+		Logger:         testLogger(t),
+	})
+	if err != nil {
+		t.Fatalf("NewOwner() with SessionHandler only must not error, got: %v", err)
+	}
+	defer o.Shutdown()
+
+	// Verify upstream is nil — we are in SessionHandler-only mode.
+	if o.upstream != nil {
+		t.Error("upstream must be nil in SessionHandler-only mode")
+	}
+
+	// Add a session and send an initialize request; the handler should receive it.
+	cwd := "/test-session-handler-only-project"
+	pr, pw := io.Pipe()
+	buf := &safeBuf{}
+	s := NewSession(pr, buf)
+	s.Cwd = cwd
+	o.AddSession(s)
+
+	// Send an initialize request into the session's reader.
+	initReq := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0.0"}}}` + "\n"
+	go func() {
+		pw.Write([]byte(initReq))
+		// Close so readSession exits after processing the single request.
+		time.Sleep(200 * time.Millisecond)
+		pw.Close()
+	}()
+
+	// Wait for the handler to receive the request.
+	ok := waitCondition(t, 2*time.Second, func() bool {
+		return len(handler.captured()) > 0
+	})
+	if !ok {
+		t.Fatal("SessionHandler.HandleRequest was not called within timeout")
+	}
+
+	captured := handler.captured()
+	if len(captured) < 1 {
+		t.Fatalf("expected at least 1 captured request, got 0")
+	}
+	req := captured[0]
+	if req.project.Cwd != cwd {
+		t.Errorf("handler got Cwd=%q, want %q", req.project.Cwd, cwd)
+	}
+	if !strings.Contains(string(req.request), "initialize") {
+		t.Errorf("handler did not receive initialize request; got: %s", req.request)
+	}
+
+	// Verify OnProjectConnect was called (handler implements ProjectLifecycle).
+	ok = waitCondition(t, 2*time.Second, func() bool {
+		return len(handler.capturedConnects()) > 0
+	})
+	if !ok {
+		t.Fatal("OnProjectConnect was not called within timeout")
+	}
+
+	wantID := muxcore.ProjectContextID(cwd)
+	connects := handler.capturedConnects()
+	if len(connects) == 0 || connects[0] != wantID {
+		t.Errorf("OnProjectConnect got IDs=%v, want first=%q", connects, wantID)
+	}
+
+	// Verify the session received a JSON-RPC response (mock handler returns result).
+	ok = waitCondition(t, 2*time.Second, func() bool {
+		return buf.String() != ""
+	})
+	if !ok {
+		t.Fatal("session did not receive a response within timeout")
+	}
+	resp := buf.String()
+	if !strings.Contains(resp, `"result"`) && !strings.Contains(resp, `"error"`) {
+		t.Errorf("session response is not a JSON-RPC response: %s", resp)
+	}
+
+	// Verify owner shuts down cleanly.
+	o.Shutdown()
+	select {
+	case <-o.Done():
+		// Expected
+	case <-time.After(2 * time.Second):
+		t.Error("owner did not shut down within timeout after Shutdown()")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// T009: TestServe_SessionHandlerOnly_BlocksUntilDone
+// ---------------------------------------------------------------------------
+
+// TestServe_SessionHandlerOnly_BlocksUntilDone verifies that Serve blocks
+// (does not return immediately) on a SessionHandler-only owner, returns nil
+// on Shutdown(), and completes quickly without stuck goroutines.
+func TestServe_SessionHandlerOnly_BlocksUntilDone(t *testing.T) {
+	ipcPath := testIPCPath(t)
+
+	handler := &mockSessionHandler{}
+
+	o, err := NewOwner(OwnerConfig{
+		IPCPath:        ipcPath,
+		SessionHandler: handler,
+		ServerID:       "test-serve-session-handler-only",
+		Logger:         testLogger(t),
+	})
+	if err != nil {
+		t.Fatalf("NewOwner() error: %v", err)
+	}
+	o.controlServer = nil // avoid control server in Shutdown()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- o.Serve(context.Background())
+	}()
+
+	// Verify Serve does NOT return immediately (it must block).
+	time.Sleep(100 * time.Millisecond)
+	select {
+	case err := <-errCh:
+		t.Fatalf("Serve returned immediately (should block): %v", err)
+	default:
+		// Correct: still blocking
+	}
+
+	start := time.Now()
+
+	// Call Shutdown — Serve should return nil (clean exit, no restart).
+	o.Shutdown()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Errorf("Serve returned %v after Shutdown, want nil", err)
+		}
+		elapsed := time.Since(start)
+		if elapsed > 200*time.Millisecond {
+			t.Errorf("Serve took %v to return after Shutdown — possible goroutine stuck", elapsed)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Serve did not return within 2s after Shutdown")
+	}
+
+	// Confirm done channel is closed (Shutdown was called).
+	select {
+	case <-o.Done():
+		// Expected
+	case <-time.After(500 * time.Millisecond):
+		t.Error("done channel not closed after Shutdown")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes `NewOwner` crash when only `SessionHandler` is configured (no `HandlerFunc`, no `Command`).

Previously, `NewOwner` unconditionally tried to spawn an upstream process when `HandlerFunc` was nil, causing `exec: no command` crash for SessionHandler-only consumers like engram.

## Changes

### owner.go
- **NewOwner**: Add `SessionHandler-only` branch — when `SessionHandler != nil && HandlerFunc == nil`, set `proc = nil` (no upstream needed)
- **handleDownstreamMessage**: Move `SessionHandler` dispatch BEFORE upstream nil check, so SessionHandler-only owners can serve requests
- **Serve()**: Add early-return path for SessionHandler-only (blocks on `done`/`ctx`, avoids upstream death-check loop)  
- **readUpstream()**: Add defensive nil guard at top
- **writeUpstream()**: Document SessionHandler path exclusion
- Guard `proc.Close()` and upstream exit monitor goroutine for nil proc

### owner_test.go (new)
- `TestNewOwner_SessionHandlerOnly_NoUpstream`: Creates owner with SessionHandler-only, verifies upstream==nil, dispatches request, verifies OnProjectConnect lifecycle
- `TestServe_SessionHandlerOnly_BlocksUntilDone`: Verifies Serve blocks without CPU spin, returns nil on Shutdown

## Upstream nil-safety audit

All 11 `o.upstream` usage sites in owner.go audited and verified nil-safe.

## Testing

- Both new tests pass
- Full `go test ./muxcore/...` passes (one pre-existing flaky test in mux_test.go unrelated to this change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Улучшения надежности и тестирования

* **Исправления ошибок**
  * Улучшена обработка ошибок при инициализации компонентов и создании соединений IPC.
  * Оптимизирована логика управления жизненным циклом приложения для повышения общей стабильности.
  * Усовершенствован контроль потока обработки входящих запросов и асинхронных операций.

* **Тесты**
  * Добавлены новые интеграционные тесты для проверки различных режимов работы системы.
  * Расширено тестовое покрытие критических путей выполнения и сценариев инициализации.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->