### PR TITLE
fix: full env passthrough — remove diffEnv

### DIFF
--- a/muxcore/daemon/daemon.go
+++ b/muxcore/daemon/daemon.go
@@ -492,14 +492,12 @@ func (d *Daemon) Spawn(req control.Request) (string, string, string, error) {
 
 	ipcPath := serverid.IPCPath(sid, "")
 
-	// Compute env diff: only vars that the shim has but daemon doesn't (CC-configured vars).
-	envDiff := diffEnv(req.Env)
-	if len(envDiff) > 0 {
-		keys := make([]string, 0, len(envDiff))
-		for k := range envDiff {
-			keys = append(keys, k)
-		}
-		d.logger.Printf("owner %s: env diff %d vars: %v", sid[:8], len(envDiff), keys)
+	// Pass full session env to the owner. No diff — the owner and upstream
+	// receive exactly the environment the CC session had. This prevents env
+	// leaks between sessions and ensures session-aware servers see all vars.
+	sessionEnv := req.Env
+	if len(sessionEnv) > 0 {
+		d.logger.Printf("owner %s: session env %d vars", sid[:8], len(sessionEnv))
 	}
 
 	// Build the shared owner config (used by both template and fresh paths).
@@ -507,7 +505,7 @@ func (d *Daemon) Spawn(req control.Request) (string, string, string, error) {
 	ownerCfg := owner.OwnerConfig{
 		Command:        req.Command,
 		Args:           req.Args,
-		Env:            envDiff,
+		Env:            sessionEnv,
 		Cwd:            req.Cwd,
 		IPCPath:        ipcPath,
 		ControlPath:    controlPath,
@@ -548,7 +546,7 @@ func (d *Daemon) Spawn(req control.Request) (string, string, string, error) {
 		tmpl.ServerID = sid
 		tmpl.Cwd = req.Cwd
 		tmpl.CwdSet = []string{req.Cwd}
-		tmpl.Env = envDiff
+		tmpl.Env = sessionEnv
 		tmpl.Mode = req.Mode
 
 		o, err = owner.NewOwnerFromSnapshot(ownerCfg, tmpl)
@@ -819,25 +817,6 @@ func envTransient(key string) bool {
 		return true
 	}
 	return false
-}
-
-// diffEnv returns only the env vars from shim that differ from daemon's own env.
-// This extracts CC-configured vars (API keys, config paths) without duplicating
-// the ~100 standard OS vars that daemon already has.
-func diffEnv(shimEnv map[string]string) map[string]string {
-	if len(shimEnv) == 0 {
-		return nil
-	}
-	diff := make(map[string]string)
-	for k, v := range shimEnv {
-		if daemonVal, ok := os.LookupEnv(k); !ok || daemonVal != v {
-			diff[k] = v
-		}
-	}
-	if len(diff) == 0 {
-		return nil
-	}
-	return diff
 }
 
 // Shutdown gracefully stops all owners and the daemon.

--- a/muxcore/upstream/process.go
+++ b/muxcore/upstream/process.go
@@ -46,13 +46,21 @@ func (p *Process) SetDrainTimeout(d time.Duration) {
 }
 
 // Start spawns an upstream process with the given command, args, environment, and working directory.
-// The env map is merged with the current process environment.
+// When env is non-empty, it is used as the complete process environment (converted from map to slice).
+// When env is nil/empty, the current process environment (os.Environ()) is used as fallback.
 // If cwd is non-empty, the child process runs in that directory.
 func Start(command string, args []string, env map[string]string, cwd string) (*Process, error) {
-	// Build merged environment: start from current process env, then overlay caller-supplied vars.
-	merged := os.Environ()
-	for k, v := range env {
-		merged = append(merged, fmt.Sprintf("%s=%s", k, v))
+	var merged []string
+	if len(env) > 0 {
+		// Full session env provided — use it directly, no os.Environ() merge.
+		merged = make([]string, 0, len(env))
+		for k, v := range env {
+			merged = append(merged, fmt.Sprintf("%s=%s", k, v))
+		}
+	} else {
+		// No session env (nil map) — fallback to daemon process env.
+		// This covers owners created without spawn request (tests, direct construction).
+		merged = os.Environ()
 	}
 
 	p := &Process{


### PR DESCRIPTION
## Problem

diffEnv computed only vars that differ between shim and daemon env. This caused:
1. Session-aware servers missing vars daemon already had (pr-review-mcp token)
2. Env leaks between sessions
3. Snapshot restore on different daemon loses vars

## Fix

Remove diffEnv. Store full session env everywhere:
- OwnerConfig.Env = full session env (was diff)
- upstream.Start uses session env directly (was os.Environ + diff overlay)
- Nil env = fallback to os.Environ (backward compat)

2 files, +21/-34 lines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Исправления**
  * Улучшена обработка переменных окружения при запуске дочерних процессов в демоне для надежной передачи полного набора конфигурационных параметров из сессии.
  * Оптимизирована логика инициализации переменных окружения: система теперь использует либо предоставленные переменные, либо переменные текущего процесса.
  * Упрощена логика обработки параметров окружения для повышения стабильности и предсказуемости работы приложения в различных сценариях.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->