### PR TITLE
fix(control): apply read/write deadlines to handler connections (FR-5)

### DIFF
--- a/muxcore/control/control_test.go
+++ b/muxcore/control/control_test.go
@@ -484,3 +484,59 @@ func TestCloseIdempotent(t *testing.T) {
 	srv.Close()
 	srv.Close() // second close must be a no-op, not a panic
 }
+
+// TestControlServer_ReadDeadlineFiresOnSilentClient verifies that a client connecting
+// to the control socket without sending any data does not occupy the handler goroutine
+// indefinitely. After clientDeadline elapses, the handler's Decode must return an
+// i/o timeout error, the server must write an error response, and the connection must
+// be closed. If the deadline is not applied, this test hangs until the Go test harness
+// kills the run.
+//
+// Regression test for FR-5 (post-audit remediation): a malicious or broken client could
+// DoS the daemon control plane by opening connections and never sending a request,
+// accumulating handler goroutines forever.
+func TestControlServer_ReadDeadlineFiresOnSilentClient(t *testing.T) {
+	path := testSocketPath(t)
+	handler := &mockHandler{}
+	srv, err := NewServer(path, handler, testLogger(t))
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	defer srv.Close()
+
+	conn, err := net.DialTimeout("unix", path, 2*time.Second)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	// Observe server-side timeout by blocking on Read: the server's writeResponse will
+	// produce a JSON error line, then close the connection. We should see that response
+	// (or EOF on close) within clientDeadline + small slack.
+	if err := conn.SetReadDeadline(time.Now().Add(clientDeadline + 3*time.Second)); err != nil {
+		t.Fatalf("set client read deadline: %v", err)
+	}
+
+	start := time.Now()
+	buf := make([]byte, 1024)
+	n, readErr := conn.Read(buf)
+	elapsed := time.Since(start)
+
+	// The server must react within clientDeadline + slack, not hang forever.
+	if elapsed > clientDeadline+2*time.Second {
+		t.Errorf("server did not react within %s: elapsed=%s (handler likely hung on silent client)",
+			clientDeadline+2*time.Second, elapsed)
+	}
+
+	// Either we got an error response line or EOF after the server closed the conn.
+	// Both indicate the handler unblocked and exited. Hang = test fails via harness timeout.
+	if readErr == nil && n > 0 {
+		var resp Response
+		if err := json.Unmarshal(buf[:n], &resp); err != nil {
+			t.Errorf("unexpected non-JSON response after deadline: %q (err=%v)", buf[:n], err)
+		}
+		if resp.OK {
+			t.Errorf("expected error response after read deadline, got OK=%v msg=%q", resp.OK, resp.Message)
+		}
+	}
+}

--- a/muxcore/control/control_test.go
+++ b/muxcore/control/control_test.go
@@ -1,6 +1,7 @@
 package control
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -485,17 +486,16 @@ func TestCloseIdempotent(t *testing.T) {
 	srv.Close() // second close must be a no-op, not a panic
 }
 
-// TestControlServer_ReadDeadlineFiresOnSilentClient verifies that a client connecting
-// to the control socket without sending any data does not occupy the handler goroutine
-// indefinitely. After clientDeadline elapses, the handler's Decode must return an
-// i/o timeout error, the server must write an error response, and the connection must
-// be closed. If the deadline is not applied, this test hangs until the Go test harness
-// kills the run.
+// TestControlServer_ReadDeadlineFiresOnSilentClient is a regression test for FR-5.
+// A client that connects but never sends data must not block the server goroutine
+// forever. The server's read deadline must fire within clientDeadline + slack.
 //
