### PR TITLE
docs: bump AGENTS.md to muxcore v0.19.2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,15 +57,19 @@ CC 4 ──stdio──> mcp-mux ──IPC──┘
 | **Reasoning first** | Document WHY before implementing |
 | **Spec compliance** | MCP protocol spec is authoritative — verify all protocol behavior against it |
 
-## muxcore Library API (v0.19.1)
+## muxcore Library API (v0.19.2)
 
 ### Upgrade
 
 ```bash
-go get github.com/thebtf/mcp-mux/muxcore@v0.19.1
+go get github.com/thebtf/mcp-mux/muxcore@v0.19.2
 ```
 
-v0.19.1 is a refactor-only release on top of v0.19.0 — zero behaviour change.
+v0.19.2 is a bug fix release on top of v0.19.1 — fixes a recursive goroutine
+leak in `daemon.Spawn` when a concurrent placeholder wait times out. No API
+changes, zero consumer code modifications required.
+
+v0.19.1 was a refactor-only release on top of v0.19.0 — zero behaviour change.
 Adds `engine.Config.SkipSnapshot` as an opt-in field (zero-value preserves the
 prior hardcoded default). All v0.19.0 migration notes below still apply.
 


### PR DESCRIPTION
Mechanical docs bump following release of muxcore/v0.19.2. Updates the muxcore Library API header and upgrade snippet from v0.19.1 to v0.19.2, and adds a one-paragraph summary of the v0.19.1 → v0.19.2 delta (recursive Spawn timeout fix).

No code changes. Following the 'Never push directly to main' rule this time instead of the direct-to-master doc bump pattern I used for c65e8a0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Исправления ошибок**
  * Исправлена утечка ресурсов, возникающая при обработке истечения времени ожидания в многопоточной среде.

* **Документация**
  * Обновлена документация для версии v0.19.2. API остался без изменений.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->