### PR TITLE
fix(owner): concurrency bundle — CPU spin, lock release, JSON escape (FR-1,2,3)

### DIFF
--- a/muxcore/owner/dispatch_test.go
+++ b/muxcore/owner/dispatch_test.go
@@ -755,3 +755,45 @@ func TestNotifier_Broadcast(t *testing.T) {
 		t.Errorf("sessB did not receive broadcast; got: %s", lineB)
 	}
 }
+
+// TestNotifier_MultiSessionSameProject verifies that Notify delivers the
+// notification to ALL sessions sharing the same CWD (Shared mode: two CC
+// terminals in the same project directory). Previously the implementation
+// stopped at the first matching session (random Go map iteration order), so
+// one of the two sessions would silently miss the notification.
+//
+// Regression test for the Gemini reviewer finding on PR #54.
+func TestNotifier_MultiSessionSameProject(t *testing.T) {
+	sharedCwd := "/project-shared"
+
+	mock := &mockLifecycleHandler{}
+	o := newLifecycleOwner(mock)
+
+	// Two sessions with identical Cwd — simulates Shared mode with two CC terminals.
+	sessA, bufA := newTestSession(sharedCwd)
+	defer sessA.Close()
+	sessB, bufB := newTestSession(sharedCwd)
+	defer sessB.Close()
+
+	addSessionDirect(o, sessA)
+	addSessionDirect(o, sessB)
+
+	notification := []byte(`{"jsonrpc":"2.0","method":"notifications/tools/list_changed"}`)
+	projectID := muxcore.ProjectContextID(sharedCwd)
+
+	n := &ownerNotifier{owner: o}
+	if err := n.Notify(projectID, notification); err != nil {
+		t.Fatalf("Notify returned unexpected error: %v", err)
+	}
+
+	// Both sessions must receive the notification — previously only one would.
+	lineA := waitForWrite(t, bufA, 2*time.Second)
+	if !strings.Contains(lineA, "notifications/tools/list_changed") {
+		t.Errorf("sessA did not receive notification; got: %q", lineA)
+	}
+
+	lineB := waitForWrite(t, bufB, 2*time.Second)
+	if !strings.Contains(lineB, "notifications/tools/list_changed") {
+		t.Errorf("sessB did not receive notification; got: %q", lineB)
+	}
+}

