### PR TITLE
fix(reconnect): remove spec-violating mux-reconnect keepalive + add muxcore to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,10 @@ jobs:
         run: go test -coverprofile=coverage.out -count=1 -timeout 180s ./...
       - uses: codecov/codecov-action@v4
         with:
-          files: coverage.out
+          # codecov-action@v4: `files` is a comma-separated explicit list.
+          # Include the muxcore module's profile so coverage from the nested
+          # Go module is uploaded alongside the root profile (CodeRabbit major
+          # finding on PR #63).
+          files: coverage.out,muxcore/coverage.out
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,14 @@ jobs:
       - run: go test -race -coverprofile=coverage.out ./...
       - name: muxcore coverage
         working-directory: muxcore
-        run: go test -race -coverprofile=coverage.out ./...
+        # Note: no -race here. The test matrix (ubuntu/windows/macos) already
+        # exercises the race detector across all muxcore packages, so the
+        # coverage job only needs the coverage profile. Adding -race here
+        # double-serialises the tests and made TestOwnerStatusWithClassification-
+        # Reason flake on slow CI runners (upstream spawn racing the priming
+        # writes) — not a product bug, just coverage + race + timing amplifying
+        # each other.
+        run: go test -coverprofile=coverage.out -count=1 -timeout 180s ./...
       - uses: codecov/codecov-action@v4
         with:
           files: coverage.out

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,11 @@ jobs:
           go-version: "1.25"
       - run: go vet ./...
       - run: go test -race -count=1 -timeout 120s ./...
+      - name: muxcore module
+        working-directory: muxcore
+        run: |
+          go vet ./...
+          go test -race -count=1 -timeout 180s ./...
 
   coverage:
     runs-on: ubuntu-latest
@@ -28,6 +33,9 @@ jobs:
         with:
           go-version: "1.25"
       - run: go test -race -coverprofile=coverage.out ./...
+      - name: muxcore coverage
+        working-directory: muxcore
+        run: go test -race -coverprofile=coverage.out ./...
       - uses: codecov/codecov-action@v4
         with:
           files: coverage.out

--- a/muxcore/owner/coverage_test.go
+++ b/muxcore/owner/coverage_test.go
@@ -813,10 +813,19 @@ func TestRouteProgressNotification_Routed(t *testing.T) {
 		t.Errorf("routeProgressNotification: %v", err)
 	}
 
-	got := buf.String()
-	if !strings.Contains(got, "tok-1") {
-		t.Errorf("expected progress notification routed to session, got: %s", got)
+	// routeProgressNotification dispatches via session.SendNotification, which
+	// is async (queues to notifCh, drained by the session's writer goroutine).
+	// Poll the buffer with a short deadline instead of reading immediately.
+	deadline := time.Now().Add(1 * time.Second)
+	var got string
+	for time.Now().Before(deadline) {
+		got = buf.String()
+		if strings.Contains(got, "tok-1") {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
+	t.Errorf("expected progress notification routed to session within 1s, got: %q", got)
 }
 
 func TestRouteProgressNotification_NoOwner(t *testing.T) {

--- a/muxcore/owner/dispatch_test.go
+++ b/muxcore/owner/dispatch_test.go
@@ -330,13 +330,8 @@ func TestDispatchToSessionHandler_Timeout(t *testing.T) {
 		},
 	}
 	o := newDispatchOwner(mock)
-	// Timeout chosen to be comfortably larger than -race scheduler jitter on
-	// slow CI runners while still an order of magnitude below the 5-second
-	// handler budget (which this test asserts must NOT elapse). Earlier value
-	// of 100ms was flaky on ubuntu/macos under -race because the
-	// context-cancellation-and-error-emit path could exceed 100ms of wall
-	// clock when contending with the race detector's serialisation overhead.
-	o.toolTimeoutNs.Store(int64(500 * time.Millisecond))
+	// Set 100 ms timeout.
+	o.toolTimeoutNs.Store(int64(100 * time.Millisecond))
 
 	sess, buf := newTestSession("/project-timeout")
 	defer sess.Close()

--- a/muxcore/owner/dispatch_test.go
+++ b/muxcore/owner/dispatch_test.go
@@ -330,8 +330,13 @@ func TestDispatchToSessionHandler_Timeout(t *testing.T) {
 		},
 	}
 	o := newDispatchOwner(mock)
-	// Set 100 ms timeout.
-	o.toolTimeoutNs.Store(int64(100 * time.Millisecond))
+	// Timeout chosen to be comfortably larger than -race scheduler jitter on
+	// slow CI runners while still an order of magnitude below the 5-second
+	// handler budget (which this test asserts must NOT elapse). Earlier value
+	// of 100ms was flaky on ubuntu/macos under -race because the
+	// context-cancellation-and-error-emit path could exceed 100ms of wall
+	// clock when contending with the race detector's serialisation overhead.
+	o.toolTimeoutNs.Store(int64(500 * time.Millisecond))
 
 	sess, buf := newTestSession("/project-timeout")
 	defer sess.Close()

--- a/muxcore/owner/owner.go
+++ b/muxcore/owner/owner.go
@@ -867,9 +867,24 @@ func (o *Owner) dispatchToSessionHandler(s *Session, msg *jsonrpc.Message) error
 			}
 		}()
 
