### PR TITLE
refactor: extract hardcoded timeouts to named constants

### DIFF
--- a/muxcore/daemon/daemon.go
+++ b/muxcore/daemon/daemon.go
@@ -412,7 +412,7 @@ func (d *Daemon) Spawn(req control.Request) (string, string, string, error) {
 			d.mu.Unlock()
 			select {
 			case <-creating:
-			case <-time.After(30 * time.Second):
+			case <-time.After(concurrentCreateWaitTimeout):
 				d.logger.Printf("timeout waiting for placeholder %s, creating new", sid[:8])
 				return d.Spawn(req) // recursive — will create new placeholder
 			}
@@ -736,7 +736,7 @@ func (d *Daemon) findSharedOwner(command string, args []string, env map[string]s
 			d.mu.Unlock()
 			select {
 			case <-creating:
-			case <-time.After(30 * time.Second):
+			case <-time.After(concurrentCreateWaitTimeout):
 				d.mu.Lock()
 				return nil // timed out waiting for placeholder — caller will create new
 			}
@@ -933,6 +933,12 @@ func (d *Daemon) onUpstreamExit(serverID string) {
 // crashThreshold times within this window, further spawns are rejected.
 const crashWindow = 60 * time.Second
 const crashThreshold = 5
+
+// concurrentCreateWaitTimeout is the maximum time a Spawn / findSharedOwner
+// goroutine will wait for another goroutine that is currently creating the
+// same owner entry (i.e. holds the creating channel). Beyond this, the waiter
+// gives up and either returns nil (shared-owner lookup) or retries Spawn.
+const concurrentCreateWaitTimeout = 30 * time.Second
 
 // recordCrash adds a crash timestamp for the given command key.
 // Must be called with d.mu held.

--- a/muxcore/engine/engine.go
+++ b/muxcore/engine/engine.go
@@ -21,6 +21,27 @@ import (
 	"github.com/thebtf/mcp-mux/muxcore/serverid"
 )
 
+// Internal timing defaults for the engine. Kept as named constants (not inline
+// literals) so the rationale is discoverable and future tuning has a single
+// place to change.
+const (
+	// defaultReaperInterval is how often the daemon reaper scans for dead or
+	// idle owners. 10s balances responsiveness against scan cost.
+	defaultReaperInterval = 10 * time.Second
+
+	// daemonStartupTimeout is the maximum time startDaemon waits for the
+	// newly spawned daemon process to become reachable on its control socket.
+	daemonStartupTimeout = 10 * time.Second
+
+	// daemonPollInterval is how often startDaemon probes the control socket
+	// while waiting for the daemon to come up.
+	daemonPollInterval = 100 * time.Millisecond
+
+	// spawnRPCTimeout covers daemon processing + upstream process start +
+	// proactive MCP init handshake for the "spawn" control command.
+	spawnRPCTimeout = 30 * time.Second
+)
+
 // Handler is the MCP server implementation function.
 // When running in daemon mode, this is called with the upstream's stdin/stdout.
 // When running in proxy mode, this is called with the CC session's stdin/stdout.
@@ -73,6 +94,13 @@ type Config struct {
 
 	// Logger for debug output. Uses log.Default() if nil.
 	Logger *log.Logger
+
+	// SkipSnapshot disables daemon snapshot loading on startup.
+	// Zero value (false) means snapshots are enabled — the normal production
+	// behaviour used by aimux / engram / mcp-mux.
+	// Set to true for ephemeral daemons (tests, one-shot tools) that should
+	// not rehydrate state from prior runs.
+	SkipSnapshot bool
 }
 
 // MuxEngine manages the muxcore multiplexer lifecycle.
@@ -167,7 +195,7 @@ func (e *MuxEngine) runDaemon(ctx context.Context) error {
 		OwnerIdleTimeout: e.cfg.IdleTimeout,
 		IdleTimeout:      e.cfg.IdleTimeout,
 		Logger:           e.logger,
-		SkipSnapshot:     false,
+		SkipSnapshot:     e.cfg.SkipSnapshot,
 		HandlerFunc:      handlerFunc,
 		SessionHandler:   e.cfg.SessionHandler,
 	})
@@ -175,7 +203,7 @@ func (e *MuxEngine) runDaemon(ctx context.Context) error {
 		return fmt.Errorf("engine daemon: %w", err)
 	}
 
-	reaper := daemon.NewReaper(d, 10*time.Second)
+	reaper := daemon.NewReaper(d, defaultReaperInterval)
 
 	select {
 	case <-ctx.Done():
@@ -284,7 +312,8 @@ func (e *MuxEngine) runProxy(ctx context.Context) error {
 }
 
 // startDaemon re-execs the current binary with DaemonFlag as a detached background
-// process, then polls until the daemon control socket responds (up to 10 seconds).
+// process, then polls until the daemon control socket responds (up to
+// daemonStartupTimeout).
 func (e *MuxEngine) startDaemon() error {
 	exe, err := os.Executable()
 	if err != nil {
@@ -307,7 +336,7 @@ func (e *MuxEngine) startDaemon() error {
 	}
 
 	ctlPath := serverid.DaemonControlPath(e.cfg.BaseDir, e.cfg.Name)
-	return waitForDaemon(ctlPath, 10*time.Second)
+	return waitForDaemon(ctlPath, daemonStartupTimeout)
 }
 
 // isDaemonRunning checks whether the daemon control socket responds to ping.
@@ -322,7 +351,7 @@ func isDaemonRunning(ctlPath string) bool {
 // waitForDaemon polls until the daemon control socket responds (up to timeout).
 func waitForDaemon(ctlPath string, timeout time.Duration) error {
 	deadline := time.After(timeout)
-	ticker := time.NewTicker(100 * time.Millisecond)
+	ticker := time.NewTicker(daemonPollInterval)
 	defer ticker.Stop()
 
 	for {
@@ -340,7 +369,7 @@ func waitForDaemon(ctlPath string, timeout time.Duration) error {
 // spawnViaDaemon sends a spawn request to the daemon and returns the IPC path
 // and handshake token for the owner that will serve our server identity.
 func spawnViaDaemon(ctlPath, command string, args []string, cwd, mode string, env map[string]string, logger *log.Logger) (string, string, error) {
-	// 30s covers daemon processing + upstream process start + proactive init.
+	// spawnRPCTimeout covers daemon processing + upstream process start + proactive init.
 	resp, err := control.SendWithTimeout(ctlPath, control.Request{
 		Cmd:     "spawn",
 		Command: command,
@@ -348,7 +377,7 @@ func spawnViaDaemon(ctlPath, command string, args []string, cwd, mode string, en
 		Cwd:     cwd,
 		Mode:    mode,
 		Env:     env,
-	}, 30*time.Second)
+	}, spawnRPCTimeout)
 	if err != nil {
 		return "", "", fmt.Errorf("spawn via daemon: %w", err)
 	}


### PR DESCRIPTION
## Summary

Resolves the hardcode review question raised on `engine.go:170` (`SkipSnapshot: false`) plus all adjacent magic-literal timeouts found during the follow-up sweep.

## Changes

### `muxcore/engine/engine.go`
- **`engine.Config.SkipSnapshot bool`** — new field. Zero value (`false`) preserves the prior hardcoded default, so aimux/engram/mcp-mux see no behaviour change. Ephemeral daemons (tests, one-shot tools) can now opt out of snapshot rehydration without bypassing the engine API.
- **Package-level constants** with rationale doc comments:
  - `defaultReaperInterval = 10 * time.Second`
  - `daemonStartupTimeout  = 10 * time.Second`
  - `daemonPollInterval    = 100 * time.Millisecond`
  - `spawnRPCTimeout       = 30 * time.Second`

### `muxcore/daemon/daemon.go`
- **`concurrentCreateWaitTimeout = 30 * time.Second`** — named constant shared by `Spawn` and `findSharedOwner` (was two separate inline `time.After(30 * time.Second)` calls with duplicated intent).

## Rationale

`~/.claude/rules/common/coding-style.md` Code Quality Checklist:

> - [ ] No hardcoded values (use constants or config)

The engine was violating this on a user-visible API surface (`SkipSnapshot`) and on five internal magic numbers with no single source of truth. Future tuning / audits now have one place to change each value.

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test -count=1 ./engine/... ./daemon/...` — all green (engine 0.25s, daemon 11.4s)

## Risk

Zero behavioural change. All literal values preserved exactly; only lifted to named symbols. `SkipSnapshot` zero-value semantics match the removed hardcoded `false`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Обновления

* **Оптимизация**
  * Стандартизированы таймауты для управления ожиданием в фоновых процессах на уровне 30 секунд.
  * Добавлены новые константы временных интервалов для оптимизации запуска, опроса и обработки фоновых сервисов.

* **Новые параметры конфигурации**
  * Добавлена опция конфигурации для управления созданием снимков состояния.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->