### PR TITLE
feat(shim): structured startup diagnostic logging

### DIFF
--- a/cmd/mcp-mux/daemon.go
+++ b/cmd/mcp-mux/daemon.go
@@ -110,14 +110,16 @@ func runGlobalDaemon() {
 func ensureDaemon(logger *log.Logger) error {
 	ctlPath := serverid.DaemonControlPath("", "")
 
-	// Fast path: daemon already running (no lock needed)
+	// Fast path: daemon already running (no lock needed).
+	// Log lines use key=value with no trailing prose so post-mortem grep/awk
+	// can parse them without surprises.
 	pingStart := time.Now()
 	if isDaemonRunning(ctlPath) {
-		logger.Printf("ensure_daemon substep=fast_ping status=ok duration=%v (daemon already up)",
+		logger.Printf("ensure_daemon substep=fast_ping status=ok duration=%v",
 			time.Since(pingStart))
 		return nil
 	}
-	logger.Printf("ensure_daemon substep=fast_ping status=miss duration=%v (daemon not running)",
+	logger.Printf("ensure_daemon substep=fast_ping status=miss duration=%v",
 		time.Since(pingStart))
 
 	// Acquire lock to prevent multiple shims from starting daemon simultaneously.
@@ -133,13 +135,13 @@ func ensureDaemon(logger *log.Logger) error {
 	if err := lockFile(lock); err != nil {
 		// Another shim holds the lock (starting daemon) — wait longer for it.
 		// 15s covers: daemon startup + upstream spawn + init response.
-		logger.Printf("ensure_daemon substep=lock_attempt status=contended duration=%v err=%v (another shim is starting daemon, waiting)",
-			time.Since(lockStart), err)
+		logger.Printf("ensure_daemon substep=lock_attempt status=contended duration=%v err=%q",
+			time.Since(lockStart), err.Error())
 		waitStart := time.Now()
 		waitErr := waitForDaemon(ctlPath, 15*time.Second)
 		if waitErr != nil {
-			logger.Printf("ensure_daemon substep=wait_for_other_shim status=error duration=%v err=%v",
-				time.Since(waitStart), waitErr)
+			logger.Printf("ensure_daemon substep=wait_for_other_shim status=error duration=%v err=%q",
+				time.Since(waitStart), waitErr.Error())
 			return waitErr
 		}
 		logger.Printf("ensure_daemon substep=wait_for_other_shim status=ok duration=%v",
@@ -153,7 +155,7 @@ func ensureDaemon(logger *log.Logger) error {
 	// Re-check after acquiring lock (another shim may have started it)
 	recheckStart := time.Now()
 	if isDaemonRunning(ctlPath) {
-		logger.Printf("ensure_daemon substep=lock_recheck status=already_running duration=%v (another shim started daemon before us)",
+		logger.Printf("ensure_daemon substep=lock_recheck status=already_running duration=%v",
 			time.Since(recheckStart))
 		return nil
 	}
@@ -163,8 +165,8 @@ func ensureDaemon(logger *log.Logger) error {
 	// Start daemon as detached process
 	spawnStart := time.Now()
 	if err := startDaemonProcess(); err != nil {
-		logger.Printf("ensure_daemon substep=spawn_process status=error duration=%v err=%v",
-			time.Since(spawnStart), err)
+		logger.Printf("ensure_daemon substep=spawn_process status=error duration=%v err=%q",
+			time.Since(spawnStart), err.Error())
 		return fmt.Errorf("start daemon: %w", err)
 	}
 	logger.Printf("ensure_daemon substep=spawn_process status=ok duration=%v",
@@ -172,8 +174,8 @@ func ensureDaemon(logger *log.Logger) error {
 
 	waitStart := time.Now()
 	if err := waitForDaemon(ctlPath, 10*time.Second); err != nil {
-		logger.Printf("ensure_daemon substep=wait_for_self status=timeout duration=%v err=%v",
-			time.Since(waitStart), err)
+		logger.Printf("ensure_daemon substep=wait_for_self status=timeout duration=%v err=%q",
+			time.Since(waitStart), err.Error())
 		return err
 	}
 	logger.Printf("ensure_daemon substep=wait_for_self status=ok duration=%v",
@@ -259,7 +261,7 @@ func spawnViaDaemon(command string, args []string, cwd, mode string, env map[str
 	}, 30*time.Second)
 	rpcDur := time.Since(rpcStart)
 	if err != nil {
-		logger.Printf("daemon_rpc_spawn status=error duration=%v err=%v", rpcDur, err)
+		logger.Printf("daemon_rpc_spawn status=error duration=%v err=%q", rpcDur, err.Error())
 		return "", "", fmt.Errorf("spawn via daemon: %w", err)
 	}
 	if !resp.OK {
@@ -267,8 +269,15 @@ func spawnViaDaemon(command string, args []string, cwd, mode string, env map[str
 		return "", "", fmt.Errorf("daemon spawn failed: %s", resp.Message)
 	}
 
-	logger.Printf("daemon_rpc_spawn status=ok duration=%v server=%s ipc=%s",
-		rpcDur, resp.ServerID[:8], resp.IPCPath)
+	// Safe ID truncation: resp.ServerID may be shorter than 8 chars in edge cases
+	// (test daemons, non-hashed IDs). Matches the pattern used in
+	// muxcore/engine/engine.go and muxcore/daemon/snapshot.go.
+	shortID := resp.ServerID
+	if len(shortID) > 8 {
+		shortID = shortID[:8]
+	}
+	logger.Printf("daemon_rpc_spawn status=ok duration=%v server=%s ipc=%q",
+		rpcDur, shortID, resp.IPCPath)
 	return resp.IPCPath, resp.Token, nil
 }
 

--- a/cmd/mcp-mux/daemon.go
+++ b/cmd/mcp-mux/daemon.go
@@ -104,13 +104,21 @@ func runGlobalDaemon() {
 // ensureDaemon checks if the global daemon is running. If not, starts it
 // as a detached background process. Returns nil when daemon is ready.
 // Uses a file lock to prevent multiple shims from spawning concurrent daemons.
+//
+// Emits structured "ensure_daemon substep=<name>" log lines so the shim's
+// startup timeline can be reconstructed from the CC mcp-logs jsonl.
 func ensureDaemon(logger *log.Logger) error {
 	ctlPath := serverid.DaemonControlPath("", "")
 
 	// Fast path: daemon already running (no lock needed)
+	pingStart := time.Now()
 	if isDaemonRunning(ctlPath) {
+		logger.Printf("ensure_daemon substep=fast_ping status=ok duration=%v (daemon already up)",
+			time.Since(pingStart))
 		return nil
 	}
+	logger.Printf("ensure_daemon substep=fast_ping status=miss duration=%v (daemon not running)",
+		time.Since(pingStart))
 
 	// Acquire lock to prevent multiple shims from starting daemon simultaneously.
 	// Lock file is NOT deleted — it persists for coordination across shims.
@@ -121,39 +129,72 @@ func ensureDaemon(logger *log.Logger) error {
 	}
 	defer lock.Close()
 
+	lockStart := time.Now()
 	if err := lockFile(lock); err != nil {
 		// Another shim holds the lock (starting daemon) — wait longer for it.
 		// 15s covers: daemon startup + upstream spawn + init response.
-		logger.Printf("another shim is starting daemon, waiting...")
-		return waitForDaemon(ctlPath, 15*time.Second)
-	}
-	defer unlockFile(lock)
-
-	// Re-check after acquiring lock (another shim may have started it)
-	if isDaemonRunning(ctlPath) {
+		logger.Printf("ensure_daemon substep=lock_attempt status=contended duration=%v err=%v (another shim is starting daemon, waiting)",
+			time.Since(lockStart), err)
+		waitStart := time.Now()
+		waitErr := waitForDaemon(ctlPath, 15*time.Second)
+		if waitErr != nil {
+			logger.Printf("ensure_daemon substep=wait_for_other_shim status=error duration=%v err=%v",
+				time.Since(waitStart), waitErr)
+			return waitErr
+		}
+		logger.Printf("ensure_daemon substep=wait_for_other_shim status=ok duration=%v",
+			time.Since(waitStart))
 		return nil
 	}
+	defer unlockFile(lock)
+	logger.Printf("ensure_daemon substep=lock_attempt status=acquired duration=%v",
+		time.Since(lockStart))
+
+	// Re-check after acquiring lock (another shim may have started it)
+	recheckStart := time.Now()
+	if isDaemonRunning(ctlPath) {
+		logger.Printf("ensure_daemon substep=lock_recheck status=already_running duration=%v (another shim started daemon before us)",
+			time.Since(recheckStart))
+		return nil
+	}
+	logger.Printf("ensure_daemon substep=lock_recheck status=still_missing duration=%v",
+		time.Since(recheckStart))
 
 	// Start daemon as detached process
-	logger.Printf("starting daemon...")
+	spawnStart := time.Now()
 	if err := startDaemonProcess(); err != nil {
+		logger.Printf("ensure_daemon substep=spawn_process status=error duration=%v err=%v",
+			time.Since(spawnStart), err)
 		return fmt.Errorf("start daemon: %w", err)
 	}
+	logger.Printf("ensure_daemon substep=spawn_process status=ok duration=%v",
+		time.Since(spawnStart))
 
-	return waitForDaemon(ctlPath, 10*time.Second)
+	waitStart := time.Now()
+	if err := waitForDaemon(ctlPath, 10*time.Second); err != nil {
+		logger.Printf("ensure_daemon substep=wait_for_self status=timeout duration=%v err=%v",
+			time.Since(waitStart), err)
+		return err
+	}
+	logger.Printf("ensure_daemon substep=wait_for_self status=ok duration=%v",
+		time.Since(waitStart))
+	return nil
 }
 
 // waitForDaemon polls until the daemon control socket responds (up to timeout).
+// Counts polling attempts so slow daemon startup is observable via log.
 func waitForDaemon(ctlPath string, timeout time.Duration) error {
 	deadline := time.After(timeout)
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 
+	attempts := 0
 	for {
 		select {
 		case <-deadline:
-			return fmt.Errorf("daemon did not start within %s", timeout)
+			return fmt.Errorf("daemon did not start within %s (polls=%d)", timeout, attempts)
 		case <-ticker.C:
+			attempts++
 			if isDaemonRunning(ctlPath) {
 				return nil
 			}
@@ -201,11 +242,13 @@ func startDaemonProcess() error {
 }
 
 // spawnViaDaemon sends a spawn request to the daemon and returns the IPC path and handshake token.
+// Emits a "daemon_rpc_spawn" log line with the total RPC duration for post-mortem latency analysis.
 func spawnViaDaemon(command string, args []string, cwd, mode string, env map[string]string, logger *log.Logger) (string, string, error) {
 	ctlPath := serverid.DaemonControlPath("", "")
 
 	// Spawn returns immediately after creating the owner — proactive init runs
 	// in background. 30s timeout covers daemon processing + upstream process start.
+	rpcStart := time.Now()
 	resp, err := control.SendWithTimeout(ctlPath, control.Request{
 		Cmd:     "spawn",
 		Command: command,
@@ -214,14 +257,18 @@ func spawnViaDaemon(command string, args []string, cwd, mode string, env map[str
 		Mode:    mode,
 		Env:     env,
 	}, 30*time.Second)
+	rpcDur := time.Since(rpcStart)
 	if err != nil {
+		logger.Printf("daemon_rpc_spawn status=error duration=%v err=%v", rpcDur, err)
 		return "", "", fmt.Errorf("spawn via daemon: %w", err)
 	}
 	if !resp.OK {
+		logger.Printf("daemon_rpc_spawn status=not_ok duration=%v msg=%q", rpcDur, resp.Message)
 		return "", "", fmt.Errorf("daemon spawn failed: %s", resp.Message)
 	}
 
-	logger.Printf("daemon spawned server %s at %s", resp.ServerID[:8], resp.IPCPath)
+	logger.Printf("daemon_rpc_spawn status=ok duration=%v server=%s ipc=%s",
+		rpcDur, resp.ServerID[:8], resp.IPCPath)
 	return resp.IPCPath, resp.Token, nil
 }
 

--- a/cmd/mcp-mux/main.go
+++ b/cmd/mcp-mux/main.go
@@ -126,6 +126,10 @@ func main() {
 		logger = log.New(os.Stderr, fmt.Sprintf("[mcp-mux:%s] ", sid[:8]), log.LstdFlags)
 	}
 
+	// Startup-time diagnostic: measure total shim startup so the
+	// per-server jsonl can show slow/hung sessions at a glance.
+	shimStart := time.Now()
+
 	// In isolated mode, always become owner (skip IPC check)
 	if *isolated {
 		logger.Printf("isolated mode: starting dedicated upstream")
@@ -133,29 +137,47 @@ func main() {
 		return
 	}
 
-	// Fast path: per-server IPC socket exists → connect as client (works with both legacy and daemon)
-	if ipc.IsAvailable(ipcPath) {
-		logger.Printf("connecting to existing owner at %s", ipcPath)
+	// Fast path: per-server IPC socket exists → connect as client (works with both legacy and daemon).
+	// Log the probe result + duration so post-mortem can distinguish fast-path hits from misses.
+	ipcProbeStart := time.Now()
+	ipcAvail := ipc.IsAvailable(ipcPath)
+	logger.Printf("shim startup step=ipc_probe result=%v duration=%v path=%s",
+		ipcAvail, time.Since(ipcProbeStart), ipcPath)
+	if ipcAvail {
+		runClientStart := time.Now()
+		logger.Printf("shim startup step=run_client_begin target=existing_owner path=%s", ipcPath)
 		if err := owner.RunClient(ipcPath, os.Stdin, os.Stdout); err != nil {
-			logger.Printf("client error: %v", err)
+			logger.Printf("shim startup step=run_client_end status=error duration=%v err=%v total=%v",
+				time.Since(runClientStart), err, time.Since(shimStart))
 			os.Exit(1)
 		}
+		logger.Printf("shim startup step=run_client_end status=ok duration=%v total=%v (stdin closed)",
+			time.Since(runClientStart), time.Since(shimStart))
 		return
 	}
 
 	// Daemon mode (default): shim → daemon → spawn → connect
 	// Disable with MCP_MUX_NO_DAEMON=1 to fall back to legacy per-session owner.
 	if os.Getenv("MCP_MUX_NO_DAEMON") != "1" {
+		ensureStart := time.Now()
 		if err := ensureDaemon(logger); err != nil {
-			logger.Printf("daemon unavailable: %v, falling back to legacy owner", err)
+			logger.Printf("shim startup step=ensure_daemon status=error duration=%v err=%v (falling back to legacy owner)",
+				time.Since(ensureStart), err)
 		} else {
+			logger.Printf("shim startup step=ensure_daemon status=ok duration=%v",
+				time.Since(ensureStart))
 			modeStr := string(mode)
 			shimEnv := collectEnv()
+			spawnStart := time.Now()
 			daemonIPC, daemonToken, err := spawnViaDaemon(command, cmdArgs, cwd, modeStr, shimEnv, logger)
 			if err != nil {
-				logger.Printf("daemon spawn failed: %v, falling back to legacy owner", err)
+				logger.Printf("shim startup step=daemon_spawn status=error duration=%v err=%v (falling back to legacy owner)",
+					time.Since(spawnStart), err)
 			} else {
-				logger.Printf("connecting via daemon to %s (resilient)", daemonIPC)
+				logger.Printf("shim startup step=daemon_spawn status=ok duration=%v ipc=%s",
+					time.Since(spawnStart), daemonIPC)
+				logger.Printf("shim startup step=resilient_begin path=%s total_before_client=%v",
+					daemonIPC, time.Since(shimStart))
 				reconnectFn := func() (string, string, error) {
 					// Retry ensureDaemon with jitter to avoid thundering herd.
 					// Multiple shims reconnecting simultaneously compete for lock;
@@ -168,6 +190,7 @@ func main() {
 					}
 					return spawnViaDaemon(command, cmdArgs, cwd, modeStr, shimEnv, logger)
 				}
+				resilientStart := time.Now()
 				if err := owner.RunResilientClient(owner.ResilientClientConfig{
 					Stdin:          os.Stdin,
 					Stdout:         os.Stdout,
@@ -176,9 +199,12 @@ func main() {
 					Reconnect:      reconnectFn,
 					Logger:         logger,
 				}); err != nil {
-					logger.Printf("client error: %v", err)
+					logger.Printf("shim startup step=resilient_end status=error duration=%v err=%v total=%v",
+						time.Since(resilientStart), err, time.Since(shimStart))
 					os.Exit(1)
 				}
+				logger.Printf("shim startup step=resilient_end status=ok duration=%v total=%v (session ended cleanly)",
+					time.Since(resilientStart), time.Since(shimStart))
 				return
 			}
 		}

--- a/cmd/mcp-mux/main.go
+++ b/cmd/mcp-mux/main.go
@@ -139,19 +139,21 @@ func main() {
 
 	// Fast path: per-server IPC socket exists → connect as client (works with both legacy and daemon).
 	// Log the probe result + duration so post-mortem can distinguish fast-path hits from misses.
+	// Uses %q for path (may contain spaces/quotes on Windows) and %q for err
+	// so grep/awk over the jsonl parses reliably.
 	ipcProbeStart := time.Now()
 	ipcAvail := ipc.IsAvailable(ipcPath)
-	logger.Printf("shim startup step=ipc_probe result=%v duration=%v path=%s",
+	logger.Printf("shim startup step=ipc_probe result=%v duration=%v path=%q",
 		ipcAvail, time.Since(ipcProbeStart), ipcPath)
 	if ipcAvail {
 		runClientStart := time.Now()
-		logger.Printf("shim startup step=run_client_begin target=existing_owner path=%s", ipcPath)
+		logger.Printf("shim startup step=run_client_begin target=existing_owner path=%q", ipcPath)
 		if err := owner.RunClient(ipcPath, os.Stdin, os.Stdout); err != nil {
-			logger.Printf("shim startup step=run_client_end status=error duration=%v err=%v total=%v",
-				time.Since(runClientStart), err, time.Since(shimStart))
+			logger.Printf("shim startup step=run_client_end status=error duration=%v err=%q total=%v",
+				time.Since(runClientStart), err.Error(), time.Since(shimStart))
 			os.Exit(1)
 		}
-		logger.Printf("shim startup step=run_client_end status=ok duration=%v total=%v (stdin closed)",
+		logger.Printf("shim startup step=run_client_end status=ok duration=%v total=%v reason=stdin_closed",
 			time.Since(runClientStart), time.Since(shimStart))
 		return
 	}
@@ -161,8 +163,8 @@ func main() {
 	if os.Getenv("MCP_MUX_NO_DAEMON") != "1" {
 		ensureStart := time.Now()
 		if err := ensureDaemon(logger); err != nil {
-			logger.Printf("shim startup step=ensure_daemon status=error duration=%v err=%v (falling back to legacy owner)",
-				time.Since(ensureStart), err)
+			logger.Printf("shim startup step=ensure_daemon status=error duration=%v err=%q fallback=legacy_owner",
+				time.Since(ensureStart), err.Error())
 		} else {
 			logger.Printf("shim startup step=ensure_daemon status=ok duration=%v",
 				time.Since(ensureStart))
@@ -171,12 +173,12 @@ func main() {
 			spawnStart := time.Now()
 			daemonIPC, daemonToken, err := spawnViaDaemon(command, cmdArgs, cwd, modeStr, shimEnv, logger)
 			if err != nil {
-				logger.Printf("shim startup step=daemon_spawn status=error duration=%v err=%v (falling back to legacy owner)",
-					time.Since(spawnStart), err)
+				logger.Printf("shim startup step=daemon_spawn status=error duration=%v err=%q fallback=legacy_owner",
+					time.Since(spawnStart), err.Error())
 			} else {
-				logger.Printf("shim startup step=daemon_spawn status=ok duration=%v ipc=%s",
+				logger.Printf("shim startup step=daemon_spawn status=ok duration=%v ipc=%q",
 					time.Since(spawnStart), daemonIPC)
-				logger.Printf("shim startup step=resilient_begin path=%s total_before_client=%v",
+				logger.Printf("shim startup step=resilient_begin path=%q total_before_client=%v",
 					daemonIPC, time.Since(shimStart))
 				reconnectFn := func() (string, string, error) {
 					// Retry ensureDaemon with jitter to avoid thundering herd.
@@ -199,11 +201,11 @@ func main() {
 					Reconnect:      reconnectFn,
 					Logger:         logger,
 				}); err != nil {
-					logger.Printf("shim startup step=resilient_end status=error duration=%v err=%v total=%v",
-						time.Since(resilientStart), err, time.Since(shimStart))
+					logger.Printf("shim startup step=resilient_end status=error duration=%v err=%q total=%v",
+						time.Since(resilientStart), err.Error(), time.Since(shimStart))
 					os.Exit(1)
 				}
-				logger.Printf("shim startup step=resilient_end status=ok duration=%v total=%v (session ended cleanly)",
+				logger.Printf("shim startup step=resilient_end status=ok duration=%v total=%v reason=session_ended",
 					time.Since(resilientStart), time.Since(shimStart))
 				return
 			}


### PR DESCRIPTION
## Summary
Pure observability PR — no behaviour change. Adds timing-instrumented log lines across the shim startup path so the per-server CC `mcp-logs` jsonl can be post-analysed when a server flips to `failed` in the `/mcp` UI.

## Motivation
User reports: *"serena, pr, cclsp, aimux постоянно failed в сессиях и требуют ручного реконнекта"*. Current logs only capture `Connection established` on success — no duration, no substep timings, no observable state when the shim exits quickly or takes unusually long. In investigation, every log line showed `Successfully connected` yet the `/mcp` UI sometimes reports the same servers as failed. Without timing and substep status we cannot tell which failure path fires.

## Hypotheses this will let us distinguish

| Hypothesis | Expected log signature |
|---|---|
| Stale `ipc.IsAvailable` → RunClient exits immediately | `run_client_end status=error duration=<tiny>` |
| ensureDaemon lock contention → wait-for-other-shim times out | `wait_for_other_shim status=error` |
| Slow upstream cold start (uvx/npx download) | `daemon_rpc_spawn duration>5s` |
| Daemon process stuck binding control socket | `daemon did not start within 10s (polls=100)` |
| System freeze (ticker never fires) | `daemon did not start within 10s (polls=0)` |

## New log markers

### main.go — shim entry flow
- `shim startup step=ipc_probe result=<bool> duration=<dur> path=<ipc>`
- `shim startup step=run_client_{begin|end} status=<ok|error> duration=<dur> total=<dur>`
- `shim startup step=ensure_daemon status=<ok|error> duration=<dur>`
- `shim startup step=daemon_spawn status=<ok|error> duration=<dur> ipc=<path>`
- `shim startup step=resilient_{begin|end} status=<ok|error> duration=<dur> total=<dur>`

### daemon.go — ensureDaemon substeps
- `ensure_daemon substep=fast_ping status=<ok|miss> duration=<dur>`
- `ensure_daemon substep=lock_attempt status=<acquired|contended> duration=<dur>`
- `ensure_daemon substep=wait_for_other_shim status=<ok|error> duration=<dur>`
- `ensure_daemon substep=lock_recheck status=<already_running|still_missing> duration=<dur>`
- `ensure_daemon substep=spawn_process status=<ok|error> duration=<dur>`
- `ensure_daemon substep=wait_for_self status=<ok|timeout> duration=<dur>`

### daemon.go — spawnViaDaemon
- `daemon_rpc_spawn status=<ok|error|not_ok> duration=<dur> server=<sid> ipc=<path>` (replaces the older unstructured `daemon spawned server` line)

### waitForDaemon
- Timeout error now includes poll count: `daemon did not start within 10s (polls=100)`. Polls=0 means the 100ms ticker never fired (system freeze); polls=100 means daemon was slow to bind the socket.

## Verification
- `go build ./...` — clean
- `go vet ./...` — clean
- `go test -count=1 ./...` (root) — `internal/mcpserver` green
- `go test -count=1 ./...` (muxcore) — all 18 packages green
- No existing log assertions regressed (new lines additive, old structured `[mcp-mux:<sid>] connecting to existing owner` replaced by new structured form in the daemon path; tests do not depend on the exact text)

## Rollout plan
1. PR review via pr-reviewer subagent
2. Merge to master
3. Rebuild mcp-mux.exe, deploy via `mcp-mux upgrade --restart`
4. Wait for next failed-state reproduction — read shim timeline directly from `mcp-logs-<server>/*.jsonl`

## What it is NOT
Not a fix. Not a perf change. Not a protocol change. Just turning on the lights so the next debug session has data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Улучшения**
  * Расширена диагностика и детальное измерение времени каждого этапа инициализации демона (проба IPC, проверка/соперничество за блокировку, повторная проверка, запуск и ожидание готовности).
  * Добавлены структурированные лог-записи для фаз быстрого пути, запуска через демон и устойчивого подключения клиента с метриками длительности.
  * Сообщения об ошибках ожидания содержат число попыток опроса и длительности.
* **Исправления**
  * Избежание потенциальной ошибки при усечении идентификатора сервера; улучшена обработка тайм-аутов и логирование ожидания других шимов.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->