### PR TITLE
feat(v0.21.0-phase5): public handoff API for external daemon upgrade (T130, engram #130)

### DIFF
--- a/muxcore/.engram-project
+++ b/muxcore/.engram-project
@@ -1,3 +1,0 @@
-{
-  "name": "muxcore"
-}

--- a/muxcore/.engram-project
+++ b/muxcore/.engram-project
@@ -1,0 +1,3 @@
+{
+  "name": "muxcore"
+}

--- a/muxcore/README.md
+++ b/muxcore/README.md
@@ -26,8 +26,9 @@ import (
     "github.com/thebtf/mcp-mux/muxcore/daemon"
 )
 
-// Predecessor (old daemon) — called after accepting a connection from the successor:
-func predecessor(conn *net.UnixConn, token string, upstreams []daemon.HandoffUpstream) {
+// Predecessor (old daemon) — called after accepting a connection from the successor.
+// `conn` must be a *net.UnixConn on Unix or a *winio named-pipe conn on Windows.
+func predecessor(conn net.Conn, token string, upstreams []daemon.HandoffUpstream) {
     result, err := daemon.PerformHandoff(context.Background(), conn, token, upstreams)
     if err != nil {
         // ErrTokenMismatch, ErrProtocolVersionMismatch, or transport error
@@ -38,8 +39,9 @@ func predecessor(conn *net.UnixConn, token string, upstreams []daemon.HandoffUps
     _ = result
 }
 
-// Successor (new daemon) — called after dialing the predecessor's handoff socket:
-func successor(conn *net.UnixConn, token string) {
+// Successor (new daemon) — called after dialing the predecessor's handoff socket.
+// `conn` must be a *net.UnixConn on Unix or a *winio named-pipe conn on Windows.
+func successor(conn net.Conn, token string) {
     upstreams, err := daemon.ReceiveHandoff(context.Background(), conn, token)
     if err != nil {
         return

--- a/muxcore/README.md
+++ b/muxcore/README.md
@@ -1,0 +1,88 @@
+# muxcore
+
+Go library implementing the mcp-mux daemon engine, IPC transport, and handoff protocol
+for zero-downtime daemon upgrades.
+
+## Installation
+
+```bash
+go get github.com/thebtf/mcp-mux/muxcore@latest
+```
+
+## Handoff API (external daemon upgrade)
+
+The `daemon` package exposes five public functions for coordinating a live handoff between
+an old daemon process and its successor during a zero-downtime upgrade. Upstream processes
+(MCP servers) survive the upgrade without restarting — their file descriptors are transferred
+directly to the new daemon.
+
+### Quick start
+
+```go
+import (
+    "context"
+    "net"
+
+    "github.com/thebtf/mcp-mux/muxcore/daemon"
+)
+
+// Predecessor (old daemon) — called after accepting a connection from the successor:
+func predecessor(conn *net.UnixConn, token string, upstreams []daemon.HandoffUpstream) {
+    result, err := daemon.PerformHandoff(context.Background(), conn, token, upstreams)
+    if err != nil {
+        // ErrTokenMismatch, ErrProtocolVersionMismatch, or transport error
+        return
+    }
+    // result.Transferred — server IDs successfully handed off
+    // result.Aborted    — server IDs that fell back to clean shutdown
+    _ = result
+}
+
+// Successor (new daemon) — called after dialing the predecessor's handoff socket:
+func successor(conn *net.UnixConn, token string) {
+    upstreams, err := daemon.ReceiveHandoff(context.Background(), conn, token)
+    if err != nil {
+        return
+    }
+    // upstreams contains transferred HandoffUpstream entries with StdinFD/StdoutFD
+    // ready to attach to new Owner instances.
+    _ = upstreams
+}
+```
+
+### Token lifecycle
+
+```go
+// 1. Predecessor generates and writes the token.
+token, path, err := daemon.WriteHandoffToken(dir)
+if err != nil { /* handle */ }
+
+// 2. Pass token + socket path to the successor via env var or config.
+// os.Setenv("HANDOFF_TOKEN", token)
+// os.Setenv("HANDOFF_SOCKET", socketPath)
+
+// 3. Successor reads the token before dialing.
+token, err = daemon.ReadHandoffToken(path)
+if err != nil { /* handle */ }
+
+// 4. Clean up — idempotent, safe from defer.
+defer daemon.DeleteHandoffToken(path)
+```
+
+### Error handling
+
+| Error / Field | Meaning |
+|---------------|---------|
+| `daemon.ErrTokenMismatch` | Successor presented wrong pre-shared token (constant-time comparison) |
+| `daemon.ErrProtocolVersionMismatch` | Incompatible protocol version; fall back to shutdown |
+| `result.Aborted` | Per-upstream list of server IDs NOT transferred (individual failure; other upstreams may succeed) |
+
+### Platform constraints
+
+| Platform | Requirement |
+|----------|-------------|
+| Unix (Linux, macOS) | `conn` must be `*net.UnixConn`; any other type returns an error |
+| Windows | `conn` must be a winio named-pipe connection (`winio.DialPipeContext` / `ListenPipe.Accept`) |
+
+On Windows the successor PID is supplied automatically via the handoff protocol's
+`HelloMsg.SourcePID` field — no additional configuration is required from the caller.

--- a/muxcore/daemon/handoff_public.go
+++ b/muxcore/daemon/handoff_public.go
@@ -1,0 +1,57 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"net"
+)
+
+// PerformHandoff runs the old-daemon side of the two-daemon handoff protocol.
+// Transfers the given upstream file descriptors to the successor daemon after
+// pre-shared token authentication.
+//
+// conn must be a connected Unix domain socket (*net.UnixConn on Unix) or named
+// pipe connection (Windows, via winio). On Windows the successor PID is obtained
+// from the HelloMsg.SourcePID field automatically.
+//
+// Returns per-upstream transfer outcome. Does NOT close conn.
+func PerformHandoff(ctx context.Context, conn net.Conn, token string, upstreams []HandoffUpstream) (HandoffResult, error) {
+	fc, err := wrapNetConnAsFDConn(conn)
+	if err != nil {
+		return HandoffResult{}, fmt.Errorf("PerformHandoff: wrap conn: %w", err)
+	}
+	return performHandoff(ctx, fc, token, upstreams)
+}
+
+// ReceiveHandoff runs the new-daemon side of the two-daemon handoff protocol.
+// Called from the successor's startup path after it accepts a connection from
+// the predecessor.
+//
+// Returns the list of upstream descriptors received; callers re-attach these to
+// their own Owner instances.
+func ReceiveHandoff(ctx context.Context, conn net.Conn, token string) ([]HandoffUpstream, error) {
+	fc, err := wrapNetConnAsFDConn(conn)
+	if err != nil {
+		return nil, fmt.Errorf("ReceiveHandoff: wrap conn: %w", err)
+	}
+	return receiveHandoff(ctx, fc, token)
+}
+
+// WriteHandoffToken generates a 128-bit handoff token and writes it to
+// {dir}/mcp-mux-handoff.tok with 0600 permissions. Returns (token, path, err).
+// Callers MUST delete the file after the handoff window closes —
+// use DeleteHandoffToken for idempotent cleanup.
+func WriteHandoffToken(dir string) (token string, path string, err error) {
+	return writeHandoffToken(dir)
+}
+
+// ReadHandoffToken reads a previously written handoff token file.
+func ReadHandoffToken(path string) (token string, err error) {
+	return readHandoffToken(path)
+}
+
+// DeleteHandoffToken removes the token file if it exists. Idempotent —
+// missing file is NOT an error. Safe to call from defer.
+func DeleteHandoffToken(path string) error {
+	return deleteHandoffToken(path)
+}

--- a/muxcore/daemon/handoff_public_test.go
+++ b/muxcore/daemon/handoff_public_test.go
@@ -1,0 +1,43 @@
+package daemon
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestWriteReadDeleteHandoffToken_PublicAPI verifies the token lifecycle via the
+// public API: Write → Read → Delete → Delete (idempotent).
+func TestWriteReadDeleteHandoffToken_PublicAPI(t *testing.T) {
+	dir := t.TempDir()
+
+	token, path, err := WriteHandoffToken(dir)
+	if err != nil {
+		t.Fatalf("WriteHandoffToken: %v", err)
+	}
+	if token == "" {
+		t.Fatal("WriteHandoffToken: returned empty token")
+	}
+	if path == "" {
+		t.Fatal("WriteHandoffToken: returned empty path")
+	}
+	// path must be inside dir
+	if filepath.Dir(path) != dir {
+		t.Errorf("WriteHandoffToken path %q not in dir %q", path, dir)
+	}
+
+	got, err := ReadHandoffToken(path)
+	if err != nil {
+		t.Fatalf("ReadHandoffToken: %v", err)
+	}
+	if got != token {
+		t.Errorf("ReadHandoffToken: got %q, want %q", got, token)
+	}
+
+	if err := DeleteHandoffToken(path); err != nil {
+		t.Fatalf("DeleteHandoffToken: %v", err)
+	}
+	// Idempotent: second delete must NOT error.
+	if err := DeleteHandoffToken(path); err != nil {
+		t.Fatalf("DeleteHandoffToken idempotent second call: %v", err)
+	}
+}

--- a/muxcore/daemon/handoff_public_unix.go
+++ b/muxcore/daemon/handoff_public_unix.go
@@ -1,0 +1,18 @@
+//go:build unix
+
+package daemon
+
+import (
+	"fmt"
+	"net"
+)
+
+// wrapNetConnAsFDConn converts a net.Conn to the internal fdConn interface.
+// On Unix the conn MUST be a *net.UnixConn — other types return an error.
+func wrapNetConnAsFDConn(conn net.Conn) (fdConn, error) {
+	uc, ok := conn.(*net.UnixConn)
+	if !ok {
+		return nil, fmt.Errorf("wrapNetConnAsFDConn: expected *net.UnixConn, got %T", conn)
+	}
+	return newUnixFDConn(uc), nil
+}

--- a/muxcore/daemon/handoff_public_unix_test.go
+++ b/muxcore/daemon/handoff_public_unix_test.go
@@ -68,13 +68,19 @@ func TestPerformHandoff_PublicAPI(t *testing.T) {
 		serverCh <- serverOut{result: result, err: err}
 	}()
 
-	// Give the listener a moment to bind before dialing.
-	time.Sleep(50 * time.Millisecond)
-
 	// Client (new-daemon side): dial + ReceiveHandoff via PUBLIC API.
-	newConn, err := dialHandoffUnix(socketPath, 2*time.Second)
+	// Retry loop eliminates the flaky time.Sleep "wait for listener" pattern
+	// and tolerates up to 100ms of bind latency on slow CI runners.
+	var newConn fdConn
+	for i := 0; i < 10; i++ {
+		newConn, err = dialHandoffUnix(socketPath, 2*time.Second)
+		if err == nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 	if err != nil {
-		t.Fatalf("dialHandoffUnix: %v", err)
+		t.Fatalf("dialHandoffUnix after 10 retries: %v", err)
 	}
 	defer newConn.Close()
 

--- a/muxcore/daemon/handoff_public_unix_test.go
+++ b/muxcore/daemon/handoff_public_unix_test.go
@@ -5,7 +5,6 @@ package daemon
 import (
 	"context"
 	"os"
-	"path/filepath"
 	"testing"
 	"time"
 )
@@ -16,7 +15,17 @@ import (
 // calls the public wrappers instead of the private functions.
 func TestPerformHandoff_PublicAPI(t *testing.T) {
 	tmp := t.TempDir()
-	socketPath := filepath.Join(tmp, "handoff-pub.sock")
+	// macOS has a 104-byte unix socket path limit. t.TempDir() on darwin
+	// returns a ~90-byte path already. Use os.CreateTemp("", ...) so the
+	// socket lives in /tmp/ (short path).
+	sockFile, err := os.CreateTemp("", "handoff-pub-*.sock")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	socketPath := sockFile.Name()
+	_ = sockFile.Close()
+	_ = os.Remove(socketPath) // listenHandoffUnix creates the socket
+	t.Cleanup(func() { _ = os.Remove(socketPath) })
 	token := "public-api-test-token-128bit"
 
 	// Open a temp file whose FD we will transfer end-to-end.

--- a/muxcore/daemon/handoff_public_unix_test.go
+++ b/muxcore/daemon/handoff_public_unix_test.go
@@ -1,0 +1,106 @@
+//go:build unix
+
+package daemon
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestPerformHandoff_PublicAPI verifies that PerformHandoff + ReceiveHandoff
+// (public API) produce identical behavior to the internal performHandoff /
+// receiveHandoff. Setup mirrors TestHandoffIntegration_FullRoundtripUnix but
+// calls the public wrappers instead of the private functions.
+func TestPerformHandoff_PublicAPI(t *testing.T) {
+	tmp := t.TempDir()
+	socketPath := filepath.Join(tmp, "handoff-pub.sock")
+	token := "public-api-test-token-128bit"
+
+	// Open a temp file whose FD we will transfer end-to-end.
+	tmpFile, err := os.CreateTemp(tmp, "handoff-fd-*.tmp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tmpFile.Close()
+
+	upstreams := []HandoffUpstream{
+		{
+			ServerID: "s1",
+			Command:  "test-command",
+			PID:      os.Getpid(),
+			StdinFD:  tmpFile.Fd(),
+			StdoutFD: tmpFile.Fd(),
+		},
+	}
+
+	type serverOut struct {
+		result HandoffResult
+		err    error
+	}
+	serverCh := make(chan serverOut, 1)
+
+	// Server goroutine: listen + PerformHandoff (old-daemon side) via PUBLIC API.
+	// We use listenHandoffUnix to get an fdConn, then extract the underlying
+	// *net.UnixConn to pass to the public API — valid because this is a
+	// same-package test.
+	go func() {
+		oldConn, err := listenHandoffUnix(socketPath, 5*time.Second)
+		if err != nil {
+			serverCh <- serverOut{err: err}
+			return
+		}
+		defer oldConn.Close()
+		// Extract underlying *net.UnixConn to call the public API.
+		uc := oldConn.(*unixFDConn).conn
+		result, err := PerformHandoff(context.Background(), uc, token, upstreams)
+		serverCh <- serverOut{result: result, err: err}
+	}()
+
+	// Give the listener a moment to bind before dialing.
+	time.Sleep(50 * time.Millisecond)
+
+	// Client (new-daemon side): dial + ReceiveHandoff via PUBLIC API.
+	newConn, err := dialHandoffUnix(socketPath, 2*time.Second)
+	if err != nil {
+		t.Fatalf("dialHandoffUnix: %v", err)
+	}
+	defer newConn.Close()
+
+	// Extract underlying *net.UnixConn to call the public API.
+	newUC := newConn.(*unixFDConn).conn
+	received, err := ReceiveHandoff(context.Background(), newUC, token)
+	if err != nil {
+		t.Fatalf("ReceiveHandoff: %v", err)
+	}
+
+	srv := <-serverCh
+	if srv.err != nil {
+		t.Fatalf("PerformHandoff: %v", srv.err)
+	}
+
+	if len(srv.result.Transferred) != 1 || srv.result.Transferred[0] != "s1" {
+		t.Errorf("Transferred: got %v, want [s1]", srv.result.Transferred)
+	}
+	if len(srv.result.Aborted) != 0 {
+		t.Errorf("Aborted: got %v, want []", srv.result.Aborted)
+	}
+	if len(received) != 1 {
+		t.Errorf("ReceiveHandoff got %d upstreams, want 1", len(received))
+	}
+	if len(received) > 0 && received[0].ServerID != "s1" {
+		t.Errorf("received[0].ServerID = %q, want s1", received[0].ServerID)
+	}
+
+	// Close received FDs to avoid leaks.
+	for _, u := range received {
+		if u.StdinFD != 0 {
+			_ = os.NewFile(u.StdinFD, "").Close()
+		}
+		if u.StdoutFD != 0 && u.StdoutFD != u.StdinFD {
+			_ = os.NewFile(u.StdoutFD, "").Close()
+		}
+	}
+}

--- a/muxcore/daemon/handoff_public_windows.go
+++ b/muxcore/daemon/handoff_public_windows.go
@@ -1,0 +1,16 @@
+//go:build windows
+
+package daemon
+
+import (
+	"net"
+)
+
+// wrapNetConnAsFDConn converts a net.Conn to the internal fdConn interface.
+// On Windows the conn must be a winio named-pipe connection
+// (winio.DialPipeContext / ListenPipe.Accept). The wrapper accepts any net.Conn —
+// the caller is responsible for supplying a valid named-pipe connection.
+// SetTargetPID is set internally by performHandoff after reading HelloMsg.SourcePID.
+func wrapNetConnAsFDConn(conn net.Conn) (fdConn, error) {
+	return newWindowsFDConn(conn), nil
+}


### PR DESCRIPTION
Phase 5 of engram #109 arc — resolves engram #130 from aimux.

## Scope

aimux (and similar external daemons — engram, others) want to orchestrate their own hot-swap upgrades through muxcore's handoff protocol. Prior to v0.21.0 all handoff entry points were package-private. This PR adds 5 exported wrappers in new `muxcore/daemon/handoff_public.go`:

```go
func PerformHandoff(ctx context.Context, conn net.Conn, token string, upstreams []HandoffUpstream) (HandoffResult, error)
func ReceiveHandoff(ctx context.Context, conn net.Conn, token string) ([]HandoffUpstream, error)
func WriteHandoffToken(dir string) (token string, path string, err error)
func ReadHandoffToken(path string) (token string, err error)
func DeleteHandoffToken(path string) error
```

## Design

- `fdConn` interface + `unixFDConn` + `windowsFDConn` stay package-private (platform details hidden from public API)
- Public signatures take only `net.Conn` + publicly-safe types
- Platform dispatch via `wrapNetConnAsFDConn(net.Conn) (fdConn, error)` split by build tag:
  - `handoff_public_unix.go` — type-asserts to `*net.UnixConn`
  - `handoff_public_windows.go` — accepts any `net.Conn` (winio pipe)
- Zero-breaking additive — private `performHandoff` / `receiveHandoff` remain source of truth

## Tests

- `handoff_public_test.go` — cross-platform token lifecycle (Write → Read → Delete → idempotent re-delete)
- `handoff_public_unix_test.go` — Unix integration test calling `PerformHandoff` / `ReceiveHandoff` via the public API, asserting 1 upstream transferred end-to-end

## Documentation

- New `muxcore/README.md` with Handoff API section: quick-start, token lifecycle, error handling table (ErrTokenMismatch, ErrProtocolVersionMismatch, HandoffResult.Aborted), platform constraints

## Related

- engram issue #130 (source: 16b1f601 / aimux) — asked for this API
- engram issue #109 (this arc) — the lifecycle feature this protocol ships as part of

Design reference: `.agent/data/engram-130-public-api-design.md`

## Ordering

Can be merged independently of Phase 4 PRs (#76/#77/#78) — no file conflicts. Will naturally rebase if those land first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added daemon handoff protocol API for zero-downtime daemon upgrades with support for transferring active upstream resources between daemon processes.
  * Platform-specific support for Unix and Windows with appropriate connection handling.

* **Documentation**
  * Added comprehensive documentation describing the handoff protocol, token lifecycle, and usage examples.

* **Tests**
  * Added test coverage for the handoff token operations and end-to-end handoff functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->