### PR TITLE
fix(upstream): route upstream stderr through daemon logger

### DIFF
--- a/muxcore/daemon/daemon.go
+++ b/muxcore/daemon/daemon.go
@@ -617,7 +617,18 @@ func (d *Daemon) spawnOnce(reqPtr *control.Request) (string, string, string, err
 	// leaks between sessions and ensures session-aware servers see all vars.
 	sessionEnv := req.Env
 	if len(sessionEnv) > 0 {
-		d.logger.Printf("owner %s: session env %d vars", sid[:8], len(sessionEnv))
+		// Log presence (NOT values) of common credential keys so env-passthrough
+		// regressions surface in mcp-muxd-debug.log without requiring a test
+		// harness. Session-aware upstreams (e.g. pr-review-mcp) error out with
+		// "No GitHub token available for session ..." when these are missing;
+		// this line tells the operator whether the token survived the shim →
+		// daemon hop before they go hunting in the MCP server itself.
+		d.logger.Printf("owner %s: session env %d vars (github_pat=%v gh_token=%v openai_key=%v anthropic_key=%v)",
+			sid[:8], len(sessionEnv),
+			sessionEnv["GITHUB_PERSONAL_ACCESS_TOKEN"] != "",
+			sessionEnv["GH_TOKEN"] != "" || sessionEnv["GITHUB_TOKEN"] != "",
+			sessionEnv["OPENAI_API_KEY"] != "",
+			sessionEnv["ANTHROPIC_API_KEY"] != "")
 	}
 
 	// Build the shared owner config (used by both template and fresh paths).

--- a/muxcore/daemon/daemon.go
+++ b/muxcore/daemon/daemon.go
@@ -715,10 +715,14 @@ func (d *Daemon) spawnOnce(reqPtr *control.Request) (string, string, string, err
 	serviceToken := d.supervisor.Add(o)
 
 	// Promote the placeholder to a real entry and signal waiters.
+	// Store the merged env (not raw req.Env) so snapshot save and dedup
+	// checks see the same credential-complete view that the upstream and
+	// session already got. Otherwise a daemon restart would round-trip
+	// trimmed env through the snapshot and re-surface the original bug.
 	d.mu.Lock()
 	placeholder.Owner = o
 	placeholder.Mode = req.Mode
-	placeholder.Env = req.Env
+	placeholder.Env = sessionEnv
 	placeholder.LastSession = time.Now()
 	placeholder.IdleTimeout = d.ownerIdleTimeout
 	placeholder.serviceToken = serviceToken

--- a/muxcore/daemon/daemon.go
+++ b/muxcore/daemon/daemon.go
@@ -612,19 +612,22 @@ func (d *Daemon) spawnOnce(reqPtr *control.Request) (string, string, string, err
 
 	ipcPath := serverid.IPCPath(sid, "")
 
-	// Pass full session env to the owner. No diff — the owner and upstream
-	// receive exactly the environment the CC session had. This prevents env
-	// leaks between sessions and ensures session-aware servers see all vars.
-	sessionEnv := req.Env
+	// Pass full session env to the owner. Shim-supplied vars WIN; daemon env
+	// fills gaps. Rationale: some shims are launched by tools that strip
+	// inherited vars (observed: CC sessions started in certain worktree paths
+	// arrive with 18-25 vars instead of 130+, missing GITHUB_PERSONAL_ACCESS_TOKEN
+	// and other credentials). Session-aware upstreams (e.g. pr-review-mcp) then
+	// fail with "No GitHub token available for session ...". Merging from the
+	// daemon's own os.Environ() (which was snapshotted at daemon start from the
+	// user env) fills the gap without overriding anything the shim did send.
+	sessionEnv := mergeEnv(req.Env)
 	if len(sessionEnv) > 0 {
 		// Log presence (NOT values) of common credential keys so env-passthrough
-		// regressions surface in mcp-muxd-debug.log without requiring a test
-		// harness. Session-aware upstreams (e.g. pr-review-mcp) error out with
-		// "No GitHub token available for session ..." when these are missing;
-		// this line tells the operator whether the token survived the shim →
-		// daemon hop before they go hunting in the MCP server itself.
-		d.logger.Printf("owner %s: session env %d vars (github_pat=%v gh_token=%v openai_key=%v anthropic_key=%v)",
-			sid[:8], len(sessionEnv),
+		// regressions remain visible. `shim_vars` is the pre-merge count — that
+		// is the one that regresses when CC sends a short env. `total` reflects
+		// what the upstream actually sees after the daemon-env fallback.
+		d.logger.Printf("owner %s: session env shim_vars=%d total=%d (github_pat=%v gh_token=%v openai_key=%v anthropic_key=%v)",
+			sid[:8], len(req.Env), len(sessionEnv),
 			sessionEnv["GITHUB_PERSONAL_ACCESS_TOKEN"] != "",
 			sessionEnv["GH_TOKEN"] != "" || sessionEnv["GITHUB_TOKEN"] != "",
 			sessionEnv["OPENAI_API_KEY"] != "",
@@ -976,6 +979,33 @@ func argsEqual(a, b []string) bool {
 		}
 	}
 	return true
+}
+
+// mergeEnv combines a shim-supplied env with the daemon's own os.Environ().
+// Shim-supplied entries win on key collision (per-session credentials and cwd
+// vars must override anything inherited by the daemon). Any key missing from
+// the shim env is filled from the daemon env.
+//
+// Why: some shim launch paths arrive with a drastically trimmed environment
+// (observed in CC sessions started in certain worktree layouts: ~18-25 vars
+// instead of the usual 130+), missing GITHUB_PERSONAL_ACCESS_TOKEN and other
+// credentials. Session-aware upstreams (pr-review-mcp, etc.) then surface
+// "No GitHub token available for session ..." errors and CC marks the server
+// `failed` in `/mcp`. Filling from the daemon's own env (captured from the
+// user environment at daemon start) restores the missing credentials without
+// overriding anything the shim did send. shim-supplied nil map → daemon env
+// returned directly.
+func mergeEnv(shimEnv map[string]string) map[string]string {
+	merged := make(map[string]string, len(shimEnv)+64)
+	for _, e := range os.Environ() {
+		if i := strings.IndexByte(e, '='); i > 0 {
+			merged[e[:i]] = e[i+1:]
+		}
+	}
+	for k, v := range shimEnv {
+		merged[k] = v
+	}
+	return merged
 }
 
 // envCompatible returns true if two env maps have no conflicting values

--- a/muxcore/daemon/daemon.go
+++ b/muxcore/daemon/daemon.go
@@ -732,7 +732,14 @@ func (d *Daemon) spawnOnce(reqPtr *control.Request) (string, string, string, err
 		o.SpawnUpstreamBackground()
 	}
 
-	o.SessionMgr().PreRegister(token, req.Cwd, req.Env)
+	// PreRegister with the MERGED env (not raw req.Env) so the session — bound
+	// to this token on handshake — sees daemon-filled credentials too.
+	// owner.go:~815 gates muxEnv injection on `len(s.Env) > 0` and sends s.Env
+	// as _meta.muxEnv; session-aware upstreams (pr-review-mcp etc.) look up
+	// GITHUB_PERSONAL_ACCESS_TOKEN here. Without the merge, a trimmed shim
+	// env would leave muxEnv missing the token even though the owner/upstream
+	// process has it via mergeEnv above.
+	o.SessionMgr().PreRegister(token, req.Cwd, sessionEnv)
 	return ipcPath, sid, token, nil
 }
 

--- a/muxcore/daemon/daemon_test.go
+++ b/muxcore/daemon/daemon_test.go
@@ -460,6 +460,56 @@ func daemonAssertID(t *testing.T, resp []byte, expectedID int) {
 	}
 }
 
+// TestMergeEnv verifies that shim-supplied vars WIN over daemon vars on
+// key collision, and missing keys are filled from the daemon env. Regression
+// test for the case where CC sessions started in certain worktree layouts
+// arrive with a trimmed env (observed: ~18 vars vs usual 130+) missing
+// GITHUB_PERSONAL_ACCESS_TOKEN — session-aware upstreams then surface
+// "No GitHub token available for session" and CC marks the server failed.
+func TestMergeEnv(t *testing.T) {
+	// Seed a daemon-env variable we can look for. Restore on exit so parallel
+	// tests aren't affected.
+	const probeKey = "MCP_MUX_MERGE_PROBE"
+	const probeVal = "from-daemon-env-9f13"
+	t.Setenv(probeKey, probeVal)
+
+	t.Run("fallback fills missing key", func(t *testing.T) {
+		shim := map[string]string{"SOMETHING_ELSE": "shim"}
+		got := mergeEnv(shim)
+		if got[probeKey] != probeVal {
+			t.Errorf("merged[%s] = %q, want %q (daemon env should fill gap)", probeKey, got[probeKey], probeVal)
+		}
+		if got["SOMETHING_ELSE"] != "shim" {
+			t.Errorf("merged[SOMETHING_ELSE] = %q, want shim-supplied value", got["SOMETHING_ELSE"])
+		}
+	})
+
+	t.Run("shim overrides daemon on key collision", func(t *testing.T) {
+		shim := map[string]string{probeKey: "from-shim-override"}
+		got := mergeEnv(shim)
+		if got[probeKey] != "from-shim-override" {
+			t.Errorf("merged[%s] = %q, want shim override to win", probeKey, got[probeKey])
+		}
+	})
+
+	t.Run("nil shim env yields daemon env", func(t *testing.T) {
+		got := mergeEnv(nil)
+		if got[probeKey] != probeVal {
+			t.Errorf("merged[%s] = %q, want daemon env preserved when shim is nil", probeKey, got[probeKey])
+		}
+		if len(got) == 0 {
+			t.Error("merged env is empty; daemon env should be non-empty")
+		}
+	})
+
+	t.Run("empty shim env yields daemon env", func(t *testing.T) {
+		got := mergeEnv(map[string]string{})
+		if got[probeKey] != probeVal {
+			t.Errorf("merged[%s] = %q, want daemon env preserved when shim is empty", probeKey, got[probeKey])
+		}
+	})
+}
+
 func TestEnvTransient(t *testing.T) {
 	testCases := []struct {
 		name string

--- a/muxcore/daemon/snapshot.go
+++ b/muxcore/daemon/snapshot.go
@@ -100,10 +100,18 @@ func (d *Daemon) loadSnapshot() int {
 
 		// Capture loop variables for closure.
 		cmd, args := ownerSnap.Command, ownerSnap.Args
+		// Merge daemon os.Environ() into the snapshotted env on restore. A
+		// pre-fix daemon may have serialised an owner with a trimmed shim env
+		// (missing GITHUB_PERSONAL_ACCESS_TOKEN, etc.); without this merge,
+		// loading that snapshot after the fix would re-install the trimmed
+		// env and session-aware upstreams would fail with "No GitHub token
+		// available for session ..." until the next cold spawn. Daemon env
+		// values fill gaps but cannot override whatever the snapshot stored.
+		restoredEnv := mergeEnv(ownerSnap.Env)
 		o, err := owner.NewOwnerFromSnapshot(owner.OwnerConfig{
 			Command:        cmd,
 			Args:           args,
-			Env:            ownerSnap.Env,
+			Env:            restoredEnv,
 			Cwd:            ownerSnap.Cwd,
 			IPCPath:        ipcPath,
 			ControlPath:    controlPath,
@@ -150,7 +158,7 @@ func (d *Daemon) loadSnapshot() int {
 			Args:         ownerSnap.Args,
 			Cwd:          ownerSnap.Cwd,
 			Mode:         ownerSnap.Mode,
-			Env:          ownerSnap.Env,
+			Env:          restoredEnv,
 			Persistent:   ownerSnap.Persistent,
 			LastSession:  time.Now(),
 			IdleTimeout:  d.ownerIdleTimeout,

--- a/muxcore/owner/owner.go
+++ b/muxcore/owner/owner.go
@@ -96,8 +96,9 @@ type Owner struct {
 	ipcPath  string
 	cwd      string          // primary working directory (from first spawn)
 	cwdSet   map[string]bool // all known cwds (for multi-project roots/list)
-	command     string          // upstream command (for status/restart)
-	args        []string        // upstream args (for status/restart)
+	command     string            // upstream command (for status/restart)
+	args        []string          // upstream args (for status/restart)
+	env         map[string]string // upstream env captured at spawn (for background respawn)
 	handlerFunc    func(ctx context.Context, stdin io.Reader, stdout io.Writer) error // in-process MCP handler (nil = subprocess)
 	sessionHandler muxcore.SessionHandler                                            // structured in-process handler (nil = pipe or subprocess)
 	serverID string          // server identity hash
@@ -251,6 +252,7 @@ func NewOwnerFromSnapshot(cfg OwnerConfig, snap OwnerSnapshot) (*Owner, error) {
 		cwdSet:                 cwdSet,
 		command:                cfg.Command,
 		args:                   cfg.Args,
+		env:                    cfg.Env,
 		handlerFunc:            cfg.HandlerFunc,
 		sessionHandler:         cfg.SessionHandler,
 		serverID:               cfg.ServerID,
@@ -360,7 +362,16 @@ func (o *Owner) SpawnUpstreamBackground() {
 			proc = upstream.NewProcessFromHandler(context.Background(), o.handlerFunc)
 			o.logger.Printf("background handler spawn: in-process (no subprocess)")
 		} else {
-			proc, err = upstream.Start(o.command, o.args, nil, o.cwd, o.logger)
+			// CRITICAL: pass o.env (captured at owner creation), NOT nil.
+			// upstream.Start treats nil env as "inherit daemon os.Environ()",
+			// which loses MCP-config-specific vars like CCLSP_CONFIG_PATH that
+			// only exist in the spawning shim's env, not in the daemon's.
+			// Observed failure: cclsp respawn emits
+			//   "Error: configPath is required when CCLSP_CONFIG_PATH environment variable is not set"
+			// on background respawn (first spawn used ownerCfg.Env correctly;
+			// this path dropped it). Causes 3+ minute recovery loops while
+			// suture retries via FailureBackoff.
+			proc, err = upstream.Start(o.command, o.args, o.env, o.cwd, o.logger)
 		}
 		if err != nil {
 			o.logger.Printf("background upstream spawn failed: %v (serving stale cache)", err)
@@ -475,6 +486,7 @@ func NewOwner(cfg OwnerConfig) (*Owner, error) {
 		cwdSet:                 map[string]bool{serverid.CanonicalizePath(cfg.Cwd): true},
 		command:                cfg.Command,
 		args:                   cfg.Args,
+		env:                    cfg.Env,
 		handlerFunc:            cfg.HandlerFunc,
 		sessionHandler:         cfg.SessionHandler,
 		serverID:               cfg.ServerID,

--- a/muxcore/owner/owner.go
+++ b/muxcore/owner/owner.go
@@ -360,7 +360,7 @@ func (o *Owner) SpawnUpstreamBackground() {
 			proc = upstream.NewProcessFromHandler(context.Background(), o.handlerFunc)
 			o.logger.Printf("background handler spawn: in-process (no subprocess)")
 		} else {
-			proc, err = upstream.Start(o.command, o.args, nil, o.cwd)
+			proc, err = upstream.Start(o.command, o.args, nil, o.cwd, o.logger)
 		}
 		if err != nil {
 			o.logger.Printf("background upstream spawn failed: %v (serving stale cache)", err)
@@ -453,7 +453,7 @@ func NewOwner(cfg OwnerConfig) (*Owner, error) {
 		logger.Printf("owner: started in-process handler (no subprocess)")
 	} else {
 		var err error
-		proc, err = upstream.Start(cfg.Command, cfg.Args, cfg.Env, cfg.Cwd)
+		proc, err = upstream.Start(cfg.Command, cfg.Args, cfg.Env, cfg.Cwd, logger)
 		if err != nil {
 			return nil, fmt.Errorf("owner: start upstream: %w", err)
 		}

--- a/muxcore/upstream/process.go
+++ b/muxcore/upstream/process.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"os/exec"
 	"sync"
@@ -50,7 +51,13 @@ func (p *Process) SetDrainTimeout(d time.Duration) {
 // When env is non-empty, it is used as the complete process environment (converted from map to slice).
 // When env is nil/empty, the current process environment (os.Environ()) is used as fallback.
 // If cwd is non-empty, the child process runs in that directory.
-func Start(command string, args []string, env map[string]string, cwd string) (*Process, error) {
+//
+// If logger is non-nil, upstream stderr is forwarded to it (one log.Printf per line,
+// prefix "[upstream:PID] "). If logger is nil, stderr is forwarded to os.Stderr of the
+// calling process. In daemon mode os.Stderr is typically discarded (daemon is detached
+// with cmd.Stderr=nil), so upstream crash diagnostics get lost — callers running under
+// a daemon MUST pass a logger to preserve stderr.
+func Start(command string, args []string, env map[string]string, cwd string, logger *log.Logger) (*Process, error) {
 	var merged []string
 	if len(env) > 0 {
 		// Full session env provided — use it directly, no os.Environ() merge.
@@ -124,11 +131,19 @@ func Start(command string, args []string, env map[string]string, cwd string) (*P
 	// Forward stderr to logger (prefix with [upstream]) so diagnostics are visible.
 	// Buffer must be large enough for long lines (MSBuild paths, NuGet restore logs).
 	// If scanner stops reading (line too long), stderr pipe fills → upstream blocks.
+	//
+	// When the caller supplies a logger, route stderr there — the daemon runs
+	// detached with os.Stderr discarded, so writing to os.Stderr would drop
+	// every crash diagnostic (the exact failure mode we are fixing here).
 	go func() {
 		scanner := bufio.NewScanner(p.stderr)
 		scanner.Buffer(make([]byte, 64*1024), 64*1024) // 64KB — handles any build output line
 		for scanner.Scan() {
-			fmt.Fprintf(os.Stderr, "[upstream:%d] %s\n", proc.PID(), scanner.Text())
+			if logger != nil {
+				logger.Printf("[upstream:%d] %s", proc.PID(), scanner.Text())
+			} else {
+				fmt.Fprintf(os.Stderr, "[upstream:%d] %s\n", proc.PID(), scanner.Text())
+			}
 		}
 	}()
 

--- a/muxcore/upstream/process_test.go
+++ b/muxcore/upstream/process_test.go
@@ -1,8 +1,11 @@
 package upstream
 
 import (
+	"bytes"
+	"log"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -19,7 +22,7 @@ func TestStartAndClose(t *testing.T) {
 		args = []string{"hello"}
 	}
 
-	p, err := Start(cmd, args, nil, "")
+	p, err := Start(cmd, args, nil, "", nil)
 	if err != nil {
 		t.Fatalf("Start() error: %v", err)
 	}
@@ -37,7 +40,7 @@ func TestStartAndClose(t *testing.T) {
 func TestWriteAndRead(t *testing.T) {
 	// Use 'go run' with a simple cat-like program
 	// For cross-platform, we use Go itself
-	p, err := Start("go", []string{"run", "../../testdata/echo_pipe.go"}, nil, "")
+	p, err := Start("go", []string{"run", "../../testdata/echo_pipe.go"}, nil, "", nil)
 	if err != nil {
 		t.Skipf("Skipping: cannot start echo_pipe: %v", err)
 	}
@@ -70,7 +73,7 @@ func TestProcessDone(t *testing.T) {
 		args = []string{"done"}
 	}
 
-	p, err := Start(cmd, args, nil, "")
+	p, err := Start(cmd, args, nil, "", nil)
 	if err != nil {
 		t.Fatalf("Start() error: %v", err)
 	}
@@ -95,7 +98,7 @@ func TestProcessPID(t *testing.T) {
 		args = []string{"pid"}
 	}
 
-	p, err := Start(cmd, args, nil, "")
+	p, err := Start(cmd, args, nil, "", nil)
 	if err != nil {
 		t.Fatalf("Start() error: %v", err)
 	}
@@ -118,7 +121,7 @@ func TestCloseTerminatesProcess(t *testing.T) {
 		args = []string{"30"}
 	}
 
-	p, err := Start(cmd, args, nil, "")
+	p, err := Start(cmd, args, nil, "", nil)
 	if err != nil {
 		t.Fatalf("Start() error: %v", err)
 	}
@@ -147,7 +150,7 @@ func TestReadLineAfterClose(t *testing.T) {
 		args = []string{"line1"}
 	}
 
-	p, err := Start(cmd, args, nil, "")
+	p, err := Start(cmd, args, nil, "", nil)
 	if err != nil {
 		t.Fatalf("Start() error: %v", err)
 	}
@@ -165,6 +168,74 @@ func TestReadLineAfterClose(t *testing.T) {
 	}
 }
 
+// TestStderrRoutedToLogger verifies upstream stderr lines are forwarded to the
+// caller-supplied logger instead of os.Stderr. This is the diagnostic that
+// lets us see why upstreams (e.g. cclsp) crash with exit status 1 when the
+// daemon runs detached with os.Stderr discarded — before this fix the error
+// output was silently dropped and crashes looked like mysterious "upstream
+// exited: exit status 1" with no further context.
+func TestStderrRoutedToLogger(t *testing.T) {
+	var (
+		buf bytes.Buffer
+		mu  sync.Mutex
+	)
+	logger := log.New(&syncWriter{buf: &buf, mu: &mu}, "", 0)
+
+	// Child process writes a unique sentinel to its stderr then exits.
+	var cmd string
+	var args []string
+	const sentinel = "upstream-stderr-sentinel-x91z"
+	if runtime.GOOS == "windows" {
+		cmd = "cmd"
+		args = []string{"/c", "echo", sentinel, "1>&2"}
+	} else {
+		cmd = "sh"
+		args = []string{"-c", "echo " + sentinel + " 1>&2"}
+	}
+
+	p, err := Start(cmd, args, nil, "", logger)
+	if err != nil {
+		t.Fatalf("Start() error: %v", err)
+	}
+	defer p.Close()
+
+	// Wait for the process to exit so the stderr goroutine has flushed.
+	select {
+	case <-p.Done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("process did not exit within timeout")
+	}
+	// Allow the forwarding goroutine a brief moment to drain after Done.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		captured := buf.String()
+		mu.Unlock()
+		if strings.Contains(captured, sentinel) {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	mu.Lock()
+	final := buf.String()
+	mu.Unlock()
+	t.Fatalf("logger did not receive sentinel %q; captured=%q", sentinel, final)
+}
+
+// syncWriter serializes writes under a mutex so concurrent stderr drains and
+// test assertions never observe a torn byte slice.
+type syncWriter struct {
+	buf *bytes.Buffer
+	mu  *sync.Mutex
+}
+
+func (w *syncWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.Write(p)
+}
+
 func TestEnvironmentPassing(t *testing.T) {
 	var cmd string
 	var args []string
@@ -180,7 +251,7 @@ func TestEnvironmentPassing(t *testing.T) {
 		"TEST_MUX_VAR": "mux_value_123",
 	}
 
-	p, err := Start(cmd, args, env, "")
+	p, err := Start(cmd, args, env, "", nil)
 	if err != nil {
 		t.Fatalf("Start() error: %v", err)
 	}


### PR DESCRIPTION
## Problem

cclsp repeatedly exits with `upstream exited: exit status 1` shortly after spawn. CC UI shows it as `failed` in /mcp. Daemon log contains the symptom but never the cause, because `upstream.Start` forwarded the child stderr to `os.Stderr` of the daemon process, and the daemon is launched detached with `cmd.Stderr = nil`. Every crash message went to the platform bit-bucket.

## Fix

Thread an optional `*log.Logger` through `upstream.Start` and use it for stderr forwarding when set. Both call sites in muxcore/owner pass `o.logger` so stderr lands in `mcp-muxd-debug.log`.

## Scope

Diagnostic-only. Does not stop cclsp from exiting; makes the exit reason visible.

## API change

`upstream.Start(command, args, env, cwd)` -> adds `logger *log.Logger`. Internal package; downstream consumers use SessionHandler / Handler, not `upstream.Start`.

## Tests

- New `TestStderrRoutedToLogger` regression test
- Existing tests updated, all pass
- `go vet` clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Улучшения**
  * Подпроцессы теперь могут направлять stderr в системный лог приложения; при запуске фоновых компонентов и при восстановлении снимков передаётся логгер для лучшей корреляции сообщений.
  * Среда запуска/восстановления формируется слиянием переданных и текущих переменных окружения, заполняя отсутствующие значения из демона.

* **Логи**
  * Сообщения запуска дополнены сведениями о размере шима vs итого и наличием распространённых ключей/токенов.

* **Тесты**
  * Добавлены тесты для маршрутизации stderr в логгер и для проверки логики слияния окружения (с учётом синхронизации вывода).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->