-// Regression test for FR-5 (post-audit remediation): a malicious or broken client could
-// DoS the daemon control plane by opening connections and never sending a request,
+// Regression for post-audit-remediation: a malicious or broken client could DoS
+// the daemon control plane by opening connections and never sending a request,
 // accumulating handler goroutines forever.
 func TestControlServer_ReadDeadlineFiresOnSilentClient(t *testing.T) {
+	const slack = 2 * time.Second
+
 	path := testSocketPath(t)
 	handler := &mockHandler{}
 	srv, err := NewServer(path, handler, testLogger(t))
@@ -504,39 +504,51 @@ func TestControlServer_ReadDeadlineFiresOnSilentClient(t *testing.T) {
 	}
 	defer srv.Close()
 
-	conn, err := net.DialTimeout("unix", path, 2*time.Second)
+	// Connect but never send anything — the server's handleConn goroutine must
+	// self-terminate via the read deadline rather than block indefinitely.
+	conn, err := net.DialTimeout("unix", path, 5*time.Second)
 	if err != nil {
 		t.Fatalf("dial: %v", err)
 	}
 	defer conn.Close()
 
-	// Observe server-side timeout by blocking on Read: the server's writeResponse will
-	// produce a JSON error line, then close the connection. We should see that response
-	// (or EOF on close) within clientDeadline + small slack.
-	if err := conn.SetReadDeadline(time.Now().Add(clientDeadline + 3*time.Second)); err != nil {
-		t.Fatalf("set client read deadline: %v", err)
+	// The server should close the connection (or the goroutine should exit) within
+	// clientDeadline + slack. We verify this by attempting to read from the conn:
+	// the server side will close after deadline, making our Read return io.EOF or
+	// a deadline error.
+	deadline := clientDeadline + slack
+	if err := conn.SetDeadline(time.Now().Add(deadline)); err != nil {
+		t.Fatalf("set deadline: %v", err)
 	}
 
+	// Read one NDJSON line using bufio for correct protocol framing.
+	// The server sends JSON followed by '\n' in a single Write.
+	reader := bufio.NewReader(conn)
 	start := time.Now()
-	buf := make([]byte, 1024)
-	n, readErr := conn.Read(buf)
+	line, readErr := reader.ReadBytes('\n')
 	elapsed := time.Since(start)
 
-	// The server must react within clientDeadline + slack, not hang forever.
-	if elapsed > clientDeadline+2*time.Second {
-		t.Errorf("server did not react within %s: elapsed=%s (handler likely hung on silent client)",
-			clientDeadline+2*time.Second, elapsed)
-	}
-
-	// Either we got an error response line or EOF after the server closed the conn.
-	// Both indicate the handler unblocked and exited. Hang = test fails via harness timeout.
-	if readErr == nil && n > 0 {
+	// A non-empty line means the server sent an error response before closing
+	// (read deadline fired, server wrote the error response, then closed).
+	// Validate it is a well-formed, not-OK response.
+	if len(line) > 0 {
 		var resp Response
-		if err := json.Unmarshal(buf[:n], &resp); err != nil {
-			t.Errorf("unexpected non-JSON response after deadline: %q (err=%v)", buf[:n], err)
+		if err := json.Unmarshal(line, &resp); err != nil {
+			t.Errorf("non-JSON response after read deadline: %q (err=%v)", line, err)
 		}
 		if resp.OK {
 			t.Errorf("expected error response after read deadline, got OK=%v msg=%q", resp.OK, resp.Message)
 		}
+	}
+	// readErr may be io.EOF, a timeout error, or nil — all acceptable as long as
+	// the goroutine unblocked within the expected window.
+	_ = readErr
+
+	// The goroutine must have exited within clientDeadline + slack; if our own
+	// deadline fired first the test itself would time out here, which counts as
+	// failure via the harness.
+	if elapsed > deadline {
+		t.Errorf("server held connection for %v, want <= %v (clientDeadline %v + slack %v)",
+			elapsed, deadline, clientDeadline, slack)
 	}
 }

--- a/muxcore/control/server.go
+++ b/muxcore/control/server.go
@@ -63,6 +63,8 @@ func (s *Server) acceptLoop() {
 func (s *Server) handleConn(conn net.Conn) {
 	defer conn.Close()
 
+	// Bound the read phase: a silent/malicious client cannot hold the goroutine
+	// open in dec.Decode forever.
 	if err := conn.SetReadDeadline(time.Now().Add(clientDeadline)); err != nil {
 		s.logger.Printf("control: set read deadline: %v", err)
 		return
@@ -71,16 +73,21 @@ func (s *Server) handleConn(conn net.Conn) {
 	dec := json.NewDecoder(conn)
 	var req Request
 	if err := dec.Decode(&req); err != nil {
+		// Bound the write phase on the error path too — a non-reading client
+		// must not block writeResponse indefinitely.
+		_ = conn.SetWriteDeadline(time.Now().Add(clientDeadline))
 		s.writeResponse(conn, Response{OK: false, Message: fmt.Sprintf("invalid request: %v", err)})
 		return
 	}
 
+	// Dispatch runs the handler (e.g. graceful-restart may take longer than
+	// clientDeadline). Set the write deadline only after dispatch returns so
+	// it bounds only the I/O write, not handler execution.
+	resp := s.dispatch(req)
 	if err := conn.SetWriteDeadline(time.Now().Add(clientDeadline)); err != nil {
 		s.logger.Printf("control: set write deadline: %v", err)
 		return
 	}
-
-	resp := s.dispatch(req)
 	s.writeResponse(conn, resp)
 }
 

--- a/muxcore/control/server.go
+++ b/muxcore/control/server.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net"
 	"sync"
+	"time"
 
 	"github.com/thebtf/mcp-mux/muxcore/ipc"
 )
@@ -62,10 +63,20 @@ func (s *Server) acceptLoop() {
 func (s *Server) handleConn(conn net.Conn) {
 	defer conn.Close()
 
+	if err := conn.SetReadDeadline(time.Now().Add(clientDeadline)); err != nil {
+		s.logger.Printf("control: set read deadline: %v", err)
+		return
+	}
+
 	dec := json.NewDecoder(conn)
 	var req Request
 	if err := dec.Decode(&req); err != nil {
 		s.writeResponse(conn, Response{OK: false, Message: fmt.Sprintf("invalid request: %v", err)})
+		return
+	}
+
+	if err := conn.SetWriteDeadline(time.Now().Add(clientDeadline)); err != nil {
+		s.logger.Printf("control: set write deadline: %v", err)
 		return
 	}
 


### PR DESCRIPTION
## Summary
Fix FR-5 from post-audit remediation: a malicious or broken client could DoS the daemon control plane by opening connections and never sending a request. The handler goroutine would block in `json.Decode` forever, accumulating goroutines until OOM.

## Changes
- `handleConn` now sets `SetReadDeadline(clientDeadline)` before `Decode`
- After Decode succeeds, `SetWriteDeadline(clientDeadline)` bounds the response write path
- Both use the existing package-level `clientDeadline = 5 * time.Second` (already used symmetrically by `control.Send`)

## Regression Test
`TestControlServer_ReadDeadlineFiresOnSilentClient`:
- Dials the control socket
- Sends nothing
- Asserts the server reacts within `clientDeadline + 2s` (actually fires at exactly 5.00s)
- Hangs forever via test harness timeout if the deadline is missing

Full `go test ./control/...` (18 tests) passes. Total runtime: 5.34s (of which 5.00s is the new regression test's deadline wait — by design).

## Spec
Part of post-audit-remediation v0.19.3 (`.agent/specs/post-audit-remediation/spec.md` FR-5).

## Related
- PR #54 merged — PR-A (owner.go concurrency bundle FR-1/2/3)
- PR #55 open — PR-B (daemon.go spawn concurrency FR-4/6/8)
- PR-D pending — FR-7 (resilient_client error visibility)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Исправления**
  * Внедрена защита от зависания соединений: сервер устанавливает индивидуальные тайм-ауты на операции чтения и записи для каждого подключения, предотвращая блокировки при неактивных клиентах и повышая надёжность и предсказуемость поведения.

* **Тесты**
  * Добавлен интеграционный тест, проверяющий срабатывание механизма тайм-аута при соединении с неактивным клиентом и корректную реакцию сервера.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->