### PR TITLE
fix(resilient_client): log write errors when draining orphaned in-flight (FR-7)

### DIFF
--- a/muxcore/owner/resilient_client.go
+++ b/muxcore/owner/resilient_client.go
@@ -544,6 +544,13 @@ func (rc *resilientClient) flushBuffer(conn io.Writer) {
 // requests that were in-flight when the IPC connection died. Without this,
 // CC waits forever for responses that will never come (request was sent to
 // old upstream which was killed during reconnect).
+//
+// Stdout-failure handling: a write error on stdout is a terminal condition
+// (same rule as runStdoutWriter and the keepalive path). On the FIRST write
+// failure we log once, signal stdoutDead so the client exits gracefully,
+// and then continue iterating only to drain the inflight map — we do NOT
+// attempt further writes, so a broken pipe cannot produce N log lines for
+// N orphaned requests.
 func (rc *resilientClient) drainOrphanedInflight(stdoutMu *sync.Mutex) {
 	var orphaned []string
 	rc.inflight.Range(func(key, _ any) bool {
@@ -555,8 +562,18 @@ func (rc *resilientClient) drainOrphanedInflight(stdoutMu *sync.Mutex) {
 	}
 
 	rc.log.Printf("resilient: sending error responses for %d orphaned in-flight requests", len(orphaned))
-	var writeErrors int
+	stdoutBroken := false
 	for _, id := range orphaned {
+		// Always clear the inflight entry — drain completes regardless of
+		// write outcome so repeated reconnects do not leak tracking state.
+		rc.inflight.Delete(id)
+
+		if stdoutBroken {
+			// Stdout is dead; don't try to write N more lines only to log
+			// N more failures. Keep draining the map though.
+			continue
+		}
+
 		errResp := fmt.Sprintf(
 			`{"jsonrpc":"2.0","id":%s,"error":{"code":-32603,"message":"upstream restarted, request lost during reconnect"}}`,
 			id,
@@ -565,13 +582,15 @@ func (rc *resilientClient) drainOrphanedInflight(stdoutMu *sync.Mutex) {
 		_, err := fmt.Fprintf(rc.cfg.Stdout, "%s\n", errResp)
 		stdoutMu.Unlock()
 		if err != nil {
-			writeErrors++
-			rc.log.Printf("resilient: failed to write orphaned-inflight error response for id=%s: %v", id, err)
+			stdoutBroken = true
+			rc.log.Printf("resilient: stdout broken while draining orphaned in-flight requests: %v", err)
+			// Same terminal-condition signaling as runStdoutWriter (line ~194):
+			// close stdoutDead so the main loop unblocks and exits gracefully.
+			rc.stdoutOnce.Do(func() { close(rc.stdoutDead) })
 		}
-		rc.inflight.Delete(id)
 	}
-	if writeErrors > 0 {
-		rc.log.Printf("resilient: drainOrphanedInflight: %d/%d write errors — CC may hang on those requests", writeErrors, len(orphaned))
+	if stdoutBroken {
+		rc.log.Printf("resilient: drainOrphanedInflight: stdout broken — CC may hang on the remaining orphaned requests")
 	}
 }
 

--- a/muxcore/owner/resilient_client.go
+++ b/muxcore/owner/resilient_client.go
@@ -555,15 +555,23 @@ func (rc *resilientClient) drainOrphanedInflight(stdoutMu *sync.Mutex) {
 	}
 
 	rc.log.Printf("resilient: sending error responses for %d orphaned in-flight requests", len(orphaned))
+	var writeErrors int
 	for _, id := range orphaned {
 		errResp := fmt.Sprintf(
 			`{"jsonrpc":"2.0","id":%s,"error":{"code":-32603,"message":"upstream restarted, request lost during reconnect"}}`,
 			id,
 		)
 		stdoutMu.Lock()
-		fmt.Fprintf(rc.cfg.Stdout, "%s\n", errResp)
+		_, err := fmt.Fprintf(rc.cfg.Stdout, "%s\n", errResp)
 		stdoutMu.Unlock()
+		if err != nil {
+			writeErrors++
+			rc.log.Printf("resilient: failed to write orphaned-inflight error response for id=%s: %v", id, err)
+		}
 		rc.inflight.Delete(id)
+	}
+	if writeErrors > 0 {
+		rc.log.Printf("resilient: drainOrphanedInflight: %d/%d write errors — CC may hang on those requests", writeErrors, len(orphaned))
 	}
 }
 

--- a/muxcore/owner/resilient_client_test.go
+++ b/muxcore/owner/resilient_client_test.go
@@ -597,3 +597,133 @@ func TestResilientClient_InitReplayOnReconnect(t *testing.T) {
 		t.Fatal("RunResilientClient did not exit")
 	}
 }
+
+// failingWriter fails every Write with a configurable error.
+type failingWriter struct {
+	err   error
+	count int
+	mu    sync.Mutex
+}
+
+func (w *failingWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.count++
+	return 0, w.err
+}
+
+// capturingLogger is an io.Writer that buffers log output for inspection.
+type capturingLogger struct {
+	mu  sync.Mutex
+	buf strings.Builder
+}
+
+func (c *capturingLogger) Write(p []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.buf.Write(p)
+}
+
+func (c *capturingLogger) String() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.buf.String()
+}
+
+// TestResilientClient_DrainOrphanedInflight_LogsWriteErrors verifies FR-7:
+// when drainOrphanedInflight fails to write an error response to CC stdout
+// (e.g. pipe closed during reconnect), the failure must be logged with the
+// failing request id so operators can see which CC requests will hang.
+//
+// Regression for: previously fmt.Fprintf's error was discarded, making it
+// impossible to distinguish "CC got all responses" from "CC is hung on N
+// lost requests".
+func TestResilientClient_DrainOrphanedInflight_LogsWriteErrors(t *testing.T) {
+	sink := &capturingLogger{}
+	logger := log.New(sink, "", 0)
+	stdout := &failingWriter{err: io.ErrClosedPipe}
+
+	rc := &resilientClient{
+		cfg: ResilientClientConfig{
+			Stdout: stdout,
+		},
+		log: logger,
+	}
+
+	// Seed inflight with 3 orphaned IDs: one numeric, two string.
+	rc.inflight.Store("42", true)
+	rc.inflight.Store(`"req-xyz"`, true)
+	rc.inflight.Store(`"req-hang"`, true)
+
+	var stdoutMu sync.Mutex
+	rc.drainOrphanedInflight(&stdoutMu)
+
+	// All inflight entries must be cleared regardless of write success,
+	// otherwise they'd accumulate on every reconnect.
+	remaining := 0
+	rc.inflight.Range(func(_, _ any) bool { remaining++; return true })
+	if remaining != 0 {
+		t.Errorf("inflight not cleared after drain: %d entries remain", remaining)
+	}
+
+	// Writer must have been called 3 times (one per orphaned id).
+	if stdout.count != 3 {
+		t.Errorf("expected 3 write attempts, got %d", stdout.count)
+	}
+
+	// Log must contain: (a) the initial summary line, (b) per-id error lines
+	// identifying *which* requests will hang, (c) the aggregate failure count.
+	logs := sink.String()
+	t.Logf("captured logs:\n%s", logs)
+
+	if !strings.Contains(logs, "sending error responses for 3 orphaned in-flight requests") {
+		t.Errorf("log missing initial summary: %q", logs)
+	}
+	for _, id := range []string{"42", `"req-xyz"`, `"req-hang"`} {
+		snippet := fmt.Sprintf("failed to write orphaned-inflight error response for id=%s", id)
+		if !strings.Contains(logs, snippet) {
+			t.Errorf("log missing per-id error for id=%s: %q", id, logs)
+		}
+	}
+	if !strings.Contains(logs, "3/3 write errors") {
+		t.Errorf("log missing aggregate write-error summary: %q", logs)
+	}
+	if !strings.Contains(logs, "CC may hang on those requests") {
+		t.Errorf("log missing operator-visible hang warning: %q", logs)
+	}
+}
+
+// TestResilientClient_DrainOrphanedInflight_NoErrorsOnSuccess verifies that
+// drainOrphanedInflight does NOT log any write-error lines or aggregate
+// summary when writes succeed — avoids log-pollution false positives.
+func TestResilientClient_DrainOrphanedInflight_NoErrorsOnSuccess(t *testing.T) {
+	sink := &capturingLogger{}
+	logger := log.New(sink, "", 0)
+	var buf strings.Builder
+
+	rc := &resilientClient{
+		cfg: ResilientClientConfig{
+			Stdout: &buf,
+		},
+		log: logger,
+	}
+	rc.inflight.Store("1", true)
+	rc.inflight.Store("2", true)
+
+	var stdoutMu sync.Mutex
+	rc.drainOrphanedInflight(&stdoutMu)
+
+	logs := sink.String()
+	if strings.Contains(logs, "failed to write orphaned-inflight") {
+		t.Errorf("unexpected per-id failure log on success path: %q", logs)
+	}
+	if strings.Contains(logs, "write errors") {
+		t.Errorf("unexpected aggregate failure summary on success path: %q", logs)
+	}
+
+	// Sanity: both error responses were actually written.
+	out := buf.String()
+	if !strings.Contains(out, `"id":1`) || !strings.Contains(out, `"id":2`) {
+		t.Errorf("expected both error responses on stdout, got: %q", out)
+	}
+}

--- a/muxcore/owner/resilient_client_test.go
+++ b/muxcore/owner/resilient_client_test.go
@@ -630,14 +630,18 @@ func (c *capturingLogger) String() string {
 	return c.buf.String()
 }
 
-// TestResilientClient_DrainOrphanedInflight_LogsWriteErrors verifies FR-7:
-// when drainOrphanedInflight fails to write an error response to CC stdout
-// (e.g. pipe closed during reconnect), the failure must be logged with the
-// failing request id so operators can see which CC requests will hang.
+// TestResilientClient_DrainOrphanedInflight_LogsWriteErrors verifies FR-7 +
+// Gemini's PR #57 review finding: when drainOrphanedInflight fails to write
+// the first error response to CC stdout (e.g. pipe closed during reconnect):
+//   - exactly ONE stdout-broken log line is emitted (no log spam)
+//   - subsequent writes are skipped (count == 1, not N)
+//   - the stdoutDead channel is closed so the main loop exits gracefully
+//   - the inflight map is still fully drained (no leaked tracking state)
 //
-// Regression for: previously fmt.Fprintf's error was discarded, making it
-// impossible to distinguish "CC got all responses" from "CC is hung on N
-// lost requests".
+// Regression for two issues:
+//  1. Originally fmt.Fprintf's error was discarded — CC hang with no log.
+//  2. A naive "log per failed write" fix (PR #57 initial) produced log spam
+//     proportional to inflight queue depth and did not signal stdoutDead.
 func TestResilientClient_DrainOrphanedInflight_LogsWriteErrors(t *testing.T) {
 	sink := &capturingLogger{}
 	logger := log.New(sink, "", 0)
@@ -647,7 +651,8 @@ func TestResilientClient_DrainOrphanedInflight_LogsWriteErrors(t *testing.T) {
 		cfg: ResilientClientConfig{
 			Stdout: stdout,
 		},
-		log: logger,
+		log:        logger,
+		stdoutDead: make(chan struct{}),
 	}
 
 	// Seed inflight with 3 orphaned IDs: one numeric, two string.
@@ -666,36 +671,46 @@ func TestResilientClient_DrainOrphanedInflight_LogsWriteErrors(t *testing.T) {
 		t.Errorf("inflight not cleared after drain: %d entries remain", remaining)
 	}
 
-	// Writer must have been called 3 times (one per orphaned id).
-	if stdout.count != 3 {
-		t.Errorf("expected 3 write attempts, got %d", stdout.count)
+	// With the stdout-broken fast-path, only the first write should be
+	// attempted; the remaining orphaned IDs must be skipped to prevent spam.
+	if stdout.count != 1 {
+		t.Errorf("expected exactly 1 write attempt (fast-skip after first error), got %d", stdout.count)
 	}
 
-	// Log must contain: (a) the initial summary line, (b) per-id error lines
-	// identifying *which* requests will hang, (c) the aggregate failure count.
 	logs := sink.String()
 	t.Logf("captured logs:\n%s", logs)
 
 	if !strings.Contains(logs, "sending error responses for 3 orphaned in-flight requests") {
 		t.Errorf("log missing initial summary: %q", logs)
 	}
-	for _, id := range []string{"42", `"req-xyz"`, `"req-hang"`} {
-		snippet := fmt.Sprintf("failed to write orphaned-inflight error response for id=%s", id)
-		if !strings.Contains(logs, snippet) {
-			t.Errorf("log missing per-id error for id=%s: %q", id, logs)
-		}
+
+	// EXACTLY ONE stdout-broken notice — the core of the log-spam fix.
+	brokenCount := strings.Count(logs, "stdout broken while draining orphaned in-flight requests")
+	if brokenCount != 1 {
+		t.Errorf("expected exactly 1 stdout-broken log line, got %d (logs: %q)", brokenCount, logs)
 	}
-	if !strings.Contains(logs, "3/3 write errors") {
-		t.Errorf("log missing aggregate write-error summary: %q", logs)
+
+	// Per-id error lines from the OLD code must be gone.
+	if strings.Contains(logs, "failed to write orphaned-inflight error response for id=") {
+		t.Errorf("unexpected per-id error log (log-spam regression): %q", logs)
 	}
-	if !strings.Contains(logs, "CC may hang on those requests") {
+
+	if !strings.Contains(logs, "CC may hang on the remaining orphaned requests") {
 		t.Errorf("log missing operator-visible hang warning: %q", logs)
+	}
+
+	// stdoutDead MUST be signaled so the main client loop exits gracefully.
+	select {
+	case <-rc.stdoutDead:
+		// good — stdoutOnce.Do fired
+	default:
+		t.Error("stdoutDead not closed after stdout write failure — client will not exit gracefully")
 	}
 }
 
 // TestResilientClient_DrainOrphanedInflight_NoErrorsOnSuccess verifies that
-// drainOrphanedInflight does NOT log any write-error lines or aggregate
-// summary when writes succeed — avoids log-pollution false positives.
+// drainOrphanedInflight does NOT log any failure lines, does NOT close
+// stdoutDead, and writes every response on the happy path.
 func TestResilientClient_DrainOrphanedInflight_NoErrorsOnSuccess(t *testing.T) {
 	sink := &capturingLogger{}
 	logger := log.New(sink, "", 0)
@@ -705,7 +720,8 @@ func TestResilientClient_DrainOrphanedInflight_NoErrorsOnSuccess(t *testing.T) {
 		cfg: ResilientClientConfig{
 			Stdout: &buf,
 		},
-		log: logger,
+		log:        logger,
+		stdoutDead: make(chan struct{}),
 	}
 	rc.inflight.Store("1", true)
 	rc.inflight.Store("2", true)
@@ -714,11 +730,11 @@ func TestResilientClient_DrainOrphanedInflight_NoErrorsOnSuccess(t *testing.T) {
 	rc.drainOrphanedInflight(&stdoutMu)
 
 	logs := sink.String()
-	if strings.Contains(logs, "failed to write orphaned-inflight") {
-		t.Errorf("unexpected per-id failure log on success path: %q", logs)
+	if strings.Contains(logs, "stdout broken") {
+		t.Errorf("unexpected stdout-broken log on success path: %q", logs)
 	}
-	if strings.Contains(logs, "write errors") {
-		t.Errorf("unexpected aggregate failure summary on success path: %q", logs)
+	if strings.Contains(logs, "CC may hang") {
+		t.Errorf("unexpected hang warning on success path: %q", logs)
 	}
 
 	// Sanity: both error responses were actually written.
@@ -726,4 +742,90 @@ func TestResilientClient_DrainOrphanedInflight_NoErrorsOnSuccess(t *testing.T) {
 	if !strings.Contains(out, `"id":1`) || !strings.Contains(out, `"id":2`) {
 		t.Errorf("expected both error responses on stdout, got: %q", out)
 	}
+
+	// stdoutDead must still be open on the happy path.
+	select {
+	case <-rc.stdoutDead:
+		t.Error("stdoutDead closed on happy path — would cause false-positive graceful exit")
+	default:
+		// good
+	}
+}
+
+// TestResilientClient_DrainOrphanedInflight_FailAfterSuccess verifies that a
+// mid-iteration write failure triggers the fast-skip correctly: earlier writes
+// in the same drain cycle that succeeded remain observable on stdout, while
+// the failing and subsequent writes are dropped and logged exactly once.
+func TestResilientClient_DrainOrphanedInflight_FailAfterSuccess(t *testing.T) {
+	sink := &capturingLogger{}
+	logger := log.New(sink, "", 0)
+
+	// failAfterNWriter: succeeds for `passes` writes, then fails every subsequent write.
+	writer := &failAfterNWriter{passes: 1, err: io.ErrClosedPipe}
+
+	rc := &resilientClient{
+		cfg: ResilientClientConfig{
+			Stdout: writer,
+		},
+		log:        logger,
+		stdoutDead: make(chan struct{}),
+	}
+
+	// 4 orphaned IDs: first should succeed, rest should fast-skip after failure.
+	rc.inflight.Store("1", true)
+	rc.inflight.Store("2", true)
+	rc.inflight.Store("3", true)
+	rc.inflight.Store("4", true)
+
+	var stdoutMu sync.Mutex
+	rc.drainOrphanedInflight(&stdoutMu)
+
+	// Inflight fully drained.
+	remaining := 0
+	rc.inflight.Range(func(_, _ any) bool { remaining++; return true })
+	if remaining != 0 {
+		t.Errorf("inflight not cleared: %d entries remain", remaining)
+	}
+
+	// Exactly 2 write attempts: the first success + the first failure.
+	// The remaining 2 orphaned IDs must NOT have triggered writes.
+	if writer.attempts != 2 {
+		t.Errorf("expected 2 write attempts (1 success + 1 failure), got %d", writer.attempts)
+	}
+
+	// stdoutDead signaled.
+	select {
+	case <-rc.stdoutDead:
+		// good
+	default:
+		t.Error("stdoutDead not closed after mid-iteration failure")
+	}
+
+	// Exactly one per-failure log line. Use the specific per-failure marker,
+	// not "stdout broken" alone, because the final summary line also contains
+	// that phrase.
+	logs := sink.String()
+	perFailureCount := strings.Count(logs, "stdout broken while draining orphaned in-flight requests")
+	if perFailureCount != 1 {
+		t.Errorf("expected 1 per-failure log line, got %d: %q", perFailureCount, logs)
+	}
+}
+
+// failAfterNWriter succeeds `passes` times, then every subsequent Write
+// returns `err`. Used to test mid-iteration failure handling.
+type failAfterNWriter struct {
+	passes   int
+	err      error
+	mu       sync.Mutex
+	attempts int
+}
+
+func (w *failAfterNWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.attempts++
+	if w.attempts <= w.passes {
+		return len(p), nil
+	}
+	return 0, w.err
 }


### PR DESCRIPTION
## Summary
Fix FR-7 from post-audit remediation: `drainOrphanedInflight` silently discarded `fmt.Fprintf` write errors. If CC stdout closed during a reconnect, operators had no way to tell whether CC received the synthetic error responses or is hung waiting for them.

## Changes
- Capture `fmt.Fprintf` return value in `drainOrphanedInflight`
- Log per-id write errors: `failed to write orphaned-inflight error response for id=X: <err>`
- Emit aggregate summary when any write failed: `drainOrphanedInflight: N/M write errors — CC may hang on those requests`
- `inflight` entries still cleared on both success and failure paths (unchanged) to prevent tracking-state leaks across reconnects

## Regression Tests
- `TestResilientClient_DrainOrphanedInflight_LogsWriteErrors` — uses a `failingWriter{err: io.ErrClosedPipe}` and asserts (a) all 3 orphaned IDs get per-id error lines, (b) aggregate `3/3 write errors` summary present, (c) `CC may hang on those requests` warning present, (d) `inflight` fully drained, (e) Write called exactly 3 times.
- `TestResilientClient_DrainOrphanedInflight_NoErrorsOnSuccess` — asserts the happy path does NOT emit failure logs (prevents log-pollution false positives) and sanity-checks both error responses land on stdout.

Full `go test ./owner/...` (all tests) passes in 19.2s.

## Spec
Part of post-audit-remediation v0.19.3 (`.agent/specs/post-audit-remediation/spec.md` FR-7).

## Related
- PR #54 merged — PR-A (owner.go concurrency bundle FR-1/2/3)
- PR #55 open — PR-B (daemon.go spawn concurrency FR-4/6/8)
- PR #56 open — PR-C (control server read deadline FR-5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Заметки о выпуске

* **Исправления ошибок**
  * Улучшена обработка очистки зависающих запросов при ошибках записи
  * Повышена надежность клиента при сбое операций вывода
  * Гарантировано корректное очищение состояния независимо от результатов записи

* **Тесты**
  * Добавлено полное покрытие тестами для сценариев сбоев при записи и восстановлении

<!-- end of auto-generated comment: release notes by coderabbit.ai -->