### PR TITLE
fix(daemon): surface error instead of recursing on stuck placeholder

### DIFF
--- a/muxcore/daemon/daemon.go
+++ b/muxcore/daemon/daemon.go
@@ -413,8 +413,13 @@ func (d *Daemon) Spawn(req control.Request) (string, string, string, error) {
 			select {
 			case <-creating:
 			case <-time.After(concurrentCreateWaitTimeout):
-				d.logger.Printf("timeout waiting for placeholder %s, creating new", sid[:8])
-				return d.Spawn(req) // recursive — will create new placeholder
+				// Do NOT recurse into d.Spawn here: the stuck placeholder is
+				// still in d.owners[sid] and a recursive call would re-enter
+				// the same wait, producing a cascade of leaking goroutines.
+				// Surface the error so the shim can retry at a higher level;
+				// the circuit breaker (recordCrash) handles repeated failures.
+				d.logger.Printf("timeout waiting for placeholder %s (creator stuck)", sid[:8])
+				return "", "", "", fmt.Errorf("spawn %s: timeout waiting for concurrent creation of %s", req.Command, sid[:8])
 			}
 			d.mu.Lock()
 			// Re-check: creation may have succeeded or failed.
@@ -937,8 +942,16 @@ const crashThreshold = 5
 // concurrentCreateWaitTimeout is the maximum time a Spawn / findSharedOwner
 // goroutine will wait for another goroutine that is currently creating the
 // same owner entry (i.e. holds the creating channel). Beyond this, the waiter
-// gives up and either returns nil (shared-owner lookup) or retries Spawn.
-const concurrentCreateWaitTimeout = 30 * time.Second
+// returns a timeout error (in Spawn) or nil (in findSharedOwner).
+//
+// Note: Spawn does NOT recurse on timeout. The stuck placeholder is still in
+// d.owners[sid], so a recursive call would re-enter the same wait, producing a
+// cascade of leaked goroutines. Surfacing the error lets the shim retry at a
+// higher level and allows the circuit breaker to engage on repeated failures.
+//
+// Declared as var (not const) so tests can override it. Production code never
+// writes to it — treat it as an effective constant in all non-test paths.
+var concurrentCreateWaitTimeout = 30 * time.Second
 
 // recordCrash adds a crash timestamp for the given command key.
 // Must be called with d.mu held.

--- a/muxcore/daemon/daemon_test.go
+++ b/muxcore/daemon/daemon_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/thebtf/mcp-mux/muxcore/control"
 	"github.com/thebtf/mcp-mux/muxcore/ipc"
+	"github.com/thebtf/mcp-mux/muxcore/serverid"
 )
 
 func testLogger(t *testing.T) *log.Logger {
@@ -675,4 +676,90 @@ func TestCrashCircuitBreaker_WindowExpiry(t *testing.T) {
 	if looping {
 		t.Error("isCrashLooping = true for old crashes outside window")
 	}
+}
+
+// TestDaemonSpawnStuckPlaceholderReturnsError verifies that Spawn surfaces a
+// timeout error (rather than recursing and leaking goroutines) when a
+// placeholder for the same server is held by a stuck concurrent creator.
+//
+// Regression test for the daemon.go:417 issue flagged by Gemini in PR #51:
+// the previous behaviour was `return d.Spawn(req)` which re-entered the same
+// wait on the same unclosed `creating` channel, cascading goroutine leaks
+// until the shim-side RPC timeout fired. Post-fix behaviour: return an error,
+// let the shim retry at a higher level, let the circuit breaker engage on
+// repeat failures.
+func TestDaemonSpawnStuckPlaceholderReturnsError(t *testing.T) {
+	// Shorten the concurrent-create wait so the test runs in a reasonable
+	// time. Save and restore to avoid leaking state across tests.
+	orig := concurrentCreateWaitTimeout
+	concurrentCreateWaitTimeout = 200 * time.Millisecond
+	t.Cleanup(func() { concurrentCreateWaitTimeout = orig })
+
+	d := testDaemon(t)
+
+	req := control.Request{
+		Cmd:     "spawn",
+		Command: "go",
+		Args:    []string{"run", "../../testdata/mock_server.go"},
+		Cwd:     "",
+		Mode:    "global",
+	}
+
+	// Inject a stuck placeholder at the same sid the real Spawn would compute.
+	// We never close the `creating` channel, simulating a deadlocked creator.
+	stuckSID := serverid.GenerateContextKey(serverid.ModeGlobal, req.Command, req.Args, nil, req.Cwd)
+	stuck := &OwnerEntry{
+		ServerID: stuckSID,
+		Command:  req.Command,
+		Args:     req.Args,
+		Cwd:      req.Cwd,
+		creating: make(chan struct{}),
+	}
+	d.mu.Lock()
+	d.owners[stuckSID] = stuck
+	d.mu.Unlock()
+
+	// Before fix: recurses forever, test hangs / t.Fatal via -timeout.
+	// After fix:  returns a timeout error within ~200ms.
+	start := time.Now()
+	_, _, _, err := d.Spawn(req)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("Spawn() on stuck placeholder returned nil error, want timeout error")
+	}
+	if !strings.Contains(err.Error(), "timeout waiting for concurrent creation") {
+		t.Errorf("Spawn() error = %q, want it to mention 'timeout waiting for concurrent creation'", err.Error())
+	}
+	// Sanity: should return close to the (shortened) timeout, not 2×/3× it
+	// which would indicate recursive re-entry into the wait.
+	if elapsed > 2*concurrentCreateWaitTimeout {
+		t.Errorf("Spawn() took %v, want close to %v — suggests recursive wait", elapsed, concurrentCreateWaitTimeout)
+	}
+
+	// The stuck placeholder entry must still be present in the map under the
+	// same sid (OwnerCount skips Owner==nil placeholders, so we inspect the
+	// map directly). The daemon must NOT have created a sibling owner for
+	// the same sid, and MUST NOT have removed the placeholder we injected.
+	d.mu.RLock()
+	entry, stillPresent := d.owners[stuckSID]
+	entryCount := len(d.owners)
+	d.mu.RUnlock()
+	if !stillPresent {
+		t.Error("stuck placeholder was removed from d.owners — fix must leave it in place for the original creator to clean up")
+	} else if entry != stuck {
+		t.Error("entry at stuckSID was replaced — fix must not overwrite the placeholder")
+	}
+	if entryCount != 1 {
+		t.Errorf("len(d.owners) = %d after stuck-placeholder timeout, want 1", entryCount)
+	}
+
+	// Clean up the stuck placeholder so t.Cleanup -> Shutdown doesn't wait on it.
+	d.mu.Lock()
+	if stuck.creating != nil {
+		close(stuck.creating)
+		stuck.creating = nil
+	}
+	delete(d.owners, stuckSID)
+	d.mu.Unlock()
 }