--- a/muxcore/owner/dispatch_test.go
+++ b/muxcore/owner/dispatch_test.go
@@ -2,6 +2,7 @@ package owner
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log"
@@ -371,6 +372,163 @@ func TestDispatchToSessionHandler_Timeout(t *testing.T) {
 	case <-handlerDone:
 	case <-time.After(2 * time.Second):
 		t.Error("handler goroutine did not exit after context cancellation")
+	}
+}
+
+// blockingWriter is a test io.Writer whose Write blocks until Unblock() is
+// called. Used to simulate a slow IPC consumer for FR-2 lock-release test.
+type blockingWriter struct {
+	unblock chan struct{}
+}
+
+func newBlockingWriter() *blockingWriter {
+	return &blockingWriter{unblock: make(chan struct{})}
+}
+
+func (b *blockingWriter) Write(p []byte) (int, error) {
+	<-b.unblock
+	return len(p), nil
+}
+
+func (b *blockingWriter) Unblock() {
+	close(b.unblock)
+}
+
+// TestOwnerNotifier_NotifyReleasesLockBeforeWrite verifies that ownerNotifier.Notify
+// releases o.mu.RLock() before calling s.WriteRaw, so a slow IPC consumer cannot
+// stall every other goroutine needing o.mu.Lock().
+//
+// Regression test for FR-2 / bug-hunter BUG-002: previously Notify held RLock
+// across the full WriteRaw call. A 30s-write-deadline session could stall
+// addSession, removeSession, cacheResponse, and every other o.mu.Lock() caller
+// for the duration of the write. Broadcast (sibling) had the correct pattern
+// of copy-under-lock, release, write. Notify now mirrors that pattern.
+//
+// The test installs a session whose writer blocks indefinitely, calls Notify in
+// one goroutine, then measures how long addSession takes in another goroutine.
+// Pre-fix: addSession would block until the writer unblocks.
+// Post-fix: addSession completes in well under 100ms regardless of the blocker.
+func TestOwnerNotifier_NotifyReleasesLockBeforeWrite(t *testing.T) {
+	o := newDispatchOwner(nil)
+	notifier := &ownerNotifier{owner: o}
+
+	// Session A: writer blocks until the test unblocks it.
+	blocker := newBlockingWriter()
+	sessA := NewSession(strings.NewReader(""), blocker)
+	sessA.Cwd = "/project-slow-writer"
+	defer sessA.Close()
+
+	o.mu.Lock()
+	o.sessions[sessA.ID] = sessA
+	o.mu.Unlock()
+
+	// Call Notify in a goroutine — it will block inside WriteRaw.
+	notifyDone := make(chan struct{})
+	go func() {
+		defer close(notifyDone)
+		_ = notifier.Notify(muxcore.ProjectContextID(sessA.Cwd), []byte(`{"jsonrpc":"2.0","method":"notifications/test"}`))
+	}()
+
+	// Give Notify a moment to enter WriteRaw (so it holds session.mu and would
+	// previously still be holding o.mu.RLock in the buggy code path).
+	time.Sleep(50 * time.Millisecond)
+
+	// Concurrently call AddSession — it needs o.mu.Lock().
+	// Pre-fix: blocks until Unblock() is called.
+	// Post-fix: completes immediately.
+	newSess := NewSession(strings.NewReader(""), &safeBuf{})
+	newSess.Cwd = "/project-new"
+
+	addStart := time.Now()
+	o.AddSession(newSess)
+	addElapsed := time.Since(addStart)
+
+	// Allow a generous upper bound to account for goroutine scheduling on CI,
+	// but still well below the buggy-path elapsed time (which would be "forever"
+	// since blocker.unblock is never closed until test cleanup).
+	const maxAllowed = 200 * time.Millisecond
+	if addElapsed > maxAllowed {
+		t.Errorf("AddSession took %v while Notify was blocked; want <%v — the Notify path is still holding o.mu while WriteRaw blocks",
+			addElapsed, maxAllowed)
+	}
+
+	// Cleanup: unblock the writer so the Notify goroutine can exit.
+	blocker.Unblock()
+	select {
+	case <-notifyDone:
+	case <-time.After(1 * time.Second):
+		t.Error("Notify goroutine did not exit after Unblock")
+	}
+}
+
+// TestDispatchToSessionHandler_ErrorMessageIsValidJSON verifies that error
+// messages from HandleRequest are properly JSON-escaped in the response.
+// Regression test for FR-3 / code-reviewer H1: previously, owner.go:896
+// interpolated err.Error() as a bare %s into a raw JSON literal, so any
+// error message containing a quote, backslash, newline, tab, null byte, or
+// Windows path would produce invalid JSON that the CC client could not parse.
+// Post-fix, all error messages round-trip through json.Marshal/Unmarshal.
+func TestDispatchToSessionHandler_ErrorMessageIsValidJSON(t *testing.T) {
+	cases := []struct {
+		name   string
+		errMsg string
+	}{
+		{"plain", "something went wrong"},
+		{"double_quote", `error: expected "token" got eof`},
+		{"backslash", `path: C:\Users\btf\project`},
+		{"newline", "line one\nline two"},
+		{"tab", "col1\tcol2"},
+		{"null_byte", "before\u0000after"},
+		{"windows_path", `cannot open C:\Program Files\Node\npm.cmd: access denied`},
+		{"mixed", "quote:\" backslash:\\ newline:\n all-together"},
+		{"unicode", "привет мир ☃"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			errMsg := tc.errMsg
+			mock := &mockSessionHandler{
+				handler: func(_ context.Context, _ muxcore.ProjectContext, _ []byte) ([]byte, error) {
+					return nil, fmt.Errorf("%s", errMsg)
+				},
+			}
+			o := newDispatchOwner(mock)
+
+			sess, buf := newTestSession("/project-json-escape")
+			defer sess.Close()
+
+			rawReq := []byte(`{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{}}`)
+			msg := parseMessage(rawReq)
+
+			if err := o.dispatchToSessionHandler(sess, msg); err != nil {
+				t.Fatalf("dispatchToSessionHandler: %v", err)
+			}
+
+			line := waitForWrite(t, buf, 2*time.Second)
+
+			// Round-trip: the response must be valid JSON and the error.message
+			// field must match the original string exactly.
+			var resp struct {
+				JSONRPC string `json:"jsonrpc"`
+				ID      any    `json:"id"`
+				Error   struct {
+					Code    int    `json:"code"`
+					Message string `json:"message"`
+				} `json:"error"`
+			}
+			if err := json.Unmarshal([]byte(line), &resp); err != nil {
+				t.Fatalf("response is not valid JSON: %v\nraw: %q", err, line)
+			}
+			if resp.JSONRPC != "2.0" {
+				t.Errorf("jsonrpc = %q, want %q", resp.JSONRPC, "2.0")
+			}
+			if resp.Error.Code != -32603 {
+				t.Errorf("error.code = %d, want -32603", resp.Error.Code)
+			}
+			if resp.Error.Message != errMsg {
+				t.Errorf("error.message = %q, want %q", resp.Error.Message, errMsg)
+			}
+		})
 	}
 }
 

