### PR TITLE
feat(v0.21.0-phase4): SoftRemove reaper path with 30s stdin drain (T024)

### DIFF
--- a/muxcore/.engram-project
+++ b/muxcore/.engram-project
@@ -1,0 +1,3 @@
+{
+  "name": "muxcore"
+}

--- a/muxcore/daemon/daemon.go
+++ b/muxcore/daemon/daemon.go
@@ -845,7 +845,7 @@ func (d *Daemon) SoftRemove(serverID string) error {
 	} else if exitCode == 0 {
 		d.logger.Printf("soft-removed owner %s: upstream exited cleanly (code 0)", serverID[:8])
 	} else {
-		d.logger.Printf("soft-removed owner %s: upstream forced exit (code %d)", serverID[:8], exitCode)
+		d.logger.Printf("soft-removed owner %s: upstream exited with code %d", serverID[:8], exitCode)
 	}
 
 	if supErr != nil {

--- a/muxcore/daemon/daemon.go
+++ b/muxcore/daemon/daemon.go
@@ -807,6 +807,53 @@ func (d *Daemon) Remove(serverID string) error {
 	return supErr
 }
 
+// SoftRemove performs a graceful shutdown of the named owner, giving the upstream
+// up to 30 seconds to exit cleanly via stdin close before escalating to SIGTERM/SIGKILL.
+//
+// Use Remove (hard kill) for operator-requested restarts; use SoftRemove for idle
+// eviction so upstreams can flush caches, close files, and exit with code 0 (US3).
+func (d *Daemon) SoftRemove(serverID string) error {
+	d.mu.Lock()
+	entry, ok := d.owners[serverID]
+	if !ok {
+		d.mu.Unlock()
+		return fmt.Errorf("server %s not found", serverID)
+	}
+	if entry.Owner == nil {
+		// Placeholder still being created — do not remove.
+		d.mu.Unlock()
+		return fmt.Errorf("server %s is still being created", serverID)
+	}
+	delete(d.owners, serverID)
+	token := entry.serviceToken
+	d.mu.Unlock()
+
+	// Remove from supervisor BEFORE SoftShutdown to prevent suture from
+	// interpreting the shutdown as a failure and attempting restart.
+	var supErr error
+	if d.supervisor != nil {
+		if err := d.supervisor.RemoveAndWait(token, 2*time.Second); err != nil {
+			supErr = fmt.Errorf("soft-remove owner %s from supervisor: %w", serverID[:8], err)
+			d.logger.Printf("warning: %v", supErr)
+		}
+	}
+
+	// Soft shutdown: stdin close → 30s wait → GracefulKill fallback.
+	exitCode, err := entry.Owner.SoftShutdown(30 * time.Second)
+	if err != nil {
+		d.logger.Printf("soft-removed owner %s: forced kill (exit=%d err=%v)", serverID[:8], exitCode, err)
+	} else if exitCode == 0 {
+		d.logger.Printf("soft-removed owner %s: upstream exited cleanly (code 0)", serverID[:8])
+	} else {
+		d.logger.Printf("soft-removed owner %s: upstream forced exit (code %d)", serverID[:8], exitCode)
+	}
+
+	if supErr != nil {
+		return supErr
+	}
+	return nil
+}
+
 // HandleSpawn implements control.DaemonHandler.
 func (d *Daemon) HandleSpawn(req control.Request) (string, string, string, error) {
 	return d.Spawn(req)

--- a/muxcore/daemon/reaper.go
+++ b/muxcore/daemon/reaper.go
@@ -157,14 +157,18 @@ func (r *Reaper) sweep() int {
 		decision := shouldEvict(sample, now, r.daemon.ownerIdleTimeout)
 		if decision.evict {
 			if decision.reason == "zombie" {
+				// Upstream is already dead — hard remove (no point in stdin close).
 				r.logger.Printf("reaper: owner %s upstream dead with 0 sessions, removing", sid[:8])
+				_ = r.daemon.Remove(sid)
 			} else {
+				// Idle eviction: give upstream a chance to exit cleanly via stdin close.
+				// SoftRemove closes stdin and waits up to 30s before SIGTERM/SIGKILL (US3).
 				r.logger.Printf(
-					"reaper: owner %s idle for %.0fs (timeout %.0fs), removing",
+					"reaper: owner %s idle for %.0fs (timeout %.0fs), soft-removing",
 					sid[:8], decision.elapsed.Seconds(), decision.idleTimeout.Seconds(),
 				)
+				_ = r.daemon.SoftRemove(sid)
 			}
-			_ = r.daemon.Remove(sid)
 			affected++
 		}
 	}

--- a/muxcore/owner/owner.go
+++ b/muxcore/owner/owner.go
@@ -1832,6 +1832,36 @@ func (o *Owner) Shutdown() {
 	})
 }
 