### PR DESCRIPTION
## Summary

Fixes a pre-existing bug in `daemon.Spawn` flagged by Gemini during PR #51 review. Closes the follow-up noted in `CONTINUITY.md` under "Known Follow-ups".

## The bug

When two goroutines race to spawn the same owner:

1. **A** enters `Spawn`, reserves `d.owners[sid]` with a placeholder holding the `creating` channel (line 490).
2. **B** enters `Spawn`, finds the entry, waits on `creating` with a 30s timeout (line 413).
3. 30 s passes. **A** is still blocked (slow upstream init, deadlock, whatever).
4. **B** executes `return d.Spawn(req)` (was line 417). The recursive call goes through the full prelude, hits line 408, finds **the same** placeholder still in the map, and re-enters **the same** wait on **the same** unclosed channel.
5. Another 30 s, another recursion, another stuck waiter — until **A** finally finishes (if ever).

**Impact:**
- Daemon-side goroutine leak: each recursion adds a frame that waits 30 s in `select`, producing a stack of zombie waiters for every deadlocked creator.
- Shim-side cascade: the shim's `spawnRPCTimeout = 30 s` fires long before the daemon recovers, so the shim retries → new request → new recursing waiter. Goroutines grow quadratically under load.
- The comment `"recursive — will create new placeholder"` is a lie: the placeholder is never removed, so no new placeholder is created.

## The fix

Return a timeout error instead of recursing:

```go
case <-time.After(concurrentCreateWaitTimeout):
    d.logger.Printf("timeout waiting for placeholder %s (creator stuck)", sid[:8])
    return "", "", "", fmt.Errorf("spawn %s: timeout waiting for concurrent creation of %s", req.Command, sid[:8])
```

Rationale:
- A 30 s wait on a concurrent creator is a **signal**, not a slow-path. Normal owner creation (including subprocess spawn + MCP init handshake) takes <1 s. 30 s means something is genuinely stuck.
- The waiter must **not** mutate the map: the original creator is still running and will eventually close its own `creating` channel and promote (or clean up) its placeholder. Racing it from a waiter path would leak supervisor registrations and orphan owners.
- The shim has built-in retry. A single timeout error is recoverable. The circuit breaker (`recordCrash`) engages on repeated failures.
- Zero behaviour change on the happy path or on the `case <-creating:` branch that already handles post-creation recovery (line 430 — that recursion is safe because the channel is closed and subsequent `Spawn` calls either find a valid owner or create a new one from a removed placeholder).

## Tests

New regression test: `TestDaemonSpawnStuckPlaceholderReturnsError`

- Injects a placeholder with a `creating` channel that is **never closed**
- Shortens `concurrentCreateWaitTimeout` to 200 ms via a test-local save/restore
- Asserts:
  - `Spawn` returns an error containing `"timeout waiting for concurrent creation"`
  - Elapsed time `< 2×` the timeout (proves no recursive re-entry into the wait)
  - The injected placeholder remains in `d.owners[sid]` untouched (proves the waiter does not mutate state the creator still owns)

Supporting change: `concurrentCreateWaitTimeout` converted from `const` to `var` so the test can override it. Documented as an effective constant outside the test path.

## Verification

```
go build ./...                              # clean
go vet ./...                                # clean
go test -count=1 ./engine/... ./daemon/...  # all green (engine 0.24s, daemon 11.56s)
go test -run TestDaemonSpawnStuckPlaceholder ./daemon/...  # passes in 250ms
```

## Risk

- Shim behaviour change: callers that previously experienced unbounded recursion now receive a clean error. This is strictly an improvement — before the fix, the caller's RPC was going to time out anyway (`spawnRPCTimeout = 30 s`), and it retried blindly. Now it retries on a surfaced error, which is identical at the shim-contract level.
- No changes to the happy path, template spawn, or the `case <-creating:` success branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **Исправления ошибок**
  * Улучшена обработка ошибок при истечении времени ожидания создания заполнителя; система теперь возвращает ошибку вместо повторного входа в процесс, предотвращая каскадное создание потоков.

* **Тесты**
  * Добавлен тест регрессии для проверки корректного обработки залипающего процесса создания плейсхолдера.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->