### PR TITLE
fix(engine): runProxy must fall through to Handler when both handlers set

### DIFF
--- a/muxcore/engine/engine.go
+++ b/muxcore/engine/engine.go
@@ -293,21 +293,34 @@ func (e *MuxEngine) runClient(ctx context.Context) error {
 // SessionHandler is set (no Handler), proxy mode is unsupported because
 // SessionHandler requires per-request dispatch, not a raw stdio bridge.
 func (e *MuxEngine) runProxy(ctx context.Context) error {
-	// SessionHandler takes priority — if both are set, use Handler is skipped.
-	if e.cfg.SessionHandler != nil {
-		if e.cfg.Handler == nil {
-			return fmt.Errorf("engine proxy: proxy mode requires Handler; SessionHandler does not support raw stdio proxy mode")
-		}
-		// Both set: SessionHandler wins — do not fall through to Handler.
-		// Proxy mode is a stdio passthrough; SessionHandler is handled by the daemon.
-		// Log and skip — the daemon will route requests through SessionHandler.
-		e.logger.Printf("engine proxy: SessionHandler set, skipping Handler for proxy mode (session=%s)", os.Getenv("MCP_MUX_SESSION_ID"))
-		return nil
-	}
+	// Proxy mode: we are a subprocess of an EXTERNAL parent shim (e.g. the
+	// user wrapped us via `mcp-mux <our-binary>`). The parent owns stdio and
+	// expects us to serve one request/response per MCP message.
+	//
+	// SessionHandler cannot serve raw stdio on its own — it needs an Owner
+	// with session routing, which only exists in daemon mode. In proxy mode
+	// we rely on the legacy Handler callback for stdio I/O. Consumers that
+	// use SessionHandler in daemon mode should ALSO keep Handler set as a
+	// "proxy mode compatibility" fallback (aimux does exactly this).
+	//
+	// Historical note: v0.18.0–v0.19.3 had a branch here that logged
+	// "SessionHandler set, skipping Handler" and returned nil when both
+	// handlers were set, causing the subprocess to exit instantly. That
+	// broke every muxcore consumer wrapped by mcp-mux (observed: aimux
+	// crash-loop into FAILED state). The branch was based on the wrong
+	// mental model — in proxy mode there is no daemon "handling
+	// SessionHandler" for us; we ARE the thing being wrapped.
 	if e.cfg.Handler == nil {
+		if e.cfg.SessionHandler != nil {
+			return fmt.Errorf("engine proxy: proxy mode requires Handler; SessionHandler alone cannot serve raw stdio — consumers should keep Handler set for proxy-mode compatibility")
+		}
 		return fmt.Errorf("engine proxy: Handler is required for proxy mode")
 	}
-	e.logger.Printf("engine proxy: running handler directly on stdio (session=%s)", os.Getenv("MCP_MUX_SESSION_ID"))
+	if e.cfg.SessionHandler != nil {
+		e.logger.Printf("engine proxy: both handlers set, using Handler for stdio passthrough (session=%s)", os.Getenv("MCP_MUX_SESSION_ID"))
+	} else {
+		e.logger.Printf("engine proxy: running handler directly on stdio (session=%s)", os.Getenv("MCP_MUX_SESSION_ID"))
+	}
 	return e.cfg.Handler(ctx, os.Stdin, os.Stdout)
 }
 

--- a/muxcore/engine/engine_test.go
+++ b/muxcore/engine/engine_test.go
@@ -394,3 +394,129 @@ func TestRunProxy_HandlerReceivesData(t *testing.T) {
 		t.Error("handler did not receive stdin data")
 	}
 }