+// SoftShutdown performs the same cleanup as Shutdown (closes listener, sessions,
+// control server) but instead of calling upstream.Close() it calls
+// upstream.SoftClose(timeout) — giving the upstream a chance to exit cleanly
+// via stdin close before resorting to SIGTERM/SIGKILL.
+//
+// Returns the upstream exit code (0 = clean) and any kill-escalation error.
+// Used by the idle reaper (US3) to avoid SIGKILL on polite upstreams.
+func (o *Owner) SoftShutdown(timeout time.Duration) (int, error) {
+	exitCode := 0
+	var exitErr error
+
+	o.shutdownOnce.Do(func() {
+		o.teardownExceptUpstream()
+
+		o.mu.Lock()
+		up := o.upstream
+		o.mu.Unlock()
+		if up != nil {
+			exitCode, exitErr = up.SoftClose(timeout)
+		}
+
+		o.logger.Printf("owner soft shut down (upstream exit code %d)", exitCode)
+
+		// Signal done AFTER cleanup.
+		close(o.done)
+	})
+
+	return exitCode, exitErr
+}
+
 // Done returns a channel closed when the owner has shut down.
 func (o *Owner) Done() <-chan struct{} {
 	return o.done

--- a/muxcore/upstream/process.go
+++ b/muxcore/upstream/process.go
@@ -20,6 +20,78 @@ import (
 	"github.com/thebtf/mcp-mux/muxcore/procgroup"
 )
 
+// SoftClose closes the upstream process gracefully via stdin close, waiting up
+// to timeout for voluntary exit before escalating to GracefulKill.
+//
+// Graceful soft-close sequence (US3):
+//  1. Close stdin — polite MCP shutdown signal (well-behaved servers exit on EOF).
+//  2. Wait up to timeout for voluntary exit. Default 30s when called by the reaper.
+//  3. If still alive after timeout: proc.GracefulKill(3s) — SIGTERM→wait→SIGKILL.
+//
+// Returns the upstream exit code (0 = clean voluntary exit, non-zero = forced)
+// and any error from the kill escalation.
+// Safe to call after Close() — returns (0, nil) if already closed or detached.
+func (p *Process) SoftClose(timeout time.Duration) (int, error) {
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		return 0, nil
+	}
+	if p.detached {
+		p.mu.Unlock()
+		return 0, nil
+	}
+	p.closed = true
+	p.mu.Unlock()
+
+	// Release the Windows Job Object handle (no-op on non-Windows).
+	releaseJobHandle(p)
+
+	// Phase 1: close stdin — polite MCP shutdown signal.
+	if p.stdin != nil {
+		_ = p.stdin.Close()
+	}
+
+	// Phase 2: wait for voluntary exit.
+	select {
+	case <-p.Done:
+		// Exited cleanly on its own.
+		return softCloseExitCode(p.ExitErr), nil
+	case <-time.After(timeout):
+	}
+
+	// Phase 3: timeout — escalate to GracefulKill.
+	if p.proc != nil {
+		killErr := p.proc.GracefulKill(3 * time.Second)
+		// Wait for the process to fully exit so ExitErr is populated.
+		select {
+		case <-p.Done:
+		case <-time.After(5 * time.Second):
+			return -1, fmt.Errorf("upstream: process did not exit after GracefulKill")
+		}
+		if killErr != nil {
+			return softCloseExitCode(p.ExitErr), killErr
+		}
+		return softCloseExitCode(p.ExitErr), nil
+	}
+
+	return -1, nil
+}
+
+// softCloseExitCode extracts the process exit code from a Wait() error.
+// Returns 0 for nil (clean exit), the numeric exit code for *exec.ExitError,
+// and 1 for any other non-nil error.
+func softCloseExitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode()
+	}
+	return 1
+}
+
 // ErrAlreadyClosed is returned by Detach if the process has already been closed.
 var ErrAlreadyClosed = errors.New("upstream: process already closed")
 