-		// Build context: cancel on session disconnect or owner shutdown
+		// Build context: cancel on session disconnect or owner shutdown, and
+		// optionally apply the per-call tool timeout. The WithTimeout wrapping
+		// MUST happen before the watcher goroutine is spawned — otherwise the
+		// goroutine captures the outer ctx and races the parent's ctx
+		// reassignment on the `ctx, timeoutCancel = context.WithTimeout(...)`
+		// line (caught by -race as a data race on the ctx variable,
+		// dispatch_test.go:TestDispatchToSessionHandler_Timeout on CI).
+		// The semantic bug is real too: if toolTimeout fires before s.Done()
+		// or o.done, the watcher is still blocking on the OLD ctx.Done() and
+		// leaks until one of the other two triggers.
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+
+		if timeout := o.toolTimeoutNs.Load(); timeout > 0 {
+			var timeoutCancel context.CancelFunc
+			ctx, timeoutCancel = context.WithTimeout(ctx, time.Duration(timeout))
+			defer timeoutCancel()
+		}
 
 		go func() {
 			select {
@@ -880,13 +895,6 @@ func (o *Owner) dispatchToSessionHandler(s *Session, msg *jsonrpc.Message) error
 			case <-ctx.Done():
 			}
 		}()
-
-		// Apply toolTimeout deadline if configured
-		if timeout := o.toolTimeoutNs.Load(); timeout > 0 {
-			var timeoutCancel context.CancelFunc
-			ctx, timeoutCancel = context.WithTimeout(ctx, time.Duration(timeout))
-			defer timeoutCancel()
-		}
 
 		resp, err := o.sessionHandler.HandleRequest(ctx, project, msg.Raw)
 		if err != nil {

--- a/muxcore/owner/resilient_client.go
+++ b/muxcore/owner/resilient_client.go
@@ -16,11 +16,10 @@ import (
 )
 
 const (
-	defaultReconnectTimeout  = 30 * time.Second
-	defaultKeepaliveInterval = 5 * time.Second
-	reconnectPollInterval    = 500 * time.Millisecond
-	msgFromCCBufferSize      = 1000
-	msgFromIPCBufferSize     = 1000
+	defaultReconnectTimeout = 30 * time.Second
+	reconnectPollInterval   = 500 * time.Millisecond
+	msgFromCCBufferSize     = 1000
+	msgFromIPCBufferSize    = 1000
 )
 
 // ReconnectFunc reconnects to the daemon and returns the new IPC path and handshake token.
@@ -30,15 +29,23 @@ type ReconnectFunc func() (ipcPath string, token string, err error)
 
 // ResilientClientConfig configures the resilient shim proxy.
 type ResilientClientConfig struct {
-	Stdin             io.Reader
-	Stdout            io.Writer
-	InitialIPCPath    string
-	Token             string        // handshake token from initial spawn; sent to owner on connect
-	Reconnect         ReconnectFunc
-	ReconnectTimeout  time.Duration // default: 30s
-	KeepaliveInterval time.Duration // default: 5s
-	ProbeGracePeriod  time.Duration // default: 10s; 0 disables probe detection
-	Logger            *log.Logger
+	Stdin            io.Reader
+	Stdout           io.Writer
+	InitialIPCPath   string
+	Token            string // handshake token from initial spawn; sent to owner on connect
+	Reconnect        ReconnectFunc
+	ReconnectTimeout time.Duration // default: 30s
+
+	// KeepaliveInterval is no longer used. Previous revisions emitted a
+	// synthetic notifications/progress with progressToken="mux-reconnect"
+	// every KeepaliveInterval during reconnect. That violated the MCP spec
+	// (Claude Code tears down the stdio transport on unknown progress
+	// tokens). The field is kept for API compatibility with v0.19.x
+	// consumers (aimux, engram); setting it has no effect.
+	KeepaliveInterval time.Duration
+
+	ProbeGracePeriod time.Duration // default: 10s; 0 disables probe detection
+	Logger           *log.Logger
 }
 
 // initCache stores the first initialize request and response for replay on reconnect.
@@ -76,16 +83,13 @@ var ErrReconnectExit = errors.New("reconnect: exit for fresh handshake")
 // State machine:
 //
 //	CONNECTED     — normal proxy: stdin→IPC, IPC→stdout
-//	RECONNECTING  — IPC broken; buffer stdin, keepalive to stdout, poll Reconnect()
+//	RECONNECTING  — IPC broken; buffer stdin, tombstone inflight, poll Reconnect()
 //	EXIT          — reconnect timed out; return error
 //
 // Returns only on: CC stdin EOF (io.EOF), or reconnect timeout (error).
 func RunResilientClient(cfg ResilientClientConfig) error {
 	if cfg.ReconnectTimeout == 0 {
 		cfg.ReconnectTimeout = defaultReconnectTimeout
-	}
-	if cfg.KeepaliveInterval == 0 {
-		cfg.KeepaliveInterval = defaultKeepaliveInterval
 	}
 	if cfg.ProbeGracePeriod == 0 {
 		cfg.ProbeGracePeriod = 10 * time.Second
@@ -342,26 +346,43 @@ type reconnectResult struct {
 	err   error
 }
 
-// reconnect enters the RECONNECTING state: polls cfg.Reconnect every 500ms
-// (asynchronously so the select loop stays responsive), sends keepalive to
-// CC stdout every KeepaliveInterval, and buffers CC stdin via msgFromCC.
+// reconnect enters the RECONNECTING state: immediately tombstones every
+// in-flight request with an RPC error response (so CC does not hang), polls
+// cfg.Reconnect every 500ms asynchronously, and buffers new CC stdin traffic
+// via msgFromCC.
 //
 // On success: dials new IPC, replays cached initialize, flushes buffered
 // CC messages, and returns the new connection.
 //
 // Returns error on: reconnect timeout, or CC stdin EOF during reconnect.
+//
+// Why no keepalive: a previous revision emitted a synthetic
+// notifications/progress with progressToken="mux-reconnect" every 5s as a
+// "stay alive" signal to CC. That violated the MCP spec — progressTokens
+// must reference a _meta.progressToken the client issued, and Claude Code
+// enforces this by tearing down the stdio transport the moment it sees an
+// unknown token ("Received a progress notification for an unknown token").
+// The keepalive therefore guaranteed that every reconnect window longer
+// than KeepaliveInterval destroyed the transport it was trying to preserve.
+// CC's stdio transport does NOT time out on silence — it times out on
+// unanswered requests. Draining the in-flight map with error responses
+// below is the spec-compliant substitute.
 func (rc *resilientClient) reconnect(stdoutMu *sync.Mutex, stdinDone <-chan error) (interface {
 	io.Reader
 	io.Writer
 	io.Closer
 }, error) {
+	// Send error responses for every request that was in-flight when the IPC
+	// died, BEFORE we start the poll loop. Without this, CC waits on each
+	// request until its own timeout (tens of seconds) and marks the transport
+	// broken when it fires — even though the reconnect itself would have
+	// succeeded in under a second.
+	rc.drainOrphanedInflight(stdoutMu)
+
 	deadline := time.Now().Add(rc.cfg.ReconnectTimeout)
-	keepaliveTicker := time.NewTicker(rc.cfg.KeepaliveInterval)
 	pollTicker := time.NewTicker(reconnectPollInterval)
-	defer keepaliveTicker.Stop()
 	defer pollTicker.Stop()
 
-	keepaliveN := 0
 	resultCh := make(chan reconnectResult, 1)
 	pending := false // true when an async Reconnect() call is in-flight
 
@@ -377,22 +398,6 @@ func (rc *resilientClient) reconnect(stdoutMu *sync.Mutex, stdinDone <-chan erro
 				return nil, io.EOF
 			}
 			return nil, fmt.Errorf("resilient: stdin during reconnect: %w", err)
-
-		case <-keepaliveTicker.C:
-			keepaliveN++
-			ka := fmt.Sprintf(
-				`{"jsonrpc":"2.0","method":"notifications/progress","params":{"progressToken":"mux-reconnect","progress":%d,"total":100}}`,
-				keepaliveN,
-			)
-			stdoutMu.Lock()
-			_, err := fmt.Fprintf(rc.cfg.Stdout, "%s\n", ka)
-			stdoutMu.Unlock()
-			if err != nil {
-				// CC stdout broken pipe — CC is gone, exit to prevent zombie shim.
-				rc.log.Printf("resilient: keepalive write failed (CC gone): %v", err)
-				return nil, fmt.Errorf("resilient: CC stdout closed")
-			}
-			rc.log.Printf("resilient: sent keepalive %d", keepaliveN)
 
 		case <-pollTicker.C:
 			if pending {
@@ -434,11 +439,6 @@ func (rc *resilientClient) reconnect(stdoutMu *sync.Mutex, stdinDone <-chan erro
 				conn.Close()
 				continue
 			}
-
-			// Send error responses for in-flight requests that were lost
-			// when the old IPC connection died. Without this, CC waits
-			// forever for responses that will never come.
-			rc.drainOrphanedInflight(stdoutMu)
 
 			// Flush buffered CC messages that arrived during RECONNECTING.
 			rc.flushBuffer(conn)

--- a/muxcore/owner/resilient_client_test.go
+++ b/muxcore/owner/resilient_client_test.go
@@ -417,10 +417,21 @@ func TestResilientClient_TimeoutExits(t *testing.T) {
 	_ = ccStdinW
 }
 
-// TestResilientClient_KeepaliveEmitted verifies that during RECONNECTING state,
-// keepalive notifications are written to CC stdout at the configured interval,
-// and stop after reconnect succeeds.
-func TestResilientClient_KeepaliveEmitted(t *testing.T) {
+// TestResilientClient_NoMuxReconnectKeepalive is a regression test for the
+// "Received a progress notification for an unknown token" transport tear-down
+// symptom. Earlier revisions of resilient_client.reconnect emitted a synthetic
+// notifications/progress with progressToken="mux-reconnect" every few seconds
+// during the RECONNECTING state. The MCP spec requires progressTokens to
+// reference a _meta.progressToken previously issued by the client — Claude
+// Code enforces this by closing the stdio transport as soon as it sees an
+// unknown token. The keepalive therefore guaranteed that every real reconnect
+// window killed the very transport it was trying to preserve.
+//
+// No progress notification with progressToken="mux-reconnect" (or any other
+// shim-invented token) MUST ever be written to CC stdout — not during
+// reconnect, not after, not ever. CC stdio stays healthy via request timeouts,
+// so drainOrphanedInflight below is the spec-compliant substitute.
+func TestResilientClient_NoMuxReconnectKeepalive(t *testing.T) {
 	path1 := newTestIPCPath(t)
 	path2 := newTestIPCPath(t)
 
@@ -430,22 +441,26 @@ func TestResilientClient_KeepaliveEmitted(t *testing.T) {
 	ccStdinR, ccStdinW := io.Pipe()
 	ccStdoutR, ccStdoutW := io.Pipe()
 
+	// Reconnect takes long enough that the OLD keepalive ticker would have
+	// fired several times — so if any keepalive logic sneaks back in, the
+	// test catches it.
 	reconnectDelay := 3 * time.Second
 	reconnectFn := func() (string, string, error) {
 		time.Sleep(reconnectDelay)
 		return path2, "", nil
 	}
 
-	const keepaliveInterval = 800 * time.Millisecond
-
 	cfg := ResilientClientConfig{
 		ProbeGracePeriod: time.Nanosecond,
-		Stdin:             ccStdinR,
-		Stdout:            ccStdoutW,
-		InitialIPCPath:    path1,
-		Reconnect:         reconnectFn,
-		ReconnectTimeout:  15 * time.Second,
-		KeepaliveInterval: keepaliveInterval,
+		Stdin:            ccStdinR,
+		Stdout:           ccStdoutW,
+		InitialIPCPath:   path1,
+		Reconnect:        reconnectFn,
+		ReconnectTimeout: 15 * time.Second,
+		// Non-zero KeepaliveInterval to prove it is genuinely a no-op:
+		// a consumer on v0.19.x muxcore can still pass this value without
+		// triggering spec-violating output.
+		KeepaliveInterval: 200 * time.Millisecond,
 		Logger:            resilientTestLogger(t),
 	}
 
@@ -454,7 +469,6 @@ func TestResilientClient_KeepaliveEmitted(t *testing.T) {
 		errCh <- RunResilientClient(cfg)
 	}()
 
-	// Collect all lines from CC stdout.
 	var mu sync.Mutex
 	var stdoutLines []string
 	go func() {
@@ -467,48 +481,25 @@ func TestResilientClient_KeepaliveEmitted(t *testing.T) {
 		}
 	}()
 
-	// Let client connect then close IPC.
+	// Let the client connect, then kill the IPC to trigger reconnect.
 	time.Sleep(200 * time.Millisecond)
 	srv1.closeAll()
 
-	// Wait for reconnect to complete (reconnectDelay + grace).
+	// Wait past the point where legacy keepalives would have fired multiple
+	// times (reconnectDelay + generous grace for post-reconnect stabilisation).
 	time.Sleep(reconnectDelay + 2*time.Second)
 
-	// Count keepalive messages.
 	mu.Lock()
 	lines := make([]string, len(stdoutLines))
 	copy(lines, stdoutLines)
 	mu.Unlock()
 
-	keepaliveCount := 0
 	for _, line := range lines {
-		if strings.Contains(line, "mux-reconnect") {
-			keepaliveCount++
+		if strings.Contains(line, `"progressToken":"mux-reconnect"`) ||
+			strings.Contains(line, `"mux-reconnect"`) {
+			t.Errorf("shim emitted forbidden mux-reconnect keepalive: %q", line)
 		}
 	}
-
-	// With reconnectDelay=3s and interval=800ms, expect at least 2 keepalives.
-	if keepaliveCount < 2 {
-		t.Errorf("expected >= 2 keepalive messages, got %d (lines: %v)", keepaliveCount, lines)
-	}
-	t.Logf("keepalive count: %d", keepaliveCount)
-
-	// After reconnect, send a normal message and verify no more keepalives.
-	time.Sleep(2 * keepaliveInterval)
-
-	mu.Lock()
-	countAfter := 0
-	linesAfter := len(stdoutLines)
-	for _, line := range stdoutLines {
-		if strings.Contains(line, "mux-reconnect") {
-			countAfter++
-		}
-	}
-	mu.Unlock()
-
-	_ = linesAfter
-	t.Logf("keepalive count after reconnect stabilized: %d", countAfter)
-	// Keepalives should not continue growing significantly after reconnect.
 
 	ccStdinW.Close()
 	select {

--- a/muxcore/serverid/serverid_test.go
+++ b/muxcore/serverid/serverid_test.go
@@ -73,8 +73,20 @@ func TestLockPath(t *testing.T) {
 func TestIPCPath_EmptyBaseDir(t *testing.T) {
 	path := IPCPath("abc123", "")
 	tmpDir := os.TempDir()
-	if filepath.Dir(path) != tmpDir {
-		t.Errorf("IPCPath with empty baseDir: got dir %q, want os.TempDir() %q", filepath.Dir(path), tmpDir)
+	// macOS: os.TempDir() returns the /var/folders/... alias while the value
+	// that reaches the socket path may be resolved through /private/... —
+	// semantically the same directory, textually different. Normalise both
+	// sides via EvalSymlinks before comparing so the test works on darwin
+	// the same way it does on linux and windows.
+	gotDir := filepath.Dir(path)
+	if resolved, err := filepath.EvalSymlinks(gotDir); err == nil {
+		gotDir = resolved
+	}
+	if resolved, err := filepath.EvalSymlinks(tmpDir); err == nil {
+		tmpDir = resolved
+	}
+	if gotDir != tmpDir {
+		t.Errorf("IPCPath with empty baseDir: got dir %q, want os.TempDir() %q", gotDir, tmpDir)
 	}
 }
 


### PR DESCRIPTION
## Root cause of "failed MCP servers after `mcp-mux upgrade --restart` or compaction"

Observed in the wild (from CC's own log `mcp-logs-chrome-devtools/2026-04-17...jsonl`):

```
19:18:58 STDIO connection dropped after 12862s uptime
19:18:58 Connection error: Received a progress notification for an unknown token:
         {method:notifications/progress,params:{progress:1,total:100,progressToken:mux-reconnect}}
19:18:58 Closing transport (stdio transport error: Error)
```

The shim itself was producing that notification. During `RECONNECTING`
state, `resilient_client.reconnect` was emitting a synthetic
`notifications/progress` every 5s (`KeepaliveInterval`) to CC stdout with
`progressToken="mux-reconnect"`. That violates the MCP spec — a progress
notification must reference a `_meta.progressToken` the client issued,
and Claude Code's stdio transport handler rejects unknown tokens and
closes the transport.

So every reconnect window longer than `KeepaliveInterval` **destroyed
the very transport the keepalive was trying to preserve.** After a
`mcp-mux upgrade --restart` daemon respawn, every existing shim hit this
path and CC marked the servers "failed" across every CC session — the
exact "failed + manual `/mcp` reconnect" symptom.

PR #61 fixed a *different* source of the same CC error (upstream-
originated late progress tokens with unknown IDs). This PR closes the
shim-side source.

## Fix

1. **Remove the keepalive entirely.** CC's stdio transport does not time
   out on silence — it times out on unanswered requests.
   `drainOrphanedInflight` already sends proper JSON-RPC error responses
   for every in-flight request whose IPC died; move that drain to the
   **top** of `reconnect()` so it fires immediately on IPC EOF, before
   any poll/reconnect delay. CC gets error responses inside one tick,
   transport stays healthy, fresh CC requests queue via `msgFromCC` and
   flush after reconnect.

2. **Keep `ResilientClientConfig.KeepaliveInterval`** as a deprecated
   no-op field. v0.19.x consumers (`aimux`, `engram`) that pass it still
   compile; setting it has no effect.

3. **Add `muxcore` module to CI.** The repo has two Go modules; `go test
   ./...` from the repo root does not descend into nested modules, so
   `muxcore` tests have never actually run on CI. That is how the
   regressing test from PR #61 slipped past three green OS checks.
   Supersedes PR #62 (same CI + coverage_test.go fix, bundled here).

## Regression tests

- **`TestResilientClient_NoMuxReconnectKeepalive`** drives the client
  through a 3s reconnect window and asserts that **no** line containing
  `mux-reconnect` ever reaches CC stdout, **even when
  `KeepaliveInterval` is explicitly set** — proves the field is a
  genuine no-op.
- **`TestRouteProgressNotification_Routed`** polls the buffer with a 1s
  deadline instead of a synchronous read, matching PR #61's async
  `SendNotification` contract.

## Local verification

```
cd D:\Dev\mcp-mux\muxcore && go test -count=1 ./...
ok  github.com/thebtf/mcp-mux/muxcore                 0.266s
ok  github.com/thebtf/mcp-mux/muxcore/busy            0.283s
ok  github.com/thebtf/mcp-mux/muxcore/control         5.417s
ok  github.com/thebtf/mcp-mux/muxcore/daemon         12.936s
ok  github.com/thebtf/mcp-mux/muxcore/owner          16.642s
ok  ... (18 packages)
```

## Closes

Supersedes #62. Closes the "graceful-restart breaks reconnect" regression
originally reported on PR #60 / PR #61 thread.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Исправления ошибок

* Исправлена обработка тайм-аутов контекста при отправке запросов в обработчик сессии
* Улучшена обработка незавершённых запросов при переподключении — теперь они обрабатываются в начале процесса переподключения

## Тесты

* Повышена надёжность тестов с асинхронными операциями благодаря полингу с ожиданием
* Расширена проверка GO-тестов и покрытия кода в подпапке muxcore в CI-конвейере

## Другое

* Удалено устаревшее поведение периодических уведомлений при переподключении
<!-- end of auto-generated comment: release notes by coderabbit.ai -->