--- a/muxcore/owner/owner.go
+++ b/muxcore/owner/owner.go
@@ -861,8 +861,9 @@ func (o *Owner) dispatchToSessionHandler(s *Session, msg *jsonrpc.Message) error
 		defer func() {
 			if r := recover(); r != nil {
 				o.logger.Printf("session %d: HandleRequest panic: %v", s.ID, r)
-				errResp := fmt.Sprintf(`{"jsonrpc":"2.0","id":%s,"error":{"code":-32603,"message":"internal error: handler panic"}}`, string(msg.ID))
-				s.WriteRaw([]byte(errResp))
+				if errResp, marshalErr := buildJSONRPCErrorBytes(msg.ID, -32603, "internal error: handler panic"); marshalErr == nil {
+					s.WriteRaw(errResp)
+				}
 			}
 		}()
 
@@ -889,11 +890,20 @@ func (o *Owner) dispatchToSessionHandler(s *Session, msg *jsonrpc.Message) error
 
 		resp, err := o.sessionHandler.HandleRequest(ctx, project, msg.Raw)
 		if err != nil {
+			// Route through buildJSONRPCErrorBytes so error messages with JSON-special
+			// characters (quotes, backslashes, newlines, Windows paths, control bytes)
+			// are properly escaped and produce valid JSON for the CC client.
+			var errMsg string
 			if ctx.Err() != nil {
-				// Context cancelled (timeout or disconnect)
-				resp = []byte(fmt.Sprintf(`{"jsonrpc":"2.0","id":%s,"error":{"code":-32603,"message":"request timeout"}}`, string(msg.ID)))
+				errMsg = "request timeout"
 			} else {
-				resp = []byte(fmt.Sprintf(`{"jsonrpc":"2.0","id":%s,"error":{"code":-32603,"message":"%s"}}`, string(msg.ID), err.Error()))
+				errMsg = err.Error()
+			}
+			if errBytes, marshalErr := buildJSONRPCErrorBytes(msg.ID, -32603, errMsg); marshalErr == nil {
+				resp = errBytes
+			} else {
+				o.logger.Printf("session %d: failed to marshal error response: %v", s.ID, marshalErr)
+				resp = nil
 			}
 		}
 