--- a/muxcore/upstream/process.go
+++ b/muxcore/upstream/process.go
@@ -29,7 +29,9 @@ import (
 //  3. If still alive after timeout: proc.GracefulKill(3s) — SIGTERM→wait→SIGKILL.
 //
 // Returns the upstream exit code (0 = clean voluntary exit, non-zero = forced)
-// and any error from the kill escalation.
+// and any error from the kill escalation. A non-nil error signals that a forced
+// kill occurred (either GracefulKill failed, kill succeeded after timeout, or the
+// handler did not exit within timeout).
 // Safe to call after Close() — returns (0, nil) if already closed or detached.
 func (p *Process) SoftClose(timeout time.Duration) (int, error) {
 	p.mu.Lock()
@@ -72,10 +74,14 @@ func (p *Process) SoftClose(timeout time.Duration) (int, error) {
 		if killErr != nil {
 			return softCloseExitCode(p.ExitErr), killErr
 		}
-		return softCloseExitCode(p.ExitErr), nil
+		// GracefulKill succeeded but we still escalated past the voluntary-exit window.
+		// Return a non-nil error so callers (SoftShutdown, SoftRemove) can detect the
+		// forced-kill path even when GracefulKill itself had no error.
+		return softCloseExitCode(p.ExitErr), fmt.Errorf("upstream: forced kill after soft-close timeout")
 	}
 
-	return -1, nil
+	// In-process handler did not exit within timeout.
+	return -1, fmt.Errorf("upstream: handler did not exit after %v", timeout)
 }
 
 // softCloseExitCode extracts the process exit code from a Wait() error.

--- a/muxcore/upstream/softclose_test.go
+++ b/muxcore/upstream/softclose_test.go
@@ -38,12 +38,14 @@ func TestSoftClose_UpstreamHonorsStdinClose(t *testing.T) {
 // upstream ignores stdin close and keeps running, SoftClose falls back to
 // GracefulKill after the timeout. The process must be dead after SoftClose returns.
 func TestSoftClose_UpstreamIgnoresStdinClose_FallsBackToKill(t *testing.T) {
-	// sleep/timeout ignores stdin — it will never exit on stdin close alone.
+	// Use a command that truly ignores stdin and blocks. `timeout` on Windows
+	// rejects redirected stdin and exits immediately — breaks the test. `ping`
+	// ignores stdin on every platform and runs for N seconds.
 	var cmd string
 	var args []string
 	if runtime.GOOS == "windows" {
-		cmd = "cmd"
-		args = []string{"/c", "timeout", "/t", "30", "/nobreak"}
+		cmd = "ping"
+		args = []string{"-n", "30", "127.0.0.1"}
 	} else {
 		cmd = "sleep"
 		args = []string{"30"}
@@ -55,9 +57,14 @@ func TestSoftClose_UpstreamIgnoresStdinClose_FallsBackToKill(t *testing.T) {
 	}
 
 	// 200ms timeout — process won't exit voluntarily; GracefulKill fallback fires.
-	_, err = p.SoftClose(200 * time.Millisecond)
-	if err != nil {
-		t.Fatalf("SoftClose() fallback kill error: %v (GracefulKill should succeed)", err)
+	// Expect a non-nil error signalling the forced-kill escalation path, and a
+	// non-zero exit code confirming the process was killed rather than exiting cleanly.
+	exitCode, err := p.SoftClose(200 * time.Millisecond)
+	if err == nil {
+		t.Fatal("SoftClose() error = nil, want forced-kill signal after timeout")
+	}
+	if exitCode == 0 {
+		t.Fatalf("SoftClose() exitCode = %d, want non-zero after forced kill", exitCode)
 	}
 
 	// Process must be terminated after the forced kill path.

--- a/muxcore/upstream/softclose_test.go
+++ b/muxcore/upstream/softclose_test.go
@@ -1,0 +1,70 @@
+package upstream
+
+import (
+	"runtime"
+	"testing"
+	"time"
+)
+
+// TestSoftClose_UpstreamHonorsStdinClose verifies that an upstream which exits
+// cleanly on stdin close (the happy path) results in exitCode 0 and no SIGKILL.
+// echo_pipe.go reads stdin and exits with code 0 when stdin closes — perfect
+// for demonstrating the polite-shutdown path (US3-AC1).
+func TestSoftClose_UpstreamHonorsStdinClose(t *testing.T) {
+	// echo_pipe.go exits cleanly on stdin EOF (scan loop returns false on EOF).
+	p, err := Start("go", []string{"run", "../../testdata/echo_pipe.go"}, nil, "", nil)
+	if err != nil {
+		t.Skipf("cannot start echo_pipe.go: %v", err)
+	}
+
+	exitCode, err := p.SoftClose(10 * time.Second)
+	if err != nil {
+		t.Fatalf("SoftClose() error: %v", err)
+	}
+	if exitCode != 0 {
+		t.Errorf("SoftClose() exitCode = %d, want 0 (upstream should exit cleanly on stdin close)", exitCode)
+	}
+
+	// Process must be done within a short grace period.
+	select {
+	case <-p.Done:
+		// good
+	case <-time.After(2 * time.Second):
+		t.Fatal("process.Done not closed after SoftClose")
+	}
+}
+
+// TestSoftClose_UpstreamIgnoresStdinClose_FallsBackToKill verifies that when an
+// upstream ignores stdin close and keeps running, SoftClose falls back to
+// GracefulKill after the timeout. The process must be dead after SoftClose returns.
+func TestSoftClose_UpstreamIgnoresStdinClose_FallsBackToKill(t *testing.T) {
+	// sleep/timeout ignores stdin — it will never exit on stdin close alone.
+	var cmd string
+	var args []string
+	if runtime.GOOS == "windows" {
+		cmd = "cmd"
+		args = []string{"/c", "timeout", "/t", "30", "/nobreak"}
+	} else {
+		cmd = "sleep"
+		args = []string{"30"}
+	}
+
+	p, err := Start(cmd, args, nil, "", nil)
+	if err != nil {
+		t.Fatalf("Start() error: %v", err)
+	}
+
+	// 200ms timeout — process won't exit voluntarily; GracefulKill fallback fires.
+	_, err = p.SoftClose(200 * time.Millisecond)
+	if err != nil {
+		t.Fatalf("SoftClose() fallback kill error: %v (GracefulKill should succeed)", err)
+	}
+
+	// Process must be terminated after the forced kill path.
+	select {
+	case <-p.Done:
+		// good — process was killed
+	case <-time.After(10 * time.Second):
+		t.Fatal("process not done after SoftClose forced kill path")
+	}
+}


### PR DESCRIPTION
Phase 4 of engram #109 — T024 soft-close reaper path (US3 from spec).

## Scope

- **`upstream.SoftClose(timeout time.Duration) (int, error)`** — closes stdin (polite MCP shutdown), waits for `p.Done` up to `timeout`, falls back to `GracefulKill(3s)` if the process ignores the signal. Returns the exit code and an error if forced-kill fired.
- **`owner.SoftShutdown(timeout)`** — mirrors `Shutdown()` via the existing `shutdownOnce`, calls `teardownExceptUpstream()`, then `upstream.SoftClose(timeout)` instead of the immediate-kill `Close()`.
- **`daemon.SoftRemove(serverID)`** — same supervisor removal as `Remove`, calls `SoftShutdown(30s)`.
- **`reaper.go` `sweep()`** wired to use `SoftRemove` for idle eviction; zombie path keeps `Remove` (process already dead). `mux_restart <sid>` retains hard `Remove` for operator-intent clarity per spec clarification #8.

## Tests

`upstream/softclose_test.go`:
- `TestSoftClose_UpstreamHonorsStdinClose` — upstream reads stdin and exits cleanly on EOF → `SoftClose` returns exitCode 0, no GracefulKill invocation.
- `TestSoftClose_UpstreamIgnoresStdinClose_FallsBackToKill` — upstream blocks ignoring stdin → `SoftClose` times out after 200ms → GracefulKill fires.

## Part of engram #109 arc

[P] marker — parallel with T023 and T021. Merges independently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Улучшен механизм мягкого завершения работы сервисов и внешних процессов: сначала даётся время на аккуратное завершение через закрытие stdin, при необходимости — эскалация до принудительного убийства.
  * Обработку эвикций разделили по причинам: для "зомби" — жёсткое удаление, для прочих случаев — мягкое завершение.

* **Tests**
  * Добавлены тесты, проверяющие поведение мягкого завершения и корректную эскалацию при отсутствии ответа.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->