+
+// TestRunProxy_BothHandlersSet_FallsThroughToHandler is a regression test for
+// the muxcore engine proxy-mode fallthrough bug. v0.18.0–v0.19.3 had a branch
+// in runProxy that returned nil immediately when both Handler and SessionHandler
+// were set — the comment claimed "SessionHandler is handled by the daemon", but
+// in proxy mode the consumer IS the subprocess being wrapped by an external
+// parent shim (e.g. mcp-mux wrapping aimux), and there is no daemon at our
+// level. The early return caused the subprocess to exit in ~138ms, which the
+// parent shim observed as a dead upstream, triggering restart → circuit
+// breaker → permanent FAILED state.
+//
+// The fix: when both handlers are set, fall through to the legacy Handler
+// callback for stdio I/O. SessionHandler is irrelevant in proxy mode because
+// we cannot provide Owner-backed session routing from a subprocess.
+//
+// This test asserts the fix: with both handlers set, runProxy MUST call
+// Handler and must NOT return nil without reading stdin.
+func TestRunProxy_BothHandlersSet_FallsThroughToHandler(t *testing.T) {
+	const testPayload = `{"jsonrpc":"2.0","id":1,"method":"initialize"}`
+
+	var logBuf bytes.Buffer
+	logger := log.New(&logBuf, "", 0)
+
+	handlerCalled := false
+	handlerReadBytes := 0
+	handler := Handler(func(_ context.Context, stdin io.Reader, stdout io.Writer) error {
+		handlerCalled = true
+		buf := make([]byte, 256)
+		n, _ := stdin.Read(buf)
+		handlerReadBytes = n
+		_, err := io.WriteString(stdout, `{"jsonrpc":"2.0","id":1,"result":{}}`)
+		return err
+	})
+
+	// Both handlers set — the condition that triggered the old bug.
+	e, err := New(Config{
+		Name:           "test-both-handlers",
+		Handler:        handler,
+		SessionHandler: noopSessionHandler{},
+		Logger:         logger,
+	})
+	if err != nil {
+		t.Fatalf("New() unexpected error: %v", err)
+	}
+
+	t.Setenv("MCP_MUX_SESSION_ID", "sess_regression")
+
+	// Real os.Pipe-backed stdin/stdout so runProxy's direct use of os.Stdin/
+	// os.Stdout actually flows through to the Handler.
+	stdinR, stdinW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() stdin: %v", err)
+	}
+	stdoutR, stdoutW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() stdout: %v", err)
+	}
+	defer stdoutR.Close()
+
+	if _, err := io.WriteString(stdinW, testPayload); err != nil {
+		t.Fatalf("write stdin: %v", err)
+	}
+	stdinW.Close()
+
+	origStdin, origStdout := os.Stdin, os.Stdout
+	os.Stdin, os.Stdout = stdinR, stdoutW
+	defer func() {
+		os.Stdin = origStdin
+		os.Stdout = origStdout
+	}()
+
+	ctx := context.Background()
+	if err := e.runProxy(ctx); err != nil {
+		t.Fatalf("runProxy() unexpected error: %v", err)
+	}
+	stdoutW.Close()
+	stdinR.Close()
+
+	if !handlerCalled {
+		t.Fatal("Handler was NOT called in proxy mode with both handlers set — " +
+			"this is the regression bug: runProxy returned early without using Handler, " +
+			"which would cause the subprocess to exit and crash-loop under a parent shim")
+	}
+	if handlerReadBytes == 0 {
+		t.Error("Handler was called but did not read any stdin bytes — stdio passthrough broken")
+	}
+
+	// The new log line must NOT match the old "skipping Handler" string — that
+	// phrasing was the fingerprint of the broken code path.
+	logOut := logBuf.String()
+	if strings.Contains(logOut, "skipping Handler for proxy mode") {
+		t.Errorf("log contains the old 'skipping Handler' marker — bug regressed:\n%s", logOut)
+	}
+	if !strings.Contains(logOut, "both handlers set, using Handler for stdio passthrough") {
+		t.Errorf("log missing the new fallthrough marker:\n%s", logOut)
+	}
+}
+
+// TestRunProxy_SessionHandlerOnly_ReturnsError verifies that when only
+// SessionHandler is set (no Handler), runProxy returns a clear error
+// explaining that raw stdio proxy requires Handler. This guards the
+// negative case of the fallthrough fix: we only fall through when
+// Handler is actually present.
+func TestRunProxy_SessionHandlerOnly_ReturnsError(t *testing.T) {
+	e, err := New(Config{
+		Name:           "test-session-only",
+		SessionHandler: noopSessionHandler{},
+	})
+	if err != nil {
+		t.Fatalf("New() unexpected error: %v", err)
+	}
+
+	t.Setenv("MCP_MUX_SESSION_ID", "sess_session_only")
+
+	ctx := context.Background()
+	err = e.runProxy(ctx)
+	if err == nil {
+		t.Fatal("runProxy() expected error for SessionHandler-only config, got nil")
+	}
+	if !strings.Contains(err.Error(), "proxy mode requires Handler") {
+		t.Errorf("error should explain that Handler is required, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "proxy-mode compatibility") {
+		t.Errorf("error should hint that consumers keep Handler for proxy-mode compatibility, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
P1 regression introduced in PR #47 (v0.18.0): `runProxy` in `muxcore/engine/engine.go` returns nil immediately when both `Handler` and `SessionHandler` are set. This breaks every muxcore consumer wrapped by mcp-mux.

## Live Casualty: aimux
aimux sets both handlers in main.go:106-107 (comment: *"kept for proxy mode compatibility"*). When CC launches `mcp-mux D:/Dev/aimux/aimux.exe`:

1. mcp-mux spawns aimux, sets `MCP_MUX_SESSION_ID`
2. aimux `isProxyMode() == true` → `runProxy()`
3. `runProxy` logs *"SessionHandler set, skipping Handler"* → `return nil`
4. aimux.exe exits in **~138 ms** (measured directly) without writing a byte
5. mcp-mux owner: dead upstream → restart → 5 crashes/60s → **FAILED**

## Why the old code was wrong
The original comment claimed *"SessionHandler is handled by the daemon"*, but this is wrong by construction: in proxy mode the consumer IS the subprocess being wrapped by an EXTERNAL parent shim. There is no daemon at our level to route through. SessionHandler cannot serve raw stdio on its own — it requires an Owner with session routing, which only exists in the consumer''s own daemon mode. In proxy mode we must fall through to `Handler` (which aimux keeps precisely for this case).

## Fix
`runProxy` now uses `Handler` whenever it is set, regardless of `SessionHandler`. The error path (`Handler == nil && SessionHandler != nil`) explains the contract so future consumers see a clear message instead of silently exiting.

## Regression Tests
- **`TestRunProxy_BothHandlersSet_FallsThroughToHandler`** — reproduces the exact scenario: both handlers, `MCP_MUX_SESSION_ID`, real `os.Pipe` stdin with a JSON-RPC initialize payload. Asserts (a) `Handler` was called, (b) stdin was read, (c) the log does NOT contain `"skipping Handler for proxy mode"` (old bug fingerprint), (d) the log DOES contain `"both handlers set, using Handler for stdio passthrough"`.
- **`TestRunProxy_SessionHandlerOnly_ReturnsError`** — guards the negative case: SessionHandler-only in proxy mode must return a clear error, not silently fall through.

Full `go test ./engine/...` (15 tests) passes. `go build` + `go vet` clean.

## Release Plan
- Tag `muxcore/v0.19.4` (patch release)
- Update `aimux/go.mod` → `muxcore@v0.19.4`
- Rebuild aimux.exe
- Re-enable aimux in CC config (currently in `disabledMcpServers` because of this crash loop)

## Related
- Regression source: PR #47 commit 434524c (Phase 4 SessionHandler API)
- Affected: every muxcore consumer that sets both handlers and runs under an external shim