@@ -1211,6 +1221,22 @@ func (o *Owner) respondToElicitationCancel(id json.RawMessage) error {
 
 // respondWithError sends a JSON-RPC error response to upstream.
 func (o *Owner) respondWithError(id json.RawMessage, code int, message string) error {
+	data, err := buildJSONRPCErrorBytes(id, code, message)
+	if err != nil {
+		return fmt.Errorf("marshal error response: %w", err)
+	}
+	return o.writeUpstream(data)
+}
+
+// buildJSONRPCErrorBytes constructs a JSON-RPC 2.0 error response as bytes.
+// Uses json.Marshal on a struct to guarantee valid escaping for any message
+// content — plain strings, quotes, backslashes, newlines, Windows paths,
+// and control characters all round-trip correctly.
+//
+// Callers that need the response bytes (e.g., to send to a downstream session
+// rather than upstream) use this directly; callers that want the full
+// write-to-upstream side effect use respondWithError instead.
+func buildJSONRPCErrorBytes(id json.RawMessage, code int, message string) ([]byte, error) {
 	resp := struct {
 		JSONRPC string          `json:"jsonrpc"`
 		ID      json.RawMessage `json:"id"`
@@ -1221,11 +1247,7 @@ func (o *Owner) respondWithError(id json.RawMessage, code int, message string) e
 	}{JSONRPC: "2.0", ID: id}
 	resp.Error.Code = code
 	resp.Error.Message = message
-	data, err := json.Marshal(resp)
-	if err != nil {
-		return fmt.Errorf("marshal error response: %w", err)
-	}
-	return o.writeUpstream(data)
+	return json.Marshal(resp)
 }
 
 // routeProgressNotification sends a notifications/progress to the session that
@@ -1393,14 +1415,24 @@ type ownerNotifier struct {
 }
 
 func (n *ownerNotifier) Notify(projectID string, notification []byte) error {
+	// Copy the target pointer under RLock, then release before WriteRaw —
+	// s.WriteRaw may block up to 30 s on a slow IPC consumer (session write
+	// deadline). Holding o.mu.RLock() during that wait stalls every goroutine
+	// needing o.mu.Lock() (addSession, removeSession, cacheResponse, progress
+	// token cleanup). This pattern mirrors Broadcast below.
 	n.owner.mu.RLock()
-	defer n.owner.mu.RUnlock()
+	var target *Session
 	for _, s := range n.owner.sessions {
 		if muxcore.ProjectContextID(s.Cwd) == projectID {
-			return s.WriteRaw(notification)
+			target = s
+			break
 		}
 	}
-	return fmt.Errorf("no session found for project %s", projectID)
+	n.owner.mu.RUnlock()
+	if target == nil {
+		return fmt.Errorf("no session found for project %s", projectID)
+	}
+	return target.WriteRaw(notification)
 }
 
 func (n *ownerNotifier) Broadcast(notification []byte) {
@@ -1801,10 +1833,26 @@ func (o *Owner) Serve(ctx context.Context) error {
 // upstreamDeathResult determines the Serve return value when upstream has died.
 // Checks classification: isolated owners return ErrDoNotRestart (no auto-restart),
 // others return an error to trigger supervisor backoff+restart.
+//
+// Special case (BUG-001 / FR-1): if the owner has NEVER had a live upstream
+// (up == nil and no background spawn pending), the "death" signal came from
+// closedChan — meaning background spawn failed before upstream was ever set.
+// Returning an error here would cause suture to restart Serve, which would
+// immediately re-observe the same nil state and return the same error — a
+// tight CPU spin bounded only by FailureThreshold. Return ErrDoNotRestart
+// for this case so the supervisor stops cycling. The owner is effectively
+// broken and will be cleaned up by the reaper on the next sweep.
 func (o *Owner) upstreamDeathResult() error {
 	o.mu.RLock()
 	mode := o.autoClassification
+	hasUpstream := o.upstream != nil
+	hasPendingSpawn := o.backgroundSpawnCh != nil
 	o.mu.RUnlock()
+	if !hasUpstream && !hasPendingSpawn {
+		// Owner never had a live upstream (failed background spawn, or no
+		// spawn ever attempted). No restart — otherwise suture spins.
+		return suture.ErrDoNotRestart
+	}
 	if mode == classify.ModeIsolated {
 		// Isolated servers should not be restarted by the supervisor.
 		// Each CC session spawns its own dedicated isolated owner.

--- a/muxcore/owner/owner.go
+++ b/muxcore/owner/owner.go
@@ -1415,24 +1415,33 @@ type ownerNotifier struct {
 }
 
 func (n *ownerNotifier) Notify(projectID string, notification []byte) error {
-	// Copy the target pointer under RLock, then release before WriteRaw —
-	// s.WriteRaw may block up to 30 s on a slow IPC consumer (session write
-	// deadline). Holding o.mu.RLock() during that wait stalls every goroutine
-	// needing o.mu.Lock() (addSession, removeSession, cacheResponse, progress
-	// token cleanup). This pattern mirrors Broadcast below.
+	// Collect ALL sessions matching projectID under RLock, then release before
+	// WriteRaw — s.WriteRaw may block up to 30 s on a slow IPC consumer (session
+	// write deadline). Holding o.mu.RLock() during that wait stalls every goroutine
+	// needing o.mu.Lock() (addSession, removeSession, cacheResponse, progress token
+	// cleanup). This pattern mirrors Broadcast below.
+	//
+	// In Shared mode multiple CC sessions can share the same Cwd (same project),
+	// so we must notify ALL of them, not just the first one found (which would be
+	// random due to Go map iteration order).
 	n.owner.mu.RLock()
-	var target *Session
+	var targets []*Session
 	for _, s := range n.owner.sessions {
 		if muxcore.ProjectContextID(s.Cwd) == projectID {
-			target = s
-			break
+			targets = append(targets, s)
 		}
 	}
 	n.owner.mu.RUnlock()
-	if target == nil {
+	if len(targets) == 0 {
 		return fmt.Errorf("no session found for project %s", projectID)
 	}
-	return target.WriteRaw(notification)
+	var lastErr error
+	for _, s := range targets {
+		if err := s.WriteRaw(notification); err != nil {
+			lastErr = err
+		}
+	}
+	return lastErr
 }
 
 func (n *ownerNotifier) Broadcast(notification []byte) {

--- a/muxcore/owner/owner_serve_test.go
+++ b/muxcore/owner/owner_serve_test.go
@@ -129,21 +129,73 @@ func TestOwnerServe_IsolatedReturnsErrDoNotRestart(t *testing.T) {
 	}
 }
 
-// TestOwnerServe_NonIsolatedReturnsErrorOnUpstreamDead verifies that a
-// non-isolated owner with a nil (dead) upstream returns a non-nil error
-// to trigger supervisor restart with backoff.
-func TestOwnerServe_NonIsolatedReturnsErrorOnUpstreamDead(t *testing.T) {
+// TestOwnerServe_NonIsolatedNilUpstreamReturnsDoNotRestart verifies the FR-1
+// fix: a non-isolated owner that has NEVER had a live upstream (upstream == nil
+// AND backgroundSpawnCh == nil) returns suture.ErrDoNotRestart, NOT a
+// restartable error.
+//
+// Pre-fix: this returned a non-nil error, which caused suture to restart Serve
+// immediately. The new Serve iteration re-observed the same nil state and
+// returned the same error — a tight loop bounded only by suture's
+// FailureThreshold. This was BUG-001 from the 2026-04-15 audit.
+//
+// Post-fix: upstreamDeathResult checks for the "never had upstream" case and
+// returns ErrDoNotRestart so suture removes the owner cleanly without cycling.
+//
+// This is semantically the same as the isolated-owner case — an owner with no
+// realistic path to recovery should not be restarted.
+func TestOwnerServe_NonIsolatedNilUpstreamReturnsDoNotRestart(t *testing.T) {
 	o := newMinimalOwner()
 	o.controlServer = nil
 	o.autoClassification = classify.ModeShared
 	o.classificationSource = "tools"
 
 	err := o.Serve(context.Background())
-	if err == nil {
-		t.Error("Serve returned nil, want non-nil error for dead upstream")
+	if !errors.Is(err, suture.ErrDoNotRestart) {
+		t.Errorf("Serve with nil upstream returned %v, want suture.ErrDoNotRestart (FR-1 fix: cold owner should not restart)", err)
 	}
-	if errors.Is(err, suture.ErrDoNotRestart) {
-		t.Error("Serve returned ErrDoNotRestart for non-isolated owner")
+}
+
+// TestOwnerServe_FailedBackgroundSpawnDoesNotSpin is the direct FR-1 regression
+// test: simulates SpawnUpstreamBackground's failure path (bgCh closed then
+// cleared, upstream still nil) and asserts Serve exits exactly once with
+// ErrDoNotRestart rather than spinning on suture restarts.
+//
+// Setup mirrors what SpawnUpstreamBackground does on error:
+//  1. bgCh was created at NewOwnerFromSnapshot
+//  2. goroutine tried upstream.Start, it failed
+//  3. goroutine closed bgCh and set bgCh = nil
+//  4. upstream remains nil
+//
+// Pre-fix Serve behavior:
+//  - iter 1: deadCh = bgCh (non-nil at entry, since we test right after close)
+//            Actually, bgCh is ALREADY nil in our setup because we mimic the
+//            post-close-and-clear state. deadCh = closedChan.
+//            Non-blocking select hits deadCh → returns upstreamDeathResult()
+//            → for non-isolated: non-nil error → suture restarts → loop
+//  - iter N (inside suture restart): same state, same error, tight loop
+//
+// Post-fix: upstreamDeathResult returns ErrDoNotRestart → suture removes.
+func TestOwnerServe_FailedBackgroundSpawnDoesNotSpin(t *testing.T) {
+	o := newMinimalOwner()
+	o.controlServer = nil
+	o.autoClassification = classify.ModeShared
+	o.classificationSource = "tools"
+	// Simulate post-failed-spawn state: bgCh was allocated, goroutine closed
+	// it and set it to nil, upstream never got set.
+	o.backgroundSpawnCh = nil
+	o.upstream = nil
+
+	start := time.Now()
+	err := o.Serve(context.Background())
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, suture.ErrDoNotRestart) {
+		t.Errorf("Serve after failed background spawn returned %v, want suture.ErrDoNotRestart", err)
+	}
+	// Serve should return immediately — no retry loop, no CPU spin.
+	if elapsed > 100*time.Millisecond {
+		t.Errorf("Serve took %v to return; expected near-instant exit (FR-1: no spin on failed spawn)", elapsed)
 	}
 }
 


### PR DESCRIPTION
## Summary

v0.19.3 blocker bundle: 3 P1 findings from the 2026-04-15 production readiness audit, all in `muxcore/owner/owner.go`. Each fix has a regression test. Full spec at `.agent/specs/post-audit-remediation/spec.md` FR-1, FR-2, FR-3.

## FR-1 — CPU spin on failed background spawn (BUG-001)

**Problem:** `Owner.Serve` returned a restartable error whenever `upstream == nil`, including the case where `SpawnUpstreamBackground` failed before ever setting upstream. Suture restarted `Serve`, which re-observed the same nil state and returned the same error — a tight loop bounded only by `FailureThreshold`. The priority-check pattern from the #46 fix did not engage because `o.done` was not closed.

**Fix:** `upstreamDeathResult` now detects the "never had upstream" state (`upstream == nil && backgroundSpawnCh == nil`) and returns `suture.ErrDoNotRestart`. Suture removes the owner cleanly, no restart cycle. Same semantics as isolated-owner death.

**Regression test:**
- `TestOwnerServe_FailedBackgroundSpawnDoesNotSpin` — simulates post-failed-spawn state, asserts Serve exits in under 100 ms with `ErrDoNotRestart`.
- `TestOwnerServe_NonIsolatedNilUpstreamReturnsDoNotRestart` — updates the old test that codified the bug (expected "returns error") to the new correct behaviour.

## FR-2 — Notify holds owner lock across 30 s WriteRaw (BUG-002)

**Problem:** `ownerNotifier.Notify` held `n.owner.mu.RLock()` across the full `s.WriteRaw(notification)` call. `WriteRaw` can block up to 30 s on a slow IPC consumer (session write deadline). During that window every goroutine needing `o.mu.Lock()` (addSession, removeSession, cacheResponse, progress token cleanup) was stalled.

**Fix:** Copy the target session pointer under `RLock`, release the lock, then call `WriteRaw` on the local copy. Mirrors the pattern already used by the sibling `Broadcast`.

**Regression test:**
- `TestOwnerNotifier_NotifyReleasesLockBeforeWrite` — installs a session with an infinite-blocking writer, calls `Notify` in a goroutine, then measures `AddSession` elapsed. Post-fix <200 ms; pre-fix would block until the writer was unblocked.

## FR-3 — JSON escape in dispatchToSessionHandler error response (H1)

**Problem:** `dispatchToSessionHandler` built error JSON via `fmt.Sprintf` with the error message interpolated as a bare `%s` into a raw JSON string literal. Any error message containing a double quote, backslash, newline, tab, null byte, or Windows path produced invalid JSON that the CC client could not parse — dropping the connection.

**Regression from Phase 4 SessionHandler API** (PR #47, v0.18.0) — did not exist at the 2026-03-27 READY audit.

**Fix:** New helper `buildJSONRPCErrorBytes` uses `json.Marshal` on a typed struct so all JSON-special characters are properly escaped. All three error response sites in `dispatchToSessionHandler` (timeout, handler error, panic recovery) route through it. The existing `respondWithError` is refactored to use the same helper so there is a single source of truth.

**Regression test:**
- `TestDispatchToSessionHandler_ErrorMessageIsValidJSON` — 9 table-driven cases: plain, `"double quote"`, `backslash`, `newline`, `tab`, `null byte`, `C:\Windows\path`, `mixed`, `unicode`. Every case round-trips through `json.Marshal` / `json.Unmarshal` exactly.

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test -count=1 ./owner/... ./daemon/... ./engine/...` — all green (owner 19.1s, daemon 13.7s, engine 0.24s)
- Race detector not run locally (no gcc on Windows dev machine); CI will cover `-race`
- All 3 new regression tests pass and fail on the pre-fix code (verified by reverting and re-running each test)

## Risk

Low. The FR-1 change returns `ErrDoNotRestart` instead of a restartable error for a state that was previously causing CPU spikes — the observable behaviour improves (no spin) and the cold-start flow is unaffected because cold-start owners always have `upstream != nil` before `Serve` returns. The FR-2 fix is a pure refactor mirroring Broadcast. The FR-3 fix goes through `json.Marshal` which has no edge cases for string values.

## Out of scope

The remaining 5 blockers + warnings from the audit land in separate PRs:
- `fix/daemon-spawn-concurrency` (FR-4, FR-6, FR-8) — next
- `fix/control-read-deadline` (FR-5)
- `fix/resilient-client-error-visibility` (FR-7)

Release tag `muxcore/v0.19.3` after all 4 PRs merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **Исправления ошибок**
  * Улучшена обработка ошибок в JSON-RPC ответах с корректным форматированием специальных символов.
  * Исправлена проблема с блокировкой при операциях ввода-вывода, освобождая блокировки перед потенциально длительными операциями.
  * Предотвращены циклы перезагрузки при отсутствии подключения к вышестоящему сервису.

* **Тесты**
  * Добавлены тесты для проверки корректности JSON-RPC ошибок.
  * Добавлены тесты для проверки поведения при конкурентном доступе.
  * Добавлены регрессионные тесты для предотвращения зависаний системы.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->