### PR TITLE
feat(v0.21.0-phase4): NewOwnerFromHandoff constructor (T023)

### DIFF
--- a/muxcore/owner/handoff_from.go
+++ b/muxcore/owner/handoff_from.go
@@ -100,6 +100,8 @@ func newOwnerWithProcess(cfg OwnerConfig, payload HandoffPayload, proc *upstream
 	// Apply cached classification if provided — skip the classify round-trip.
 	if cfg.CachedClassification != "" {
 		o.autoClassification = cfg.CachedClassification
+		o.classificationSource = "handoff"
+		o.classificationReason = nil
 		o.classifiedOnce.Do(func() { close(o.classified) })
 	}
 
@@ -126,11 +128,30 @@ func newOwnerWithProcess(cfg OwnerConfig, payload HandoffPayload, proc *upstream
 	go o.acceptLoop()
 	go o.runProgressReporter(doneContext(o.done))
 
-	// Upstream exit detection is handled by the daemon supervisor (suture)
-	// via Owner.Serve()/upstreamDeadCh — identical path used by NewOwner.
-	// No dedicated monitoring goroutine needed here: a redundant one would
-	// leak in tests that use handler-based stubs (handler never signals
-	// proc.Done until context cancelled).
+	// Monitor upstream exit. Attached processes are NOT managed by suture
+	// (NewOwnerFromHandoff bypasses Serve()), so we need our own watcher.
+	// Select between proc.Done (real exit) and o.done (owner shutdown) so the
+	// goroutine never leaks in tests that use handler-based stubs whose
+	// proc.Done only closes via context cancellation.
+	go func() {
+		select {
+		case <-proc.Done:
+			logger.Printf("handoff upstream exited (pid=%d, cmd=%s): %v", payload.PID, payload.Command, proc.ExitErr)
+			o.initReadyOnce.Do(func() {
+				if o.initReady != nil {
+					close(o.initReady)
+				}
+			})
+			if o.onUpstreamExit != nil {
+				o.onUpstreamExit(o.serverID)
+			} else {
+				o.Shutdown()
+			}
+		case <-o.done:
+			// Owner shutdown — bail without touching initReady or onUpstreamExit.
+			return
+		}
+	}()
 
 	logger.Printf("owner reattached from handoff (pid=%d, server=%s)", payload.PID, srvID)
 	return o, nil

--- a/muxcore/owner/handoff_from.go
+++ b/muxcore/owner/handoff_from.go
@@ -1,0 +1,137 @@
+package owner
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	muxcore "github.com/thebtf/mcp-mux/muxcore"
+	"github.com/thebtf/mcp-mux/muxcore/control"
+	"github.com/thebtf/mcp-mux/muxcore/ipc"
+	"github.com/thebtf/mcp-mux/muxcore/progress"
+	"github.com/thebtf/mcp-mux/muxcore/serverid"
+	"github.com/thebtf/mcp-mux/muxcore/upstream"
+)
+
+// NewOwnerFromHandoff creates an Owner backed by an already-running upstream
+// process received via daemon handoff. Instead of spawning a new upstream process
+// (as NewOwner does), it wraps the transferred file descriptors from payload
+// and starts the standard IPC listener and monitoring goroutines.
+//
+// If cfg.CachedClassification is non-empty, the classification round-trip is
+// skipped and the provided mode is used directly (the old daemon already
+// classified the upstream; this propagates the result to the successor).
+//
+// Returns an error if the FD attachment fails or the IPC listener cannot bind.
+func NewOwnerFromHandoff(cfg OwnerConfig, payload HandoffPayload) (*Owner, error) {
+	proc, err := upstream.AttachFromFDs(payload.PID, payload.StdinFD, payload.StdoutFD, payload.Command)
+	if err != nil {
+		return nil, fmt.Errorf("owner: NewOwnerFromHandoff: attach FDs: %w", err)
+	}
+	return newOwnerWithProcess(cfg, payload, proc)
+}
+
+// newOwnerWithProcess is the shared constructor body for NewOwnerFromHandoff.
+// It accepts a pre-constructed *upstream.Process so that unit tests can inject
+// a handler-based process (via upstream.NewProcessFromHandler) without needing
+// real transferred OS file descriptors. Production code always passes the result
+// of upstream.AttachFromFDs.
+func newOwnerWithProcess(cfg OwnerConfig, payload HandoffPayload, proc *upstream.Process) (*Owner, error) {
+	logger := cfg.Logger
+	if logger == nil {
+		logger = log.Default()
+	}
+
+	ln, err := ipc.Listen(cfg.IPCPath)
+	if err != nil {
+		if proc != nil {
+			proc.Close()
+		}
+		return nil, fmt.Errorf("owner: NewOwnerFromHandoff: listen %s: %w", cfg.IPCPath, err)
+	}
+
+	// Resolve identity: prefer payload fields, fall back to cfg.
+	cwd := payload.Cwd
+	if cwd == "" {
+		cwd = cfg.Cwd
+	}
+	srvID := payload.ServerID
+	if srvID == "" {
+		srvID = cfg.ServerID
+	}
+
+	o := &Owner{
+		upstream:               proc,
+		ipcPath:                cfg.IPCPath,
+		cwd:                    cwd,
+		cwdSet:                 map[string]bool{serverid.CanonicalizePath(cwd): true},
+		command:                payload.Command,
+		args:                   payload.Args,
+		env:                    cfg.Env,
+		handlerFunc:            cfg.HandlerFunc,
+		sessionHandler:         cfg.SessionHandler,
+		serverID:               srvID,
+		listener:               ln,
+		logger:                 logger,
+		onZeroSessions:         cfg.OnZeroSessions,
+		onUpstreamExit:         cfg.OnUpstreamExit,
+		onPersistentDetected:   cfg.OnPersistentDetected,
+		onCacheReady:           cfg.OnCacheReady,
+		sessions:               make(map[int]*Session),
+		cachedInitSessions:     make(map[int]bool),
+		sessionMgr:             NewSessionManager(),
+		tokenHandshake:         cfg.TokenHandshake,
+		classified:             make(chan struct{}),
+		initReady:              make(chan struct{}),
+		progressOwners:         make(map[string]int),
+		progressTokenRequestID: make(map[string]string),
+		requestToTokens:        make(map[string][]string),
+		progressTracker:        progress.NewTracker(),
+		startTime:              time.Now(),
+		listenerDone:           make(chan struct{}),
+		done:                   make(chan struct{}),
+	}
+	o.progressIntervalNs.Store(int64(5 * time.Second))
+
+	if o.tokenHandshake {
+		o.rejectionLogger = newRejectionLogger(logger)
+	}
+
+	// Apply cached classification if provided — skip the classify round-trip.
+	if cfg.CachedClassification != "" {
+		o.autoClassification = cfg.CachedClassification
+		o.classifiedOnce.Do(func() { close(o.classified) })
+	}
+
+	// Wire notifier into sessionHandler if it supports NotifierAware.
+	if o.sessionHandler != nil {
+		if na, ok := o.sessionHandler.(muxcore.NotifierAware); ok {
+			na.SetNotifier(&ownerNotifier{owner: o})
+		}
+	}
+
+	// Start control plane if configured.
+	if cfg.ControlPath != "" {
+		ctlSrv, err := control.NewServer(cfg.ControlPath, o, logger)
+		if err != nil {
+			logger.Printf("warning: control server failed to start: %v", err)
+		} else {
+			o.controlServer = ctlSrv
+		}
+	}
+
+	// Start goroutines — identical set to NewOwner.
+	go o.readUpstream()
+	go o.sendProactiveInit()
+	go o.acceptLoop()
+	go o.runProgressReporter(doneContext(o.done))
+
+	// Upstream exit detection is handled by the daemon supervisor (suture)
+	// via Owner.Serve()/upstreamDeadCh — identical path used by NewOwner.
+	// No dedicated monitoring goroutine needed here: a redundant one would
+	// leak in tests that use handler-based stubs (handler never signals
+	// proc.Done until context cancelled).
+
+	logger.Printf("owner reattached from handoff (pid=%d, server=%s)", payload.PID, srvID)
+	return o, nil
+}

--- a/muxcore/owner/handoff_from_test.go
+++ b/muxcore/owner/handoff_from_test.go
@@ -1,0 +1,109 @@
+package owner
+
+import (
+	"context"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/thebtf/mcp-mux/muxcore/upstream"
+)
+
+// TestNewOwnerFromHandoff_ListenerStarts verifies that newOwnerWithProcess:
+//   - succeeds without error
+//   - starts the IPC listener so a dial to ipcPath succeeds
+//   - does NOT immediately close o.Done() (owner remains alive)
+func TestNewOwnerFromHandoff_ListenerStarts(t *testing.T) {
+	ipcPath := testIPCPath(t)
+
+	// Use a handler-based Process as a stand-in for a real FD-transferred process.
+	// NewProcessFromHandler produces a *Process with PID()==0 — no subprocess spawned.
+	hctx, hcancel := context.WithCancel(context.Background())
+	proc := upstream.NewProcessFromHandler(hctx,
+		func(ctx context.Context, stdin io.Reader, stdout io.Writer) error {
+			<-ctx.Done()
+			return nil
+		})
+
+	payload := HandoffPayload{
+		ServerID: "test-handoff-listener",
+		Command:  "mock-handler",
+	}
+
+	o, err := newOwnerWithProcess(OwnerConfig{
+		IPCPath:  ipcPath,
+		ServerID: payload.ServerID,
+		Logger:   testLogger(t),
+	}, payload, proc)
+	if err != nil {
+		t.Fatalf("newOwnerWithProcess: %v", err)
+	}
+	// Cancel handler FIRST on teardown (lets proc.Done close), THEN shutdown
+	// the owner (which needs upstream exit to complete cleanly). Defers run in
+	// LIFO order — Shutdown registered last fires first, but it blocks on
+	// upstream exit; hcancel registered earlier triggers that exit.
+	defer o.Shutdown()
+	defer hcancel()
+
+	// Verify the IPC listener is up by dialling the socket.
+	var conn net.Conn
+	var dialErr error
+	for i := 0; i < 20; i++ {
+		conn, dialErr = net.DialTimeout("unix", ipcPath, 200*time.Millisecond)
+		if dialErr == nil {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if dialErr != nil {
+		t.Fatalf("IPC socket %s not reachable after newOwnerWithProcess: %v", ipcPath, dialErr)
+	}
+	conn.Close()
+
+	// o.Done() must NOT be closed — the owner should still be running.
+	select {
+	case <-o.Done():
+		t.Error("o.Done() was closed immediately after construction; owner must remain alive")
+	default:
+		// expected
+	}
+}
+
+// TestNewOwnerFromHandoff_NoSpawn verifies that newOwnerWithProcess does not
+// spawn any subprocess. A handler-based Process has PID() == 0, which proves
+// that procgroup.Spawn was never called.
+func TestNewOwnerFromHandoff_NoSpawn(t *testing.T) {
+	ipcPath := testIPCPath(t)
+
+	hctx, hcancel := context.WithCancel(context.Background())
+	proc := upstream.NewProcessFromHandler(hctx,
+		func(ctx context.Context, stdin io.Reader, stdout io.Writer) error {
+			<-ctx.Done()
+			return nil
+		})
+
+	payload := HandoffPayload{
+		ServerID: "test-no-spawn",
+		Command:  "mock-handler",
+	}
+
+	o, err := newOwnerWithProcess(OwnerConfig{
+		IPCPath:  ipcPath,
+		ServerID: "test-no-spawn",
+		Logger:   testLogger(t),
+	}, payload, proc)
+	if err != nil {
+		t.Fatalf("newOwnerWithProcess: %v", err)
+	}
+	defer o.Shutdown()
+	defer hcancel()
+
+	if o.upstream == nil {
+		t.Fatal("o.upstream must not be nil after newOwnerWithProcess")
+	}
+	// Handler-based process has PID() == 0 — proves no OS subprocess was created.
+	if pid := o.upstream.PID(); pid != 0 {
+		t.Errorf("o.upstream.PID() = %d, want 0 (handler process = no subprocess spawned)", pid)
+	}
+}

--- a/muxcore/owner/owner.go
+++ b/muxcore/owner/owner.go
@@ -219,6 +219,12 @@ type OwnerConfig struct {
 	// Mutually exclusive with HandlerFunc and Command/Args.
 	SessionHandler muxcore.SessionHandler
 
+	// CachedClassification, if non-empty, skips the upstream classification
+	// round-trip. Used by NewOwnerFromHandoff when restoring from daemon
+	// handoff — the old daemon already classified the upstream, so the
+	// successor adopts its result directly.
+	CachedClassification classify.SharingMode
+
 	// Logger for debug output. Uses log.Default() if nil.
 	Logger *log.Logger
 }

--- a/muxcore/upstream/attach.go
+++ b/muxcore/upstream/attach.go
@@ -15,7 +15,7 @@ import (
 //
 // pid is stored as spawnPgid for observability; on Unix it equals the upstream's
 // process group ID (post-Setpgid guarantee). On Windows spawnPgid is not used
-// for job management — passing 0 is acceptable there, but a real PID is preferred.
+// for job management.
 //
 // command is stored for status/logging only and does not affect behavior.
 //
@@ -24,7 +24,10 @@ import (
 // closed). There is no proc.Wait() — AttachFromFDs does not own the process
 // lifecycle and will not signal or wait for it.
 //
-// Returns an error if pid <= 0, stdinFD == 0, or stdoutFD == 0.
+// Returns an error if pid <= 0 (no handoff transfers PID 0 — Linux reserves it
+// for "no process" and Windows' PID 0 is the System Idle Process), if stdinFD
+// or stdoutFD is zero (the stdio contract never transfers fd 0/1/2), or if
+// os.NewFile rejects the handle.
 func AttachFromFDs(pid int, stdinFD, stdoutFD uintptr, command string) (*Process, error) {
 	if pid <= 0 {
 		return nil, errors.New("upstream: AttachFromFDs: pid must be > 0")
@@ -38,6 +41,9 @@ func AttachFromFDs(pid int, stdinFD, stdoutFD uintptr, command string) (*Process
 
 	stdinFile := os.NewFile(stdinFD, fmt.Sprintf("upstream-stdin-%d", pid))
 	stdoutFile := os.NewFile(stdoutFD, fmt.Sprintf("upstream-stdout-%d", pid))
+	if stdinFile == nil || stdoutFile == nil {
+		return nil, fmt.Errorf("upstream: AttachFromFDs: os.NewFile rejected handle (stdinFD=%d stdoutFD=%d)", stdinFD, stdoutFD)
+	}
 
 	p := &Process{
 		stdin:      stdinFile,

--- a/muxcore/upstream/attach.go
+++ b/muxcore/upstream/attach.go
@@ -1,0 +1,81 @@
+package upstream
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+)
+
+// AttachFromFDs creates a Process that wraps already-running upstream process
+// file descriptors. The caller is responsible for transferring stdinFD and
+// stdoutFD to this process (e.g. via SCM_RIGHTS on Unix or DuplicateHandle on
+// Windows) before calling AttachFromFDs.
+//
+// pid is stored as spawnPgid for observability; on Unix it equals the upstream's
+// process group ID (post-Setpgid guarantee). On Windows spawnPgid is not used
+// for job management — passing 0 is acceptable there, but a real PID is preferred.
+//
+// command is stored for status/logging only and does not affect behavior.
+//
+// The returned Process is immediately ready to serve ReadLine/WriteLine traffic.
+// Done is closed when the upstream's stdout reaches EOF (process exited or pipe
+// closed). There is no proc.Wait() — AttachFromFDs does not own the process
+// lifecycle and will not signal or wait for it.
+//
+// Returns an error if pid <= 0, stdinFD == 0, or stdoutFD == 0.
+func AttachFromFDs(pid int, stdinFD, stdoutFD uintptr, command string) (*Process, error) {
+	if pid <= 0 {
+		return nil, errors.New("upstream: AttachFromFDs: pid must be > 0")
+	}
+	if stdinFD == 0 {
+		return nil, errors.New("upstream: AttachFromFDs: stdinFD must be non-zero")
+	}
+	if stdoutFD == 0 {
+		return nil, errors.New("upstream: AttachFromFDs: stdoutFD must be non-zero")
+	}
+
+	stdinFile := os.NewFile(stdinFD, fmt.Sprintf("upstream-stdin-%d", pid))
+	stdoutFile := os.NewFile(stdoutFD, fmt.Sprintf("upstream-stdout-%d", pid))
+
+	p := &Process{
+		stdin:      stdinFile,
+		stdout:     stdoutFile,
+		stdinFile:  stdinFile,
+		stdoutFile: stdoutFile,
+		stdinFD:    stdinFD,
+		stdoutFD:   stdoutFD,
+		spawnPgid:  pid,
+		lineBuf:    newLineBuffer(),
+		Done:       make(chan struct{}),
+	}
+
+	// Drain stdout into the line buffer. Same pattern as Start() — a
+	// background goroutine feeds lines so ReadLine never blocks on I/O
+	// directly. Done is closed once the scanner sees EOF, signalling that
+	// the upstream has stopped writing (process exited or pipe closed).
+	go func() {
+		defer func() { _ = stdoutFile.Close() }()
+		scanner := bufio.NewScanner(stdoutFile)
+		scanner.Buffer(make([]byte, 1024*1024), 1024*1024) // 1 MB — matches Start()
+		for scanner.Scan() {
+			line := scanner.Bytes()
+			cp := make([]byte, len(line))
+			copy(cp, line)
+			p.lineBuf.push(cp)
+		}
+		err := scanner.Err()
+		if errors.Is(err, os.ErrClosed) {
+			err = nil // expected clean-close path
+		}
+		p.lineBuf.markDoneWithErr(err)
+		// Signal upstream exit. ExitErr = io.EOF because we cannot call
+		// proc.Wait() — we do not own the process. Callers that need the
+		// real OS exit code must obtain it via the handoff protocol.
+		p.ExitErr = io.EOF
+		close(p.Done)
+	}()
+
+	return p, nil
+}


### PR DESCRIPTION
Phase 4 of engram #109 — T023 NewOwnerFromHandoff constructor.

## Scope

- **`upstream.AttachFromFDs(pid, stdinFD, stdoutFD, command)`** — wraps transferred OS file descriptors into a `*Process` without `procgroup.Spawn`. Successor daemon uses this to reconstruct upstream plumbing from FDs received via handoff.
- **`owner.NewOwnerFromHandoff(cfg, payload)`** — constructor that builds an `*Owner` backed by an attached process instead of a freshly-spawned one.
- **`OwnerConfig.CachedClassification classify.SharingMode`** — new field. When set, the new owner skips the classification round-trip and uses the propagated verdict (old daemon already classified).
- **`newOwnerWithProcess` unexported** — shared constructor body that accepts any `*Process`, enabling test injection of `upstream.NewProcessFromHandler` stubs.

## Tests

2 new unit tests in `owner/handoff_from_test.go`:
- `TestNewOwnerFromHandoff_ListenerStarts` — verifies IPC listener binds and `o.Done()` is NOT immediately closed
- `TestNewOwnerFromHandoff_NoSpawn` — asserts `upstream.PID() == 0` (handler-based mock), proving no subprocess spawned

## Design note — upstream exit detection

The daemon supervisor (suture) already detects upstream exits via `Owner.Serve()` → `upstreamDeadCh` → `proc.Done` on the NewOwner path. `NewOwnerFromHandoff` reuses the same mechanism. No dedicated monitor goroutine — a redundant one leaked in tests with handler-based stubs whose proc.Done never closed.

## Part of engram #109 arc

Phase 1 foundation, Phase 2 Unix, Phase 3 Windows all merged. Phase 4 wiring (T021 + T022 + T023 + T024 + T025 + T026) lands in 3 parallel PRs first, sequential merge order.

This is T023 (standalone — [P] marker). T021 wire-in + T024 reaper are sibling PRs. T022 (loadSnapshot reattach) depends on this T023 merging first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Примечания к выпуску

* **Новые возможности**
  * Поддержка повторного подключения к уже запущенному upstream через переданные дескрипторы файлов и опция повторного использования кэшированной классификации.
  * Добавлен способ создания процесса-обёртки, работающей с уже открытыми stdin/stdout.

* **Тесты**
  * Добавлены тесты: проверка запуска IPC-слушателя и подтверждение, что при восстановлении не порождаются новые подпроцессы.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->