### PR TITLE
fix(owner,daemon): authoritative listener liveness probe + post-restore gate

### DIFF
--- a/TECHNICAL_DEBT.md
+++ b/TECHNICAL_DEBT.md
@@ -20,3 +20,63 @@ All items from the 2026-04-08 debt batch have been resolved:
   research task. The debt entry was explicitly marked "if feasible" and
   requires CC-side investigation of MCP progress-display support. Not
   suitable for implementation without upstream protocol research.
+
+---
+
+## Open items
+
+### 2026-04-18: `upstream.Start` Wait-vs-ReadLine race (muxcore/upstream)
+
+**What:** `muxcore/upstream/process.go::Start` uses `cmd.StdoutPipe()`,
+whose docs state explicitly: *"it is incorrect to call Wait before all
+reads from the pipe have completed."* Our code violates this by running
+`proc.Wait()` in a background goroutine (to signal `Done`) while
+`ReadLine()` is invoked asynchronously by external callers. When the
+upstream exits quickly (e.g. `echo hello` in `TestStartAndClose`), `Wait`
+closes the stdout pipe before `ReadLine` has scanned it, and bufio.Scanner
+surfaces `read |0: file already closed` (os.ErrClosed).
+
+**Why deferred:** The fix requires replacing `cmd.StdoutPipe()` with
+explicit `os.Pipe()` + `cmd.Stdout = writer` so cmd.Wait no longer owns
+the reader side, OR adding a drain goroutine that copies stdout into an
+internal buffered reader before Wait returns. Both changes touch the
+production upstream spawn path and require cross-platform validation
+(procgroup wraps cmd differently on Windows vs Unix). Out of scope for
+PR #64 (zombie-listener fix).
+
+**Impact:**
+- CI flake on fast machines when a test upstream exits immediately after
+  writing stdout. Observed on `TestStartAndClose` (muxcore/upstream) and
+  `TestRespondToRootsList_WithCwd` (muxcore/owner). Rerun-pass rate ~90%.
+- In production, MCP upstreams are long-lived (server process keeps
+  running to serve tool calls) — the race is not triggerable under the
+  documented usage. The test setup using `echo` is the artificial case.
+
+**Mitigation applied in PR #64 (boy-scout):** `ReadLine` now maps
+`os.ErrClosed` → `io.EOF` so callers that read after Wait closed the pipe
+see a clean EOF instead of a misleading "file already closed" error.
+Does NOT fix the underlying race.
+
+**Files:**
+- `muxcore/upstream/process.go::Start` (line ~66-134 — Wait goroutine
+  and StdoutPipe usage)
+- `muxcore/upstream/process_test.go::TestStartAndClose` (the flaky test)
+- `muxcore/owner/coverage_test.go::TestRespondToRootsList_WithCwd` (the
+  second flake; symptom is `upstream: process closed` when mock_server
+  exits before respondToRootsList completes)
+
+**Context:** First observed on PR #63's addition of `muxcore` to CI.
+Re-surfaced on PR #64 at higher rate because the new test load (restore
+health gate sweep + three extra daemon-package tests) shifts timing on
+shared CI runners.
+
+**Proposed fix (next iteration):**
+1. Introduce `drainStdout` goroutine in `Start`: `io.Copy(internalBuf,
+   p.stdout)` with a mutex-protected deque of lines. `ReadLine` reads
+   from the deque, not directly from the pipe.
+2. Wait goroutine proceeds independently; pipe closure no longer races
+   with ReadLine because data is buffered before close.
+3. Add regression test that spawns a process which writes N lines then
+   exits immediately; assert all N lines are read.
+4. Validate on ubuntu/windows/macos under `-race`.
+

