### PR TITLE
fix(test): poll for async progress notification delivery + add muxcore to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,11 @@ jobs:
           go-version: "1.25"
       - run: go vet ./...
       - run: go test -race -count=1 -timeout 120s ./...
+      - name: muxcore module
+        working-directory: muxcore
+        run: |
+          go vet ./...
+          go test -race -count=1 -timeout 180s ./...
 
   coverage:
     runs-on: ubuntu-latest
@@ -28,6 +33,9 @@ jobs:
         with:
           go-version: "1.25"
       - run: go test -race -coverprofile=coverage.out ./...
+      - name: muxcore coverage
+        working-directory: muxcore
+        run: go test -race -coverprofile=coverage.out ./...
       - uses: codecov/codecov-action@v4
         with:
           files: coverage.out

--- a/muxcore/owner/coverage_test.go
+++ b/muxcore/owner/coverage_test.go
@@ -813,10 +813,19 @@ func TestRouteProgressNotification_Routed(t *testing.T) {
 		t.Errorf("routeProgressNotification: %v", err)
 	}
 
-	got := buf.String()
-	if !strings.Contains(got, "tok-1") {
-		t.Errorf("expected progress notification routed to session, got: %s", got)
+	// routeProgressNotification dispatches via session.SendNotification, which
+	// is async (queues to notifCh, drained by the session's writer goroutine).
+	// Poll the buffer with a short deadline instead of reading immediately.
+	deadline := time.Now().Add(1 * time.Second)
+	var got string
+	for time.Now().Before(deadline) {
+		got = buf.String()
+		if strings.Contains(got, "tok-1") {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
+	t.Errorf("expected progress notification routed to session within 1s, got: %q", got)
 }
 
 func TestRouteProgressNotification_NoOwner(t *testing.T) {


### PR DESCRIPTION
## Summary

Post-merge follow-up for PR #61. Two fixes:

1. **Fix `TestRouteProgressNotification_Routed` race.** Since PR #61,
   `routeProgressNotification` dispatches via `session.SendNotification`
   (async queue → notifier goroutine) instead of a synchronous
   `WriteRaw` call — this was Gemini's medium-severity finding on
   PR #61 and the right fix for the "upstream reader can stall for
   30s on a slow client" concern. But the existing test reads
   `buf.String()` immediately, before the notifier goroutine has
   had a chance to write. Locally, the test fails ~100% of the
   time on master. Poll with a 1s deadline to match the async
   contract.

2. **Add muxcore to CI.** The repo has two Go modules: the root
   module (`cmd/mcp-mux`, `internal/...`) and `muxcore/`. `go test
   ./...` from the repo root does **not** descend into nested
   modules, so the muxcore tests have never actually run on CI —
   which is how the regression above slipped past three green
   OS checks on PR #61. Add an explicit step that runs `go vet`
   and `go test -race` inside `muxcore/`.

## Verification

```
cd D:\Dev\mcp-mux\muxcore && go test -count=1 -timeout 180s ./...
ok  	github.com/thebtf/mcp-mux/muxcore                 0.245s
ok  	github.com/thebtf/mcp-mux/muxcore/busy            0.254s
...
ok  	github.com/thebtf/mcp-mux/muxcore/owner          18.446s
...
ok  	github.com/thebtf/mcp-mux/muxcore/upstream        1.030s
```

No race runs locally (no gcc on Windows box), but `-race` enabled in the new CI step.

## Scope

- `muxcore/owner/coverage_test.go` — poll buf with bounded deadline
- `.github/workflows/ci.yml` — new muxcore step in test + coverage jobs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Тестирование**
  * Добавлены дополнительные шаги проверки качества кода в процесс непрерывной интеграции.
  * Расширено покрытие тестами основных компонентов системы.
  * Улучшена надежность тестов для асинхронных операций.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->