--- a/muxcore/daemon/daemon.go
+++ b/muxcore/daemon/daemon.go
@@ -499,37 +499,60 @@ func (d *Daemon) spawnOnce(reqPtr *control.Request) (string, string, string, err
 		// channel (observed in production on 2026-04-17 after a graceful-restart
 		// snapshot sequence: 6/9 restored owners had upstream_pid alive in
 		// d.owners but refused ipc.Dial from a fresh shim). IsReachable() adds
-		// an authoritative dial probe on top. We run BOTH checks so the fast
-		// path (IsAccepting == false → closed isolated server) keeps its cheap
-		// sync-channel semantics, and only owners that pass IsAccepting pay the
-		// ~1ms dial probe cost.
+		// an authoritative dial probe on top, but it can block for up to the
+		// ipc dial timeout (500ms), so we MUST NOT hold d.mu across it —
+		// otherwise every other spawn / status request freezes for that
+		// window. Pattern: release d.mu → probe → re-acquire under CAS (is
+		// this still the same entry we probed?) → tear down or reuse.
 		if entry.Owner.IsAccepting() {
-			if entry.Owner.IsReachable() {
-				entry.LastSession = time.Now()
+			probeOwner := entry.Owner
+			probeSID := sid
+			d.mu.Unlock()
+
+			if probeOwner.IsReachable() {
+				// Healthy — re-acquire to update LastSession (cheap), then
+				// return the path. Re-check that the entry is still the same
+				// pointer; if a concurrent path replaced it, retry from the
+				// top so the new entry goes through its own probe.
+				d.mu.Lock()
+				current, still := d.owners[probeSID]
+				if !still || current.Owner != probeOwner {
+					d.mu.Unlock()
+					return "", "", "", errSpawnRetry
+				}
+				current.LastSession = time.Now()
 				d.mu.Unlock()
-				entry.Owner.SessionMgr().PreRegister(token, req.Cwd, req.Env)
-				// Note: no log here — this path is the hot path (every CC session reconnect).
-				// Logging each reuse produced 500+ lines/minute during multi-session incidents.
-				return entry.Owner.IPCPath(), sid, token, nil
+				probeOwner.SessionMgr().PreRegister(token, req.Cwd, req.Env)
+				// Note: no log here — this path is the hot path (every CC
+				// session reconnect). Logging each reuse produced 500+
+				// lines/minute during multi-session incidents.
+				return probeOwner.IPCPath(), probeSID, token, nil
 			}
-			// IsAccepting==true but IsReachable==false: zombie listener.
-			// Tear down the dead entry under lock, bump the detection counter,
-			// emit a single structured log line per detection so operators can
-			// grep for zombie recoveries, and fall through to the cold-spawn
-			// path (the shim gets a fresh path, never the zombie path).
+
+			// Zombie. Re-acquire, CAS, delete + bump counter, then Shutdown
+			// OUTSIDE the lock (Shutdown is heavy — closes sockets, tears
+			// down upstream, may fire callbacks back into the daemon).
+			d.mu.Lock()
+			current, still := d.owners[probeSID]
+			if !still || current.Owner != probeOwner {
+				// Some other path already replaced the zombie; defer to
+				// its replacement and retry.
+				d.mu.Unlock()
+				return "", "", "", errSpawnRetry
+			}
 			d.zombieDetectedSpawn++
-			shortSID := sid
+			shortSID := probeSID
 			if len(shortSID) > 8 {
 				shortSID = shortSID[:8]
 			}
 			d.logger.Printf(
 				"zombie-listener detected: path=spawn server=%s ipc=%q cmd=%q action=tear-down-and-respawn",
-				shortSID, entry.Owner.IPCPath(), entry.Command,
+				shortSID, probeOwner.IPCPath(), current.Command,
 			)
-			entry.Owner.Shutdown()
-			delete(d.owners, sid)
+			delete(d.owners, probeSID)
 			d.mu.Unlock()
-			// Retry from the top so placeholder/dedup paths can see the cleared slot.
+			probeOwner.Shutdown()
+			// Retry from the top so placeholder/dedup paths see the cleared slot.
 			return "", "", "", errSpawnRetry
 		}
 		// Owner exists but IPC listener is closed (isolated server).

--- a/muxcore/daemon/daemon.go
+++ b/muxcore/daemon/daemon.go
@@ -1089,6 +1089,22 @@ func (d *Daemon) onZeroSessions(serverID string) {
 func (d *Daemon) onUpstreamExit(serverID string) {
 	d.mu.Lock()
 	entry, ok := d.owners[serverID]
+
+	// If the current entry is a placeholder for a different pending owner
+	// creation (entry.Owner == nil), this callback is from a PRIOR owner
+	// whose entry was already replaced in the registry — typically via the
+	// FR-4 zombie-spawn tear-down path which deletes the entry under d.mu
+	// and then calls Shutdown outside the lock, after which a concurrent
+	// shim can install a fresh placeholder at the same serverID. Acting on
+	// the placeholder here would panic on entry.Owner.Shutdown() and would
+	// incorrectly delete the placeholder belonging to a completely different
+	// spawn goroutine. Skip cleanly — the prior owner's tear-down path is
+	// already draining it, and the placeholder will resolve on its own.
+	if ok && entry.Owner == nil {
+		d.mu.Unlock()
+		return
+	}
+
 	if ok {
 		// Record crash for circuit breaker before any other action.
 		cmdKey := entry.Command + " " + strings.Join(entry.Args, " ")

--- a/muxcore/daemon/daemon.go
+++ b/muxcore/daemon/daemon.go
@@ -96,6 +96,18 @@ type Daemon struct {
 	// creating an infinite respawn loop that burns CPU.
 	crashTracker map[string][]time.Time
 
+	// zombieDetectedSpawn counts how many times the FR-4 spawn-time health
+	// gate in spawnOnce tore down a registered owner because IsReachable()
+	// returned false despite IsAccepting() reporting open. Counter is
+	// monotonically increasing for the daemon's lifetime and is surfaced via
+	// HandleStatus / mux_list so operators can correlate zombie recoveries
+	// with upstream churn. Protected by d.mu.
+	zombieDetectedSpawn int
+
+	// zombieDetectedRestore counts zombies detected by the FR-3 post-snapshot
+	// gate. Incremented only by the snapshot.go path, always under d.mu.
+	zombieDetectedRestore int
+
 	shutdownOnce sync.Once
 }
 
@@ -480,13 +492,45 @@ func (d *Daemon) spawnOnce(reqPtr *control.Request) (string, string, string, err
 			d.mu.Unlock()
 			return "", "", "", errSpawnRetry
 		}
+		// FR-4 — spawn-time listener health gate.
+		//
+		// IsAccepting() only checks the listenerDone sync signal; it does NOT
+		// detect zombies where the listener died without signalling that
+		// channel (observed in production on 2026-04-17 after a graceful-restart
+		// snapshot sequence: 6/9 restored owners had upstream_pid alive in
+		// d.owners but refused ipc.Dial from a fresh shim). IsReachable() adds
+		// an authoritative dial probe on top. We run BOTH checks so the fast
+		// path (IsAccepting == false → closed isolated server) keeps its cheap
+		// sync-channel semantics, and only owners that pass IsAccepting pay the
+		// ~1ms dial probe cost.
 		if entry.Owner.IsAccepting() {
-			entry.LastSession = time.Now()
+			if entry.Owner.IsReachable() {
+				entry.LastSession = time.Now()
+				d.mu.Unlock()
+				entry.Owner.SessionMgr().PreRegister(token, req.Cwd, req.Env)
+				// Note: no log here — this path is the hot path (every CC session reconnect).
+				// Logging each reuse produced 500+ lines/minute during multi-session incidents.
+				return entry.Owner.IPCPath(), sid, token, nil
+			}
+			// IsAccepting==true but IsReachable==false: zombie listener.
+			// Tear down the dead entry under lock, bump the detection counter,
+			// emit a single structured log line per detection so operators can
+			// grep for zombie recoveries, and fall through to the cold-spawn
+			// path (the shim gets a fresh path, never the zombie path).
+			d.zombieDetectedSpawn++
+			shortSID := sid
+			if len(shortSID) > 8 {
+				shortSID = shortSID[:8]
+			}
+			d.logger.Printf(
+				"zombie-listener detected: path=spawn server=%s ipc=%q cmd=%q action=tear-down-and-respawn",
+				shortSID, entry.Owner.IPCPath(), entry.Command,
+			)
+			entry.Owner.Shutdown()
+			delete(d.owners, sid)
 			d.mu.Unlock()
-			entry.Owner.SessionMgr().PreRegister(token, req.Cwd, req.Env)
-			// Note: no log here — this path is the hot path (every CC session reconnect).
-			// Logging each reuse produced 500+ lines/minute during multi-session incidents.
-			return entry.Owner.IPCPath(), sid, token, nil
+			// Retry from the top so placeholder/dedup paths can see the cleared slot.
+			return "", "", "", errSpawnRetry
 		}
 		// Owner exists but IPC listener is closed (isolated server).
 		// If owner still has active sessions (in-flight requests), DON'T kill it —
@@ -748,11 +792,13 @@ func (d *Daemon) HandleStatus() map[string]any {
 	}
 
 	return map[string]any{
-		"daemon":             true,
-		"owner_count":        len(servers), // excludes placeholders still being created
-		"servers":            servers,
-		"owner_idle_timeout": d.ownerIdleTimeout.String(),
-		"idle_timeout":       d.idleTimeout.String(),
+		"daemon":                   true,
+		"owner_count":              len(servers), // excludes placeholders still being created
+		"servers":                  servers,
+		"owner_idle_timeout":       d.ownerIdleTimeout.String(),
+		"idle_timeout":             d.idleTimeout.String(),
+		"zombie_detections_spawn":  d.zombieDetectedSpawn,
+		"zombie_detections_restore": d.zombieDetectedRestore,
 	}
 }
 

--- a/muxcore/daemon/snapshot.go
+++ b/muxcore/daemon/snapshot.go
@@ -210,7 +210,14 @@ func (d *Daemon) runRestoreHealthGate() {
 	// but before the goroutine wakes.
 	window := restoreHealthGateWindow
 	go func() {
-		time.Sleep(window)
+		// Respect daemon shutdown: if Shutdown closes d.done during our
+		// sleep window, exit immediately instead of sweeping a daemon that
+		// is already tearing itself down.
+		select {
+		case <-time.After(window):
+		case <-d.done:
+			return
+		}
 
 		d.mu.RLock()
 		entries := make([]*OwnerEntry, 0, len(d.owners))
@@ -223,9 +230,30 @@ func (d *Daemon) runRestoreHealthGate() {
 
 		zombies := 0
 		for _, entry := range entries {
+			// Re-check shutdown between probes so a large owner set cannot
+			// extend our presence on a dying daemon.
+			select {
+			case <-d.done:
+				return
+			default:
+			}
+
+			// IMPORTANT: a zombie is an owner whose listener died WITHOUT a
+			// closeListener() call — i.e. IsAccepting reports true (sync
+			// channel still open) but IsReachable reports false (dial fails).
+			// Owners that legitimately closed their listener (e.g. isolated
+			// servers after the first session connects) report IsAccepting
+			// false and IsReachable false; they are NOT zombies and we MUST
+			// NOT tear them down here — the health gate is a defensive
+			// check against the unreachable-despite-IsAccepting class only.
+			if !entry.Owner.IsAccepting() {
+				continue
+			}
+			// Probe outside d.mu — ipc.Dial can take up to 500ms.
 			if entry.Owner.IsReachable() {
 				continue
 			}
+
 			d.mu.Lock()
 			sid := entry.ServerID
 			current, ok := d.owners[sid]
@@ -244,6 +272,8 @@ func (d *Daemon) runRestoreHealthGate() {
 			)
 			delete(d.owners, sid)
 			d.mu.Unlock()
+			// Shutdown OUTSIDE the lock — it closes sockets, tears down
+			// upstream, and may fire callbacks back into the daemon.
 			entry.Owner.Shutdown()
 			zombies++
 		}

--- a/muxcore/daemon/snapshot.go
+++ b/muxcore/daemon/snapshot.go
@@ -171,5 +171,79 @@ func (d *Daemon) loadSnapshot() int {
 	}
 
 	d.logger.Printf("snapshot: restored %d/%d owners", restored, len(snap.Owners))
+
+	// FR-3 — post-restore listener health gate.
+	//
+	// Snapshot restore synchronously calls ipc.Listen, so a bind failure would
+	// already have aborted the entry above. But the listener can die AFTER
+	// successful bind for reasons that do not flow through closeListener()
+	// and therefore leave IsAccepting() lying. Observed in production on
+	// 2026-04-17 after a graceful-restart: 6/9 restored owners passed
+	// IsAccepting but refused ipc.Dial from a fresh shim. Until the exact
+	// trigger is pinned down, validate every restored owner defensively and
+	// tear down the zombies so the next shim request cold-spawns a fresh one.
+	d.runRestoreHealthGate()
+
 	return restored
+}
+
+// restoreHealthGateWindow is the time we allow newly-restored owners to fully
+// bind their IPC listeners before the FR-3 sweep runs. Calibrated above the
+// ipc.Dial 500ms timeout plus a small margin for scheduler jitter on slow CI
+// runners. Declared as var so tests can override it.
+var restoreHealthGateWindow = 750 * time.Millisecond
+
+// runRestoreHealthGate walks every owner currently in d.owners and verifies
+// its listener is reachable via an outbound dial probe. Entries that fail the
+// probe are torn down and removed from the registry.
+//
+// Runs in a goroutine so the probe sweep does not block the startup path;
+// the goroutine logs its summary and exits. Each probe uses ipc.Dial's
+// 500ms timeout. The sweep takes an RLock snapshot of the owners map, then
+// re-acquires the write lock under CAS (entry still matches what we probed)
+// for each zombie found, so concurrent spawn/shutdown cannot produce torn
+// state.
+func (d *Daemon) runRestoreHealthGate() {
+	go func() {
+		time.Sleep(restoreHealthGateWindow)
+
+		d.mu.RLock()
+		entries := make([]*OwnerEntry, 0, len(d.owners))
+		for _, e := range d.owners {
+			if e.Owner != nil {
+				entries = append(entries, e)
+			}
+		}
+		d.mu.RUnlock()
+
+		zombies := 0
+		for _, entry := range entries {
+			if entry.Owner.IsReachable() {
+				continue
+			}
+			d.mu.Lock()
+			sid := entry.ServerID
+			current, ok := d.owners[sid]
+			if !ok || current != entry {
+				d.mu.Unlock()
+				continue
+			}
+			d.zombieDetectedRestore++
+			shortSID := sid
+			if len(shortSID) > 8 {
+				shortSID = shortSID[:8]
+			}
+			d.logger.Printf(
+				"zombie-listener detected: path=restore server=%s ipc=%q cmd=%q action=tear-down-and-respawn-on-demand",
+				shortSID, entry.Owner.IPCPath(), entry.Command,
+			)
+			delete(d.owners, sid)
+			d.mu.Unlock()
+			entry.Owner.Shutdown()
+			zombies++
+		}
+		if zombies > 0 {
+			d.logger.Printf("post-restore health gate: tore down %d zombie owner(s)", zombies)
+		}
+	}()
 }

--- a/muxcore/daemon/snapshot.go
+++ b/muxcore/daemon/snapshot.go
@@ -204,8 +204,13 @@ var restoreHealthGateWindow = 750 * time.Millisecond
 // for each zombie found, so concurrent spawn/shutdown cannot produce torn
 // state.
 func (d *Daemon) runRestoreHealthGate() {
+	// Read the tunable once here (main goroutine) and pass into the worker
+	// via closure capture. Reading it inside the worker would race t.Cleanup
+	// callers in tests that restore the var after the test function returns
+	// but before the goroutine wakes.
+	window := restoreHealthGateWindow
 	go func() {
-		time.Sleep(restoreHealthGateWindow)
+		time.Sleep(window)
 
 		d.mu.RLock()
 		entries := make([]*OwnerEntry, 0, len(d.owners))

--- a/muxcore/daemon/zombie_listener_test.go
+++ b/muxcore/daemon/zombie_listener_test.go
@@ -131,12 +131,16 @@ func TestHandleStatus_ZombieCounters(t *testing.T) {
 }
 
 // TestRunRestoreHealthGate_ZombieTornDown exercises the FR-3 post-restore
-// sweep directly: install a zombie entry, call runRestoreHealthGate, and
-// assert the entry was removed and the counter incremented.
+// sweep directly: install three owners in distinct states — zombie (listener
+// died, IsAccepting lies), healthy (bound + accepting), and legitimately
+// closed (closeListener() ran, IsAccepting correctly reports false) — then
+// verify the sweep tears down ONLY the zombie and preserves the other two.
 //
-// We override restoreHealthGateWindow to a short value so the test does not
-// wait 750ms, and we re-override at t.Cleanup to restore the production
-// default for other tests in the same package.
+// The legitimately-closed case is the one CodeRabbit + Gemini flagged: if
+// the gate used `!IsReachable` alone it would tear down isolated owners that
+// legitimately closed their listener after the first session (production
+// regression — would break every isolated MCP server's post-snapshot
+// reconnect contract).
 func TestRunRestoreHealthGate_ZombieTornDown(t *testing.T) {
 	origWindow := restoreHealthGateWindow
 	restoreHealthGateWindow = 10 * time.Millisecond
@@ -144,12 +148,8 @@ func TestRunRestoreHealthGate_ZombieTornDown(t *testing.T) {
 
 	d := testDaemon(t)
 
-	// Install two owners: one zombie, one legit-but-closed (IsAccepting
-	// false, listener never bound). The sweep should only tear down the
-	// zombie — the explicitly-closed owner is a pre-existing legitimate
-	// state (isolated server, listener closed after first session).
-
-	// Zombie: bound listener then closed directly.
+	// Zombie: bind listener then close the fd without signalling
+	// listenerDone — IsAccepting lies, IsReachable tells the truth.
 	zPath := shortSocketPath(t, "zombie.sock")
 	zLn, err := net.Listen("unix", zPath)
 	if err != nil {
@@ -178,6 +178,21 @@ func TestRunRestoreHealthGate_ZombieTornDown(t *testing.T) {
 	hSID := fmt.Sprintf("%064x", 0xBEEF)
 	healthy := owner.NewTestOwnerWithListener(hPath, hSID, hLn)
 
+	// Legitimately closed: bind, close, AND signal listenerDone. This is
+	// the state an isolated owner lands in after its first session — the
+	// owner itself explicitly closed its listener because it will never
+	// accept another connection. The health gate MUST NOT treat this as
+	// a zombie.
+	cPath := shortSocketPath(t, "closed.sock")
+	cLn, err := net.Listen("unix", cPath)
+	if err != nil {
+		t.Fatalf("net.Listen closed: %v", err)
+	}
+	cLn.Close()
+	cSID := fmt.Sprintf("%064x", 0xC105ED)
+	closed := owner.NewTestOwner(cPath, cSID)
+	owner.TestOwnerSignalListenerDone(closed)
+
 	d.mu.Lock()
 	d.owners[zSID] = &OwnerEntry{
 		Owner: zombie, ServerID: zSID, Command: "echo", Args: []string{"z"}, LastSession: time.Now(),
@@ -185,11 +200,12 @@ func TestRunRestoreHealthGate_ZombieTornDown(t *testing.T) {
 	d.owners[hSID] = &OwnerEntry{
 		Owner: healthy, ServerID: hSID, Command: "echo", Args: []string{"h"}, LastSession: time.Now(),
 	}
+	d.owners[cSID] = &OwnerEntry{
+		Owner: closed, ServerID: cSID, Command: "echo", Args: []string{"c"}, LastSession: time.Now(),
+	}
 	d.mu.Unlock()
 
-	// Run the sweep and wait for its goroutine to finish its work. We poll
-	// for up to 2 seconds — the override reduces the sleep to 10ms, so the
-	// sweep completes well inside that window even under -race on slow CI.
+	// Run the sweep and wait for its goroutine to finish. Poll up to 2s.
 	d.runRestoreHealthGate()
 
 	deadline := time.Now().Add(2 * time.Second)
@@ -197,9 +213,10 @@ func TestRunRestoreHealthGate_ZombieTornDown(t *testing.T) {
 		d.mu.RLock()
 		_, zPresent := d.owners[zSID]
 		_, hPresent := d.owners[hSID]
+		_, cPresent := d.owners[cSID]
 		counter := d.zombieDetectedRestore
 		d.mu.RUnlock()
-		if !zPresent && hPresent && counter == 1 {
+		if !zPresent && hPresent && cPresent && counter == 1 {
 			return
 		}
 		time.Sleep(25 * time.Millisecond)
@@ -208,10 +225,14 @@ func TestRunRestoreHealthGate_ZombieTornDown(t *testing.T) {
 	d.mu.RLock()
 	_, zPresent := d.owners[zSID]
 	_, hPresent := d.owners[hSID]
+	_, cPresent := d.owners[cSID]
 	counter := d.zombieDetectedRestore
 	d.mu.RUnlock()
-	t.Fatalf("post-sweep state: zPresent=%v hPresent=%v counter=%d "+
-		"(want zPresent=false hPresent=true counter=1)", zPresent, hPresent, counter)
+	t.Fatalf("post-sweep state: zPresent=%v hPresent=%v cPresent=%v counter=%d "+
+		"(want zPresent=false hPresent=true cPresent=true counter=1) — "+
+		"critical: cPresent==false means the gate tore down a legitimately-"+
+		"closed isolated owner (production regression)",
+		zPresent, hPresent, cPresent, counter)
 }
 
 // Sanity imports — keep the toolchain honest about unused imports when the

--- a/muxcore/daemon/zombie_listener_test.go
+++ b/muxcore/daemon/zombie_listener_test.go
@@ -75,9 +75,13 @@ func TestSpawn_ZombieListenerIsTornDownAndRespawned(t *testing.T) {
 	}
 
 	// Call Spawn. Under the fix, spawnOnce detects the zombie, tears it down,
-	// and returns errSpawnRetry; Spawn's outer loop then tries again and will
-	// typically fail to cold-spawn (since "echo zombie" is not a real MCP
-	// server) — we only care about the zombie detection side-effects.
+	// and returns errSpawnRetry; Spawn's outer loop then tries again. The
+	// second attempt falls through the reuse path (no entry for sid anymore),
+	// hits findSharedOwner (no match), and enters the cold-spawn placeholder
+	// path. That path WILL try to spawn "echo zombie" as a real MCP server
+	// and will ultimately fail — but the zombie detection side-effects we
+	// care about (counter increment + the original zombie pointer removed
+	// from d.owners) already fired before any cold-spawn attempt.
 	req := control.Request{
 		Cmd:     "spawn",
 		Command: "echo",
@@ -87,14 +91,18 @@ func TestSpawn_ZombieListenerIsTornDownAndRespawned(t *testing.T) {
 	}
 	_, _, _, _ = d.Spawn(req)
 
-	// Assertions.
+	// The assertion is "the original zombie entry was torn down" — a later
+	// cold-spawn placeholder or partial entry for the SAME serverID is fine
+	// (it's a fresh owner, not the zombie we installed). So compare by
+	// pointer identity, not by presence.
 	d.mu.RLock()
-	_, stillPresent := d.owners[sid]
+	entry, stillPresent := d.owners[sid]
+	isOriginalZombie := stillPresent && entry != nil && entry.Owner == zombie
 	counter := d.zombieDetectedSpawn
 	d.mu.RUnlock()
 
-	if stillPresent {
-		t.Errorf("zombie owner still present in d.owners after Spawn — tear-down path did not run")
+	if isOriginalZombie {
+		t.Errorf("original zombie Owner still registered in d.owners after Spawn — tear-down path did not run (stillPresent=%v entry.Owner==zombie=true)", stillPresent)
 	}
 	if counter != 1 {
 		t.Errorf("zombie_detections_spawn counter = %d, want 1", counter)

--- a/muxcore/daemon/zombie_listener_test.go
+++ b/muxcore/daemon/zombie_listener_test.go
@@ -1,0 +1,213 @@
+package daemon
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/thebtf/mcp-mux/muxcore/control"
+	"github.com/thebtf/mcp-mux/muxcore/owner"
+	"github.com/thebtf/mcp-mux/muxcore/serverid"
+)
+
+// TestSpawn_ZombieListenerIsTornDownAndRespawned is the production regression
+// test for the FR-4 spawn-time listener health gate.
+//
+// Pre-fix behaviour: a zombie owner (listener fd closed, listenerDone NOT
+// signalled) would be handed to a spawning shim as a valid reusable entry;
+// the shim's subsequent ipc.Dial returned "connection refused" and the shim
+// exited. This test reproduces the zombie state and asserts that:
+//
+//  1. The daemon detects the zombie via IsReachable (not just IsAccepting).
+//  2. The zombie entry is torn down and removed from d.owners.
+//  3. The zombie_detections_spawn counter increments by exactly 1.
+//  4. The retry signals errSpawnRetry so Spawn's outer loop can cold-spawn.
+//
+// This test will fail on master prior to the fix: IsAccepting returns true
+// on a zombie, the Spawn RPC returns the dead path, and no counter moves.
+func TestSpawn_ZombieListenerIsTornDownAndRespawned(t *testing.T) {
+	d := testDaemon(t)
+
+	// Build a zombie owner directly: bind a real net.Listener to a real
+	// socket path so ipc.IsAvailable has something to refuse against, then
+	// Close() the listener without going through closeListener(). This is
+	// the exact shape of the production zombie — listener fd is gone but
+	// the Owner's listenerDone channel is still open, so IsAccepting lies.
+	path := shortSocketPath(t, "zombie.sock")
+	ln, err := net.Listen("unix", path)
+	if err != nil {
+		t.Fatalf("net.Listen: %v", err)
+	}
+	// Close the listener — this is what makes it a zombie. We do NOT call
+	// closeListener() on the Owner, so listenerDone stays open.
+	ln.Close()
+
+	sid := serverid.GenerateContextKey(serverid.ModeGlobal, "echo", []string{"zombie"}, nil, "")
+
+	// Minimal Owner wired to point at the dead socket. We bypass the normal
+	// NewOwner/NewOwnerFromSnapshot paths because we want a controlled zombie
+	// — in production the zombie is a real Owner whose listener died after
+	// some external event; here we simulate that end state directly.
+	zombie := owner.NewTestOwner(path, sid)
+
+	d.mu.Lock()
+	d.owners[sid] = &OwnerEntry{
+		Owner:       zombie,
+		ServerID:    sid,
+		Command:     "echo",
+		Args:        []string{"zombie"},
+		Cwd:         "",
+		Mode:        "global",
+		LastSession: time.Now(),
+	}
+	d.mu.Unlock()
+
+	// Sanity: IsAccepting lies (pre-fix probe) but IsReachable does NOT.
+	if !zombie.IsAccepting() {
+		t.Fatalf("precondition violated: IsAccepting already false on zombie — test no longer reproduces the pre-fix behaviour")
+	}
+	if zombie.IsReachable() {
+		t.Fatalf("precondition violated: IsReachable=true on zombie — dial probe is broken")
+	}
+
+	// Call Spawn. Under the fix, spawnOnce detects the zombie, tears it down,
+	// and returns errSpawnRetry; Spawn's outer loop then tries again and will
+	// typically fail to cold-spawn (since "echo zombie" is not a real MCP
+	// server) — we only care about the zombie detection side-effects.
+	req := control.Request{
+		Cmd:     "spawn",
+		Command: "echo",
+		Args:    []string{"zombie"},
+		Cwd:     "",
+		Mode:    "global",
+	}
+	_, _, _, _ = d.Spawn(req)
+
+	// Assertions.
+	d.mu.RLock()
+	_, stillPresent := d.owners[sid]
+	counter := d.zombieDetectedSpawn
+	d.mu.RUnlock()
+
+	if stillPresent {
+		t.Errorf("zombie owner still present in d.owners after Spawn — tear-down path did not run")
+	}
+	if counter != 1 {
+		t.Errorf("zombie_detections_spawn counter = %d, want 1", counter)
+	}
+}
+
+// TestHandleStatus_ZombieCounters verifies FR-10 (operator observability):
+// the zombie detection counters are surfaced via the daemon's status output
+// so operators can watch them via `mux-mux status` / `mux_list`.
+func TestHandleStatus_ZombieCounters(t *testing.T) {
+	d := testDaemon(t)
+
+	// Manually bump both counters so we can assert they surface.
+	d.mu.Lock()
+	d.zombieDetectedSpawn = 7
+	d.zombieDetectedRestore = 3
+	d.mu.Unlock()
+
+	status := d.HandleStatus()
+	if got, ok := status["zombie_detections_spawn"]; !ok || got != 7 {
+		t.Errorf("status[zombie_detections_spawn] = %v (ok=%v), want 7", got, ok)
+	}
+	if got, ok := status["zombie_detections_restore"]; !ok || got != 3 {
+		t.Errorf("status[zombie_detections_restore] = %v (ok=%v), want 3", got, ok)
+	}
+}
+
+// TestRunRestoreHealthGate_ZombieTornDown exercises the FR-3 post-restore
+// sweep directly: install a zombie entry, call runRestoreHealthGate, and
+// assert the entry was removed and the counter incremented.
+//
+// We override restoreHealthGateWindow to a short value so the test does not
+// wait 750ms, and we re-override at t.Cleanup to restore the production
+// default for other tests in the same package.
+func TestRunRestoreHealthGate_ZombieTornDown(t *testing.T) {
+	origWindow := restoreHealthGateWindow
+	restoreHealthGateWindow = 10 * time.Millisecond
+	t.Cleanup(func() { restoreHealthGateWindow = origWindow })
+
+	d := testDaemon(t)
+
+	// Install two owners: one zombie, one legit-but-closed (IsAccepting
+	// false, listener never bound). The sweep should only tear down the
+	// zombie — the explicitly-closed owner is a pre-existing legitimate
+	// state (isolated server, listener closed after first session).
+
+	// Zombie: bound listener then closed directly.
+	zPath := shortSocketPath(t, "zombie.sock")
+	zLn, err := net.Listen("unix", zPath)
+	if err != nil {
+		t.Fatalf("net.Listen zombie: %v", err)
+	}
+	zLn.Close()
+	zSID := fmt.Sprintf("%064x", 0xDEAD)
+	zombie := owner.NewTestOwner(zPath, zSID)
+
+	// Healthy: bind and keep it bound.
+	hPath := shortSocketPath(t, "healthy.sock")
+	hLn, err := net.Listen("unix", hPath)
+	if err != nil {
+		t.Fatalf("net.Listen healthy: %v", err)
+	}
+	t.Cleanup(func() { hLn.Close() })
+	go func() {
+		for {
+			c, err := hLn.Accept()
+			if err != nil {
+				return
+			}
+			_ = c.Close()
+		}
+	}()
+	hSID := fmt.Sprintf("%064x", 0xBEEF)
+	healthy := owner.NewTestOwnerWithListener(hPath, hSID, hLn)
+
+	d.mu.Lock()
+	d.owners[zSID] = &OwnerEntry{
+		Owner: zombie, ServerID: zSID, Command: "echo", Args: []string{"z"}, LastSession: time.Now(),
+	}
+	d.owners[hSID] = &OwnerEntry{
+		Owner: healthy, ServerID: hSID, Command: "echo", Args: []string{"h"}, LastSession: time.Now(),
+	}
+	d.mu.Unlock()
+
+	// Run the sweep and wait for its goroutine to finish its work. We poll
+	// for up to 2 seconds — the override reduces the sleep to 10ms, so the
+	// sweep completes well inside that window even under -race on slow CI.
+	d.runRestoreHealthGate()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		d.mu.RLock()
+		_, zPresent := d.owners[zSID]
+		_, hPresent := d.owners[hSID]
+		counter := d.zombieDetectedRestore
+		d.mu.RUnlock()
+		if !zPresent && hPresent && counter == 1 {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+
+	d.mu.RLock()
+	_, zPresent := d.owners[zSID]
+	_, hPresent := d.owners[hSID]
+	counter := d.zombieDetectedRestore
+	d.mu.RUnlock()
+	t.Fatalf("post-sweep state: zPresent=%v hPresent=%v counter=%d "+
+		"(want zPresent=false hPresent=true counter=1)", zPresent, hPresent, counter)
+}
+
+// Sanity imports — keep the toolchain honest about unused imports when the
+// file is edited in isolation.
+var _ = log.LstdFlags
+var _ = os.Stderr
+var _ = strings.TrimSpace

--- a/muxcore/owner/coverage_test.go
+++ b/muxcore/owner/coverage_test.go
@@ -351,8 +351,19 @@ func TestOwnerStatusWithClassificationReason(t *testing.T) {
 	sendReq(t, clientW, 2, "tools/list", `{}`)
 	readResp(t, clientR)
 
-	// Manually inject classification_reason to test the branch
+	// Manually inject the full classification trio (reason + classification +
+	// source) under a single lock. Previously this test only overwrote
+	// classificationReason and relied on the priming initialize + tools/list
+	// sequence above to have already driven classifyFromToolList to
+	// completion — which is a race: readResp returns when the wire response
+	// lands, but classification runs in the upstream goroutine AFTER that,
+	// so on -race macos the classification fields were sometimes still empty
+	// when Status() ran (Status omits classification_reason when
+	// autoClassification == ""). Injecting all three deterministically
+	// removes the race regardless of goroutine scheduling.
 	owner.mu.Lock()
+	owner.autoClassification = "isolated"
+	owner.classificationSource = "tools"
 	owner.classificationReason = []string{"write_file", "bash"}
 	owner.mu.Unlock()
 

--- a/muxcore/owner/owner.go
+++ b/muxcore/owner/owner.go
@@ -1959,17 +1959,22 @@ func (o *Owner) IsAccepting() bool {
 // where a stale "accepting" answer would cause an external caller to dial a
 // dead socket.
 //
-// The probe reuses ipc.Dial's existing 500ms timeout. Bound the probe budget
-// by the bounded internal dialTimeout; callers that need tighter latency may
-// wrap this in a context.
+// The probe reuses ipc.Dial's existing 500ms timeout. Callers MUST NOT hold
+// daemon-wide locks across this call; the probe can take up to 500ms on a
+// hung peer and a daemon-wide lock would freeze every other spawn / status
+// request for that window.
 //
-// Returns false without probing if:
-//   - listenerDone has been signalled (explicit closeListener)
-//   - ipcPath is empty (test owners, SessionHandler-only pre-bind)
-//
-// For any other case the method performs a real dial. This is a ~1ms hot-path
-// cost on healthy listeners; on zombies it surfaces the failure deterministic-
-// ally in a single probe.
+// Returns:
+//   - false if listenerDone has been signalled (explicit closeListener — an
+//     owner that legitimately closed its own listener, e.g. an isolated
+//     server after its first session, will return false here; callers that
+//     need to distinguish "legitimately closed" from "zombie" must pair
+//     IsReachable with IsAccepting to tell them apart).
+//   - true if ipcPath is empty (test owners / pre-bind SessionHandler-only
+//     fixtures have no path to probe — they are treated as reachable so
+//     unit-test flows are not short-circuited).
+//   - otherwise, the result of ipc.IsAvailable(ipcPath) (dial-then-close
+//     probe with the 500ms timeout from ipc.dialTimeout).
 func (o *Owner) IsReachable() bool {
 	// Fast path: explicit close always wins.
 	select {

--- a/muxcore/owner/owner.go
+++ b/muxcore/owner/owner.go
@@ -1931,8 +1931,18 @@ func (o *Owner) IPCPath() string {
 	return o.ipcPath
 }
 
-// IsAccepting returns true if the IPC listener is still active (not closed).
-// Isolated owners close their listener after the first session connects.
+// IsAccepting returns true if the IPC listener has not been explicitly closed
+// via closeListener(). This is a fast synchronization-signal check — it does
+// NOT guarantee the listener is actually reachable from a fresh dial.
+//
+// Use IsReachable() when an authoritative liveness answer is required (e.g.
+// when deciding whether to hand out an IPC path to a shim that will dial it).
+// IsAccepting alone is insufficient: a listener can become unreachable while
+// listenerDone is still open (e.g. a race where the accept goroutine returned
+// on net.ErrClosed before closeListener signalled listenerDone, or where an
+// OS-level teardown closed the socket fd out from under us). Those zombie
+// states produce "dial: connection refused" for shims even though the owner
+// entry is still registered in the daemon.
 func (o *Owner) IsAccepting() bool {
 	select {
 	case <-o.listenerDone:
@@ -1940,6 +1950,39 @@ func (o *Owner) IsAccepting() bool {
 	default:
 		return true
 	}
+}
+
+// IsReachable returns true if the IPC listener is both marked-open
+// (listenerDone not signalled) AND actually accepting new connections right
+// now as observed by an outbound ipc.Dial probe against the owner's own
+// ipcPath. This is the authoritative liveness check — use it at any junction
+// where a stale "accepting" answer would cause an external caller to dial a
+// dead socket.
+//
+// The probe reuses ipc.Dial's existing 500ms timeout. Bound the probe budget
+// by the bounded internal dialTimeout; callers that need tighter latency may
+// wrap this in a context.
+//
+// Returns false without probing if:
+//   - listenerDone has been signalled (explicit closeListener)
+//   - ipcPath is empty (test owners, SessionHandler-only pre-bind)
+//
+// For any other case the method performs a real dial. This is a ~1ms hot-path
+// cost on healthy listeners; on zombies it surfaces the failure deterministic-
+// ally in a single probe.
+func (o *Owner) IsReachable() bool {
+	// Fast path: explicit close always wins.
+	select {
+	case <-o.listenerDone:
+		return false
+	default:
+	}
+	if o.ipcPath == "" {
+		// No path to probe (test owner, pre-bind). Treat as reachable — the
+		// caller is responsible for its own liveness semantics.
+		return true
+	}
+	return ipc.IsAvailable(o.ipcPath)
 }
 
 // InitReady returns a channel that is closed when the owner's upstream has responded

--- a/muxcore/owner/testsupport.go
+++ b/muxcore/owner/testsupport.go
@@ -49,3 +49,24 @@ func NewTestOwnerWithListener(ipcPath, serverID string, ln net.Listener) *Owner 
 	o.listener = ln
 	return o
 }
+
+// TestOwnerSignalListenerDone simulates the effect of closeListener on a test
+// Owner without going through the full Shutdown machinery. After this call
+// IsAccepting returns false — representing an Owner that legitimately closed
+// its listener (e.g. an isolated server after the first session connected).
+//
+// Used by tests that need to distinguish "legitimately closed" from "zombie":
+// a zombie is IsAccepting==true && IsReachable==false, a legitimately-closed
+// owner is IsAccepting==false regardless of IsReachable, and the health gate
+// must only tear down the former. Intended for tests only.
+//
+// Implementation note: we route the close through closeListenerOnce.Do so a
+// subsequent closeListener() call (e.g. from a t.Cleanup-triggered Shutdown)
+// is a no-op instead of a double-close panic. This mirrors the production
+// closeListener path exactly except that no ipc.Cleanup is performed on the
+// socket file (tests manage their own temp files).
+func TestOwnerSignalListenerDone(o *Owner) {
+	o.closeListenerOnce.Do(func() {
+		close(o.listenerDone)
+	})
+}

--- a/muxcore/owner/testsupport.go
+++ b/muxcore/owner/testsupport.go
@@ -1,0 +1,51 @@
+package owner
+
+import (
+	"io"
+	"log"
+	"net"
+
+	"github.com/thebtf/mcp-mux/muxcore/progress"
+)
+
+// NewTestOwner returns a minimal Owner suitable for unit-test fixtures that
+// need to exercise the public liveness API (IsAccepting, IsReachable, IPCPath,
+// ServerID) without spinning up upstream processes or IPC listeners.
+//
+// The returned owner has an open listenerDone channel (so IsAccepting returns
+// true) and the supplied ipcPath. Callers that want IsReachable to return
+// false can either bind-and-close a listener at that path (zombie shape) or
+// leave the path unbound (no-file shape). Callers that want IsReachable to
+// return true should use NewTestOwnerWithListener.
+//
+// Intended for cross-package tests in the muxcore tree (primarily
+// muxcore/daemon). Do NOT use in production code paths.
+func NewTestOwner(ipcPath, serverID string) *Owner {
+	return &Owner{
+		sessions:               make(map[int]*Session),
+		cachedInitSessions:     make(map[int]bool),
+		progressOwners:         make(map[string]int),
+		progressTokenRequestID: make(map[string]string),
+		requestToTokens:        make(map[string][]string),
+		progressTracker:        progress.NewTracker(),
+		sessionMgr:             NewSessionManager(),
+		ipcPath:                ipcPath,
+		serverID:               serverID,
+		logger:                 log.New(io.Discard, "", 0),
+		done:                   make(chan struct{}),
+		listenerDone:           make(chan struct{}),
+	}
+}
+
+// NewTestOwnerWithListener is like NewTestOwner but also wires in a live
+// net.Listener so IsReachable's dial probe succeeds. Used by tests that want
+// to verify happy-path behaviour (spawn RPC reuses a healthy owner, restore
+// sweep preserves a healthy owner, etc.).
+//
+// The caller owns the listener's lifetime and MUST Close() it during test
+// cleanup to avoid leaking accept goroutines.
+func NewTestOwnerWithListener(ipcPath, serverID string, ln net.Listener) *Owner {
+	o := NewTestOwner(ipcPath, serverID)
+	o.listener = ln
+	return o
+}

--- a/muxcore/owner/zombie_listener_test.go
+++ b/muxcore/owner/zombie_listener_test.go
@@ -1,0 +1,140 @@
+package owner
+
+import (
+	"net"
+	"strings"
+	"testing"
+)
+
+// TestIsReachable_LiveListener verifies the happy path: a freshly-bound
+// listener returns IsReachable == true.
+func TestIsReachable_LiveListener(t *testing.T) {
+	path := testIPCPath(t)
+	o := newMinimalOwner()
+	o.ipcPath = path
+
+	ln, err := net.Listen("unix", path)
+	if err != nil {
+		t.Fatalf("net.Listen: %v", err)
+	}
+	defer ln.Close()
+	o.listener = ln
+
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			_ = c.Close()
+		}
+	}()
+
+	if !o.IsReachable() {
+		t.Fatalf("IsReachable()=false on a live listener (path=%q)", path)
+	}
+	if !o.IsAccepting() {
+		t.Fatalf("IsAccepting()=false on a live listener")
+	}
+}
+
+// TestIsReachable_ExplicitClose verifies that an explicitly-closed listener
+// (closeListener path) correctly reports IsReachable == false without
+// requiring a dial probe to fire.
+func TestIsReachable_ExplicitClose(t *testing.T) {
+	path := testIPCPath(t)
+	o := newMinimalOwner()
+	o.ipcPath = path
+
+	ln, err := net.Listen("unix", path)
+	if err != nil {
+		t.Fatalf("net.Listen: %v", err)
+	}
+	o.listener = ln
+
+	// Simulate closeListener.
+	close(o.listenerDone)
+	ln.Close()
+
+	if o.IsReachable() {
+		t.Fatalf("IsReachable()=true after explicit close")
+	}
+	if o.IsAccepting() {
+		t.Fatalf("IsAccepting()=true after explicit close")
+	}
+}
+
+// TestIsReachable_ZombieListener is the pre-fix regression test. It
+// reproduces the "listener closed but listenerDone never signalled" state
+// that IsAccepting mis-reports as healthy.
+//
+// Before the IsReachable fix, daemon.Spawn used IsAccepting alone: given a
+// zombie owner the Spawn RPC returned its ipcPath to the shim, and the shim
+// then failed "dial: connection refused". This test ensures IsReachable
+// catches the exact same state and reports it correctly — any future
+// refactor that reintroduces a synchronization-only liveness check here
+// will immediately fail this test.
+func TestIsReachable_ZombieListener(t *testing.T) {
+	path := testIPCPath(t)
+	o := newMinimalOwner()
+	o.ipcPath = path
+
+	ln, err := net.Listen("unix", path)
+	if err != nil {
+		t.Fatalf("net.Listen: %v", err)
+	}
+	o.listener = ln
+
+	// Zombie state: the underlying listener is closed (socket file may or
+	// may not be removed), but listenerDone has NOT been signalled. This is
+	// the exact state we observed in production after graceful-restart —
+	// IsAccepting returned true, dial returned refused.
+	if err := ln.Close(); err != nil {
+		t.Fatalf("ln.Close: %v", err)
+	}
+
+	// Sanity: IsAccepting is the pre-fix probe and still returns true because
+	// listenerDone is not closed. This is the bug.
+	if !o.IsAccepting() {
+		t.Fatalf("precondition violated: IsAccepting already false without closeListener")
+	}
+
+	// The fix: IsReachable authoritatively detects the zombie.
+	if o.IsReachable() {
+		t.Fatalf("IsReachable()=true on a zombie listener (listener closed, listenerDone open) — " +
+			"pre-fix bug: daemon would hand this path to a shim and the shim would get " +
+			"'dial: connection refused'")
+	}
+}
+
+// TestIsReachable_EmptyIPCPath covers the test-owner edge case where an
+// Owner has no ipcPath (typical in unit tests that bypass the bind
+// machinery). IsReachable must not attempt a dial on an empty path and must
+// treat the owner as reachable so test owners remain usable.
+func TestIsReachable_EmptyIPCPath(t *testing.T) {
+	o := newMinimalOwner()
+	o.ipcPath = ""
+	if !o.IsReachable() {
+		t.Fatalf("IsReachable()=false with empty ipcPath — callers that use " +
+			"test owners would see false-negative zombie detections")
+	}
+}
+
+// TestIsReachable_NoListenerFile covers the case where the socket file was
+// removed by ipc.Cleanup or some other path but listenerDone is still open.
+// Dial should refuse on a missing file, and IsReachable must return false.
+func TestIsReachable_NoListenerFile(t *testing.T) {
+	path := testIPCPath(t)
+	o := newMinimalOwner()
+	o.ipcPath = path
+
+	// No net.Listen; path does not exist.
+	if o.IsReachable() {
+		t.Fatalf("IsReachable()=true on a missing socket path")
+	}
+
+	// And the error propagates through ipc.IsAvailable internally — callers
+	// that want the raw error can reach it via ipc.Dial. Sanity check here
+	// is that we don't panic on a nonexistent path.
+	_ = strings.TrimSpace("") // keep strings import referenced when only regex-style checks are removed
+}

--- a/muxcore/upstream/process.go
+++ b/muxcore/upstream/process.go
@@ -8,6 +8,7 @@ package upstream
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -158,6 +159,20 @@ func (p *Process) WriteLine(data []byte) error {
 
 // ReadLine reads the next line from the upstream process stdout.
 // Returns io.EOF when the process closes stdout.
+//
+// Error normalisation: exec.Cmd.StdoutPipe is documented to close the pipe
+// after cmd.Wait() returns, and we run Wait in a background goroutine (see
+// Start's "bridge procgroup's done channel" block). A caller that dials
+// ReadLine AFTER Wait has closed the pipe sees "read |0: file already
+// closed" from os.ErrClosed. Semantically this is EOF: no more bytes will
+// ever arrive. Map it so callers can short-circuit on io.EOF without
+// stringy matches (upstream package and product code already treat EOF as
+// clean end-of-stream — see muxcore/owner/owner.go readUpstream).
+//
+// This normalisation does NOT mask the deeper race (Wait concurrently
+// closing the pipe with ReadLine); it just prevents a misleading error
+// surface. Documented with full root-cause analysis in TECHNICAL_DEBT.md
+// under "upstream.Start Wait-vs-ReadLine race".
 func (p *Process) ReadLine() ([]byte, error) {
 	if p.scanner.Scan() {
 		// Return a copy to avoid scanner buffer reuse issues
@@ -168,6 +183,9 @@ func (p *Process) ReadLine() ([]byte, error) {
 	}
 
 	if err := p.scanner.Err(); err != nil {
+		if errors.Is(err, os.ErrClosed) {
+			return nil, io.EOF
+		}
 		return nil, fmt.Errorf("upstream: read: %w", err)
 	}
 


### PR DESCRIPTION
## Fixes the zombie MCP server failure after graceful-restart

Spec: `.agent/specs/zombie-listener-snapshot-restore/spec.md` (FR-3, FR-4, FR-9, FR-10, FR-11).

### Root cause

After `mcp-mux upgrade --restart` a subset of restored owners pass `Owner.IsAccepting()` (their `listenerDone` channel is still open) but their underlying `net.Listener` no longer accepts connections. The daemon's `spawnOnce` gated owner reuse on `IsAccepting()` alone, so it happily returned those dead paths to shims. Shims then failed with `dial: connect: No connection could be made because the target machine actively refused it` and exited, surfacing as "failed MCP server" in Claude Code.

Reproduced deterministically on 2026-04-17 after the v0.9.4 deploy — 6/9 restored owners were unreachable while their `mux_list` entries still looked healthy.

### Fix

Added `Owner.IsReachable()` — an authoritative liveness check that layers a real `ipc.Dial` probe on top of `listenerDone`:

```
fast path   : listenerDone signalled        -> false
empty path  : no ipcPath (test owners)      -> true
otherwise   : ipc.IsAvailable(ipcPath)      -> probe result (500ms timeout)
```

Integrated at two defensive junctions:

- **FR-4 spawn-time gate** (`muxcore/daemon/daemon.go`): `spawnOnce` now runs `IsReachable` immediately after `IsAccepting`. If `IsAccepting && !IsReachable` → tear down under `d.mu`, bump `zombie_detections_spawn`, structured log line, `errSpawnRetry` to cold-spawn with a fresh listener. The shim never receives the zombie path.
- **FR-3 post-restore gate** (`muxcore/daemon/snapshot.go`): after `loadSnapshot` finishes the restore loop, `runRestoreHealthGate` runs in a goroutine, waits 750 ms for listener bind to settle, then probes every owner and tears down the zombies (CAS under write lock so concurrent spawn/shutdown can't produce torn state). Counter: `zombie_detections_restore`.

### Observability

`HandleStatus` / `mux_list` now surface both counters:

```json
{
  "zombie_detections_spawn":   0,
  "zombie_detections_restore": 0
}
```

Structured log line per detection, grep-friendly:

```
zombie-listener detected: path=spawn server=<sid8> ipc="..." cmd="..." action=tear-down-and-respawn
```

### Tests

`muxcore/owner/zombie_listener_test.go`:
- `TestIsReachable_LiveListener` — happy path
- `TestIsReachable_ExplicitClose` — `closeListener` path stays false
- `TestIsReachable_ZombieListener` — the pre-fix regression (listener closed, listenerDone open)
- `TestIsReachable_EmptyIPCPath`, `TestIsReachable_NoListenerFile` — edge cases

`muxcore/daemon/zombie_listener_test.go`:
- `TestSpawn_ZombieListenerIsTornDownAndRespawned` — end-to-end tear-down + counter bump
- `TestHandleStatus_ZombieCounters` — FR-10 surfacing
- `TestRunRestoreHealthGate_ZombieTornDown` — FR-3 sweep picks zombies, preserves healthy owners

`muxcore/owner/testsupport.go` adds exported `NewTestOwner` / `NewTestOwnerWithListener` so daemon-package tests can wire minimal fixtures.

### Local verification (all 18 muxcore packages)

```
ok  github.com/thebtf/mcp-mux/muxcore                 0.344s
ok  github.com/thebtf/mcp-mux/muxcore/busy            0.304s
ok  github.com/thebtf/mcp-mux/muxcore/control         5.424s
ok  github.com/thebtf/mcp-mux/muxcore/daemon         12.629s
ok  github.com/thebtf/mcp-mux/muxcore/owner          16.798s
ok  github.com/thebtf/mcp-mux/muxcore/procgroup       3.279s
ok  github.com/thebtf/mcp-mux/muxcore/upstream        0.964s
ok  ... (18 packages total)
```

CI runs the same suite under `-race` on ubuntu / windows / macos + coverage.

### Scope

- **Zero stubs.** Every path has a real implementation exercised by the tests above.
- Does NOT change `ipc.Listen/Dial` primitives, snapshot format, or the daemon control protocol.
- PR #63 transparent-reconnect behaviour is preserved verbatim; `TestResilientClient_NoMuxReconnectKeepalive` still passes.
- The underlying trigger that initially kills the listener (why `listenerDone` stays open while the underlying fd dies) is tracked as follow-up investigation in the spec (FR-2). This PR ships defence-in-depth so the observable symptom stops today; the new counters quantify how often the defence fires, which informs the follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Исправления ошибок**
  * Улучшено обнаружение и корректное удаление «зависших» (zombie) слушателей при запуске и восстановлении, чтобы не переиспользовать неработающие инстансы и избежать некорректных обратных вызовов.

* **Новые возможности**
  * Добавлена пост‑восстановительная «воротная» проверка здоровья слушателей; разделены состояния «приёмки» и реальной доступности.
  * В статусе сервиса теперь отображаются счётчики обнаружений и восстановлений «zombie».

* **Тесты**
  * Добавлены регрессии и юнит‑тесты для сценариев с «zombie»‑слушателями, проверок доступности и вспомогательные тестовые конструкторы.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->