### PR TITLE
feat(v0.21.0-phase4): reattach upstream from handoff in loadSnapshot (T022)

### DIFF
--- a/muxcore/daemon/handoff_socket_unix.go
+++ b/muxcore/daemon/handoff_socket_unix.go
@@ -29,3 +29,9 @@ func listenHandoff(socketPath string, timeout time.Duration) (fdConn, error) {
 func setSuccessorDetached(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 }
+
+// dialHandoff connects to a handoff socket previously bound by listenHandoff.
+// Caller owns the returned conn's lifetime.
+func dialHandoff(socketPath string, timeout time.Duration) (fdConn, error) {
+	return dialHandoffUnix(socketPath, timeout)
+}

--- a/muxcore/daemon/handoff_socket_windows.go
+++ b/muxcore/daemon/handoff_socket_windows.go
@@ -41,3 +41,9 @@ func setSuccessorDetached(cmd *exec.Cmd) {
 		HideWindow:    true,
 	}
 }
+
+// dialHandoff connects to a handoff named pipe previously bound by listenHandoff.
+// Caller owns the returned conn's lifetime.
+func dialHandoff(socketPath string, timeout time.Duration) (fdConn, error) {
+	return dialHandoffWindows(socketPath, timeout)
+}

--- a/muxcore/daemon/handoff_unix.go
+++ b/muxcore/daemon/handoff_unix.go
@@ -195,8 +195,8 @@ func (u *unixFDConn) SendFDs(fds []uintptr, header []byte) error {
 		// The nil sockaddr argument is valid for a connected stream socket.
 		firstN, sendErr = syscall.SendmsgN(int(fd), header, rights, nil, 0)
 		if errors.Is(sendErr, syscall.EAGAIN) || errors.Is(sendErr, syscall.EWOULDBLOCK) {
-			sendErr = nil  // not a terminal error; poller will retry when writable
-			return false   // wait until writable and retry
+			sendErr = nil // not a terminal error; poller will retry when writable
+			return false  // wait until writable and retry
 		}
 		return true // syscall complete, release the raw fd
 	})

--- a/muxcore/daemon/snapshot.go
+++ b/muxcore/daemon/snapshot.go
@@ -1,8 +1,10 @@
 package daemon
 
 import (
+	"context"
 	"fmt"
 	"log"
+	"os"
 	"time"
 
 	"github.com/thebtf/mcp-mux/muxcore/classify"
@@ -68,6 +70,58 @@ func DeserializeSnapshot(logger interface{ Printf(string, ...any) }) (*DaemonSna
 	return mcpsnapshot.Deserialize(logger)
 }
 
+// dialHandoffHook is overridable by tests to inject a mock fdConn instead of
+// dialing a real socket. Production code always leaves this nil.
+var dialHandoffHook func(socketPath string, timeout time.Duration) (fdConn, error)
+
+// tryHandoffReceive checks for MCPMUX_HANDOFF_TOKEN_PATH and MCPMUX_HANDOFF_SOCKET
+// env vars. If both are set, dials the handoff socket, authenticates with the token,
+// and receives the list of upstream FDs from the old daemon.
+// Returns nil on any failure (FR-8 fallback: caller uses SpawnUpstreamBackground for all owners).
+func (d *Daemon) tryHandoffReceive(ctx context.Context) map[string]HandoffUpstream {
+	tokenPath := os.Getenv("MCPMUX_HANDOFF_TOKEN_PATH")
+	socketPath := os.Getenv("MCPMUX_HANDOFF_SOCKET")
+
+	if tokenPath == "" || socketPath == "" {
+		return nil
+	}
+
+	defer deleteHandoffToken(tokenPath) //nolint:errcheck
+
+	token, err := readHandoffToken(tokenPath)
+	if err != nil {
+		d.logger.Printf("handoff.receive.fail reason=%v", err)
+		return nil
+	}
+
+	dialFn := dialHandoff
+	if dialHandoffHook != nil {
+		dialFn = dialHandoffHook
+	}
+	conn, err := dialFn(socketPath, 2*time.Second)
+	if err != nil {
+		d.logger.Printf("handoff.receive.fail reason=%v", err)
+		return nil
+	}
+	defer conn.Close() //nolint:errcheck
+
+	receiveCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	received, err := receiveHandoff(receiveCtx, conn, token)
+	if err != nil {
+		d.logger.Printf("handoff.receive.fail reason=%v", err)
+		return nil
+	}
+
+	result := make(map[string]HandoffUpstream, len(received))
+	for _, hu := range received {
+		result[hu.ServerID] = hu
+	}
+	d.logger.Printf("handoff.receive.ok upstreams=%d", len(result))
+	return result
+}
+
 // loadSnapshot checks for a snapshot file and restores owners from it.
 // Called on daemon startup. If no snapshot exists, returns 0 (cold start).
 // Returns the number of owners restored.
@@ -80,6 +134,11 @@ func (d *Daemon) loadSnapshot() int {
 	if snap == nil {
 		return 0 // cold start
 	}
+
+	// Check for handoff env vars. If both are set, receive transferred FDs from
+	// the old daemon instead of respawning upstreams from scratch (FR-1 to FR-3).
+	// Returns nil if env vars are absent or handoff fails (FR-8 fallback for all owners).
+	handoffMap := d.tryHandoffReceive(context.Background())
 
 	restored := 0
 	for _, ownerSnap := range snap.Owners {
@@ -98,8 +157,6 @@ func (d *Daemon) loadSnapshot() int {
 			ownerSnap.CwdSet = []string{ownerSnap.Cwd}
 		}
 
-		// Capture loop variables for closure.
-		cmd, args := ownerSnap.Command, ownerSnap.Args
 		// Merge daemon os.Environ() into the snapshotted env on restore. A
 		// pre-fix daemon may have serialised an owner with a trimmed shim env
 		// (missing GITHUB_PERSONAL_ACCESS_TOKEN, etc.); without this merge,
@@ -108,7 +165,8 @@ func (d *Daemon) loadSnapshot() int {
 		// available for session ..." until the next cold spawn. Daemon env
 		// values fill gaps but cannot override whatever the snapshot stored.
 		restoredEnv := mergeEnv(ownerSnap.Env)
-		o, err := owner.NewOwnerFromSnapshot(owner.OwnerConfig{
+		cmd, args := ownerSnap.Command, ownerSnap.Args
+		cfg := owner.OwnerConfig{
 			Command:        cmd,
 			Args:           args,
 			Env:            restoredEnv,
@@ -137,10 +195,43 @@ func (d *Daemon) loadSnapshot() int {
 				d.updateTemplate(cmd, args, s)
 			},
 			Logger: log.New(d.logger.Writer(), fmt.Sprintf("[mcp-mux:%s] ", sid[:8]), log.LstdFlags|log.Lmicroseconds),
-		}, ownerSnap)
-		if err != nil {
-			d.logger.Printf("snapshot: failed to restore owner %s (%s): %v", sid[:8], ownerSnap.Command, err)
-			continue
+		}
+
+		var o *owner.Owner
+		reattachedFromHandoff := false
+
+		// FR-7 partial fallback: attempt handoff reattach if this serverID was received.
+		if hu, ok := handoffMap[sid]; ok {
+			cfg.CachedClassification = ownerSnap.Classification
+			payload := owner.HandoffPayload{
+				ServerID: sid,
+				PID:      hu.PID,
+				StdinFD:  hu.StdinFD,
+				StdoutFD: hu.StdoutFD,
+				Command:  hu.Command,
+				Args:     ownerSnap.Args,
+				Cwd:      ownerSnap.Cwd,
+			}
+			var handoffErr error
+			o, handoffErr = owner.NewOwnerFromHandoff(cfg, payload)
+			if handoffErr != nil {
+				d.logger.Printf("snapshot: handoff reattach failed for %s: %v — falling back to spawn",
+					sid[:8], handoffErr)
+				o = nil
+			} else {
+				reattachedFromHandoff = true
+				d.logger.Printf("snapshot: reattached owner %s from handoff (pid=%d)", sid[:8], hu.PID)
+			}
+		}
+
+		// Legacy path: restore from snapshot (runs when handoff not available or failed).
+		if o == nil {
+			var snapErr error
+			o, snapErr = owner.NewOwnerFromSnapshot(cfg, ownerSnap)
+			if snapErr != nil {
+				d.logger.Printf("snapshot: failed to restore owner %s (%s): %v", sid[:8], ownerSnap.Command, snapErr)
+				continue
+			}
 		}
 
 		// Register with supervisor BEFORE inserting into owners map so that
@@ -171,8 +262,10 @@ func (d *Daemon) loadSnapshot() int {
 			d.updateTemplate(ownerSnap.Command, ownerSnap.Args, ownerSnap)
 		}
 
-		// Spawn upstream in background — refreshes caches when ready.
-		o.SpawnUpstreamBackground()
+		// Only spawn a fresh upstream when not reattached from handoff.
+		if !reattachedFromHandoff {
+			o.SpawnUpstreamBackground()
+		}
 
 		d.logger.Printf("snapshot: restored owner %s for %s %v", sid[:8], ownerSnap.Command, ownerSnap.Args)
 		restored++

--- a/muxcore/daemon/snapshot_reattach_test.go
+++ b/muxcore/daemon/snapshot_reattach_test.go
@@ -75,6 +75,10 @@ func TestLoadSnapshot_Reattach_HappyPath(t *testing.T) {
 	// Run the old-daemon (sender) side in a background goroutine.
 	// Transfer stdinR.Fd() as StdinFD and stdoutW.Fd() as StdoutFD.
 	// These are the pipe ends the upstream process would read/write.
+	// Capture the performHandoff error on a buffered channel so we can
+	// propagate sender-side failures to the test instead of relying on
+	// receiveHandoff to time out on a half-done protocol.
+	senderErrCh := make(chan error, 1)
 	go func() {
 		upstreams := []HandoffUpstream{
 			{
@@ -86,8 +90,19 @@ func TestLoadSnapshot_Reattach_HappyPath(t *testing.T) {
 			},
 		}
 		ctx := context.Background()
-		_, _ = performHandoff(ctx, oldDaemonConn, testToken, upstreams)
+		_, err := performHandoff(ctx, oldDaemonConn, testToken, upstreams)
+		senderErrCh <- err
 	}()
+	t.Cleanup(func() {
+		select {
+		case err := <-senderErrCh:
+			if err != nil {
+				t.Errorf("performHandoff (sender): %v", err)
+			}
+		case <-time.After(500 * time.Millisecond):
+			t.Error("performHandoff (sender) did not return within 500ms")
+		}
+	})
 
 	// Install dialHandoffHook to return the successor side of the mock conn pair.
 	origHook := dialHandoffHook
@@ -138,13 +153,14 @@ func TestLoadSnapshot_Reattach_SocketUnreachable(t *testing.T) {
 		Timestamp: time.Now().UTC().Format(time.RFC3339),
 		Owners: []mcpsnapshot.OwnerSnapshot{
 			{
-				ServerID:    sid,
-				Command:     "echo",
-				Args:        []string{"fallback"},
-				Cwd:         t.TempDir(),
-				Mode:        "global",
-				CachedInit:  "e30=",
-				CachedTools: "e30=",
+				ServerID:       sid,
+				Command:        "echo",
+				Args:           []string{"fallback"},
+				Cwd:            t.TempDir(),
+				Mode:           "global",
+				Classification: classify.ModeShared,
+				CachedInit:     "e30=",
+				CachedTools:    "e30=",
 			},
 		},
 	}
@@ -200,5 +216,154 @@ func TestLoadSnapshot_Reattach_SocketUnreachable(t *testing.T) {
 	classSource, _ := status["classification_source"].(string)
 	if classSource == "handoff" {
 		t.Error("classification_source = 'handoff' but socket was unreachable; expected legacy path")
+	}
+}
+
+// TestLoadSnapshot_Reattach_PartialHandoff exercises FR-7: when the handoff
+// delivers FDs for a subset of the snapshot's owners, the remainder MUST
+// fall through to the legacy SpawnUpstreamBackground path. The snapshot
+// lists two owners (sid1, sid2) but performHandoff only transfers sid1 —
+// so sid1 reattaches via handoff (classification_source == "handoff") and
+// sid2 comes back through the legacy path (classification_source !=
+// "handoff"). Both must be present in d.owners after loadSnapshot returns.
+func TestLoadSnapshot_Reattach_PartialHandoff(t *testing.T) {
+	os.Remove(SnapshotPath())
+
+	sid1 := "aabbccdd-partial-handoff-sid1"
+	sid2 := "eeff0011-partial-handoff-sid2"
+	snapshot := DaemonSnapshot{
+		Version:   mcpsnapshot.SnapshotVersion,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Owners: []mcpsnapshot.OwnerSnapshot{
+			{
+				ServerID:       sid1,
+				Command:        "echo",
+				Args:           []string{"one"},
+				Cwd:            t.TempDir(),
+				Mode:           "global",
+				Classification: classify.ModeShared,
+				CachedInit:     "e30=",
+				CachedTools:    "e30=",
+			},
+			{
+				ServerID:       sid2,
+				Command:        "echo",
+				Args:           []string{"two"},
+				Cwd:            t.TempDir(),
+				Mode:           "global",
+				Classification: classify.ModeShared,
+				CachedInit:     "e30=",
+				CachedTools:    "e30=",
+			},
+		},
+	}
+	data, err := json.Marshal(snapshot)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	if err := os.WriteFile(SnapshotPath(), data, 0o644); err != nil {
+		t.Fatalf("WriteFile snapshot: %v", err)
+	}
+	defer os.Remove(SnapshotPath())
+
+	tokenFile, err := os.CreateTemp("", "mcp-mux-handoff-partial-*.tok")
+	if err != nil {
+		t.Fatalf("CreateTemp token: %v", err)
+	}
+	tokenFile.Close()
+	const testToken = "partial-handoff-test-token"
+	if err := os.WriteFile(tokenFile.Name(), []byte(testToken), 0o600); err != nil {
+		t.Fatalf("WriteFile token: %v", err)
+	}
+	defer os.Remove(tokenFile.Name())
+
+	// Real pipes for sid1 only — sid2 is intentionally omitted from the
+	// handoff payload so its reattach fails and the legacy path kicks in.
+	stdinR, stdinW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe stdin: %v", err)
+	}
+	defer stdinR.Close()
+	defer stdinW.Close()
+
+	stdoutR, stdoutW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe stdout: %v", err)
+	}
+	defer stdoutR.Close()
+	defer stdoutW.Close()
+
+	oldDaemonConn, successorConn := newMockFDConnPair()
+
+	senderErrCh := make(chan error, 1)
+	go func() {
+		upstreams := []HandoffUpstream{
+			{
+				ServerID: sid1, // Only sid1 transferred — sid2 falls through.
+				Command:  "echo",
+				PID:      os.Getpid(),
+				StdinFD:  stdinR.Fd(),
+				StdoutFD: stdoutW.Fd(),
+			},
+		}
+		_, err := performHandoff(context.Background(), oldDaemonConn, testToken, upstreams)
+		senderErrCh <- err
+	}()
+	t.Cleanup(func() {
+		select {
+		case err := <-senderErrCh:
+			if err != nil {
+				t.Errorf("performHandoff (sender): %v", err)
+			}
+		case <-time.After(500 * time.Millisecond):
+			t.Error("performHandoff (sender) did not return within 500ms")
+		}
+	})
+
+	origHook := dialHandoffHook
+	dialHandoffHook = func(_ string, _ time.Duration) (fdConn, error) {
+		return successorConn, nil
+	}
+	defer func() { dialHandoffHook = origHook }()
+
+	t.Setenv("MCPMUX_HANDOFF_TOKEN_PATH", tokenFile.Name())
+	t.Setenv("MCPMUX_HANDOFF_SOCKET", "/mock/socket")
+
+	d := testDaemon(t)
+	restored := d.loadSnapshot()
+	if restored != 2 {
+		t.Fatalf("loadSnapshot() restored %d owners, want 2 (sid1 via handoff, sid2 via legacy)", restored)
+	}
+
+	// Poll both entries (async supervisor insertion — see F80-1).
+	var entry1, entry2 *OwnerEntry
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		d.mu.RLock()
+		entry1 = d.owners[sid1]
+		entry2 = d.owners[sid2]
+		d.mu.RUnlock()
+		if entry1 != nil && entry1.Owner != nil && entry2 != nil && entry2.Owner != nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if entry1 == nil || entry1.Owner == nil {
+		t.Fatal("sid1 not found in d.owners after partial handoff (polled 2s)")
+	}
+	if entry2 == nil || entry2.Owner == nil {
+		t.Fatal("sid2 not found in d.owners after partial handoff (polled 2s)")
+	}
+
+	// sid1: transferred via handoff → classification_source == "handoff"
+	status1 := entry1.Owner.Status()
+	if class1, _ := status1["classification_source"].(string); class1 != "handoff" {
+		t.Errorf("sid1 classification_source = %q, want %q (handoff path not used)", class1, "handoff")
+	}
+
+	// sid2: not in handoff payload → legacy spawn path, NOT "handoff"
+	status2 := entry2.Owner.Status()
+	if class2, _ := status2["classification_source"].(string); class2 == "handoff" {
+		t.Errorf("sid2 classification_source = %q but sid2 was not in handoff; expected legacy path", class2)
 	}
 }

--- a/muxcore/daemon/snapshot_reattach_test.go
+++ b/muxcore/daemon/snapshot_reattach_test.go
@@ -1,15 +1,61 @@
 package daemon
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"log"
 	"os"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/thebtf/mcp-mux/muxcore/classify"
 	mcpsnapshot "github.com/thebtf/mcp-mux/muxcore/snapshot"
 )
+
+// syncBuffer is a thread-safe bytes.Buffer — the daemon writes logs from
+// multiple goroutines concurrently (supervisor, reaper, owner callbacks).
+// Tests that inspect log content need serialized reads.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (s *syncBuffer) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Write(p)
+}
+
+func (s *syncBuffer) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.String()
+}
+
+// testDaemonWithLog constructs a daemon whose logger writes into a
+// syncBuffer in addition to stderr, so log-based assertions can inspect
+// daemon output without racing with concurrent writers.
+func testDaemonWithLog(t *testing.T) (*Daemon, *syncBuffer) {
+	t.Helper()
+	buf := &syncBuffer{}
+	ctlPath := shortSocketPath(t, "daemon.ctl.sock")
+	logger := log.New(buf, "[daemon-test] ", log.LstdFlags)
+	d, err := New(Config{
+		ControlPath:  ctlPath,
+		GracePeriod:  1 * time.Second,
+		IdleTimeout:  5 * time.Second,
+		SkipSnapshot: true,
+		Logger:       logger,
+	})
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	t.Cleanup(func() { d.Shutdown() })
+	return d, buf
+}
 
 func TestLoadSnapshot_Reattach_HappyPath(t *testing.T) {
 	os.Remove(SnapshotPath())
@@ -329,55 +375,48 @@ func TestLoadSnapshot_Reattach_PartialHandoff(t *testing.T) {
 	t.Setenv("MCPMUX_HANDOFF_TOKEN_PATH", tokenFile.Name())
 	t.Setenv("MCPMUX_HANDOFF_SOCKET", "/mock/socket")
 
-	d := testDaemon(t)
+	d, logBuf := testDaemonWithLog(t)
 	restored := d.loadSnapshot()
 	if restored != 2 {
 		t.Fatalf("loadSnapshot() restored %d owners, want 2 (sid1 via handoff, sid2 via legacy)", restored)
 	}
 
-	// Capture each entry independently. sid2 goes through the legacy spawn
-	// path with "echo two" which exits after ~1ms — onUpstreamExit fires
-	// and removes d.owners[sid2] almost immediately. Requiring both owners
-	// to be visible in the SAME poll iteration would race on fast macOS
-	// scheduling (sid2 is already gone by the time sid1 is observed).
-	// Capture each pointer once when it first appears; the Owner struct
-	// survives subsequent removal from the map so Status() is still safe.
-	var entry1, entry2 *OwnerEntry
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		d.mu.RLock()
-		if entry1 == nil {
-			if e := d.owners[sid1]; e != nil && e.Owner != nil {
-				entry1 = e
-			}
-		}
-		if entry2 == nil {
-			if e := d.owners[sid2]; e != nil && e.Owner != nil {
-				entry2 = e
-			}
-		}
-		d.mu.RUnlock()
-		if entry1 != nil && entry2 != nil {
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	if entry1 == nil {
-		t.Fatal("sid1 never appeared in d.owners after partial handoff (polled 2s)")
-	}
-	if entry2 == nil {
-		t.Fatal("sid2 never appeared in d.owners after partial handoff (polled 2s)")
+	// FR-7 is verified by structural log inspection rather than by probing
+	// d.owners — in the partial scenario both owners get removed from the
+	// map almost immediately after insertion (sid1's proactive init writes
+	// to a stub pipe with no reader and errors out; sid2 spawns "echo two"
+	// which exits cleanly after ~1ms). The code path that routes each
+	// owner through handoff vs. legacy is already complete by the time
+	// loadSnapshot returns, and daemon.Logger emits a stable marker per
+	// path: "snapshot: reattached owner <sid> from handoff" for the
+	// handoff path, "snapshot: restored owner <sid> for <cmd> <args>"
+	// for every successful registration regardless of path.
+	logs := logBuf.String()
+
+	// Positive: sid1 took the handoff path.
+	wantSid1Handoff := "snapshot: reattached owner " + sid1[:8] + " from handoff"
+	if !strings.Contains(logs, wantSid1Handoff) {
+		t.Errorf("expected log %q for sid1 (handoff path), not found.\nLogs:\n%s", wantSid1Handoff, logs)
 	}
 
-	// sid1: transferred via handoff → classification_source == "handoff"
-	status1 := entry1.Owner.Status()
-	if class1, _ := status1["classification_source"].(string); class1 != "handoff" {
-		t.Errorf("sid1 classification_source = %q, want %q (handoff path not used)", class1, "handoff")
+	// Negative: sid2 was NOT taken via handoff path.
+	dontWantSid2Handoff := "snapshot: reattached owner " + sid2[:8] + " from handoff"
+	if strings.Contains(logs, dontWantSid2Handoff) {
+		t.Errorf("did not expect log %q for sid2 — sid2 was absent from handoff payload.\nLogs:\n%s", dontWantSid2Handoff, logs)
 	}
 
-	// sid2: not in handoff payload → legacy spawn path, NOT "handoff"
-	status2 := entry2.Owner.Status()
-	if class2, _ := status2["classification_source"].(string); class2 == "handoff" {
-		t.Errorf("sid2 classification_source = %q but sid2 was not in handoff; expected legacy path", class2)
+	// Both owners must have been registered (positive check for both).
+	for _, expected := range []string{
+		"snapshot: restored owner " + sid1[:8] + " for echo [one]",
+		"snapshot: restored owner " + sid2[:8] + " for echo [two]",
+	} {
+		if !strings.Contains(logs, expected) {
+			t.Errorf("expected log %q, not found.\nLogs:\n%s", expected, logs)
+		}
+	}
+
+	// Handoff receive must have delivered exactly one upstream.
+	if !strings.Contains(logs, "handoff.receive.ok upstreams=1") {
+		t.Errorf("expected %q in logs, not found.\nLogs:\n%s", "handoff.receive.ok upstreams=1", logs)
 	}
 }

--- a/muxcore/daemon/snapshot_reattach_test.go
+++ b/muxcore/daemon/snapshot_reattach_test.go
@@ -335,24 +335,38 @@ func TestLoadSnapshot_Reattach_PartialHandoff(t *testing.T) {
 		t.Fatalf("loadSnapshot() restored %d owners, want 2 (sid1 via handoff, sid2 via legacy)", restored)
 	}
 
-	// Poll both entries (async supervisor insertion — see F80-1).
+	// Capture each entry independently. sid2 goes through the legacy spawn
+	// path with "echo two" which exits after ~1ms — onUpstreamExit fires
+	// and removes d.owners[sid2] almost immediately. Requiring both owners
+	// to be visible in the SAME poll iteration would race on fast macOS
+	// scheduling (sid2 is already gone by the time sid1 is observed).
+	// Capture each pointer once when it first appears; the Owner struct
+	// survives subsequent removal from the map so Status() is still safe.
 	var entry1, entry2 *OwnerEntry
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
 		d.mu.RLock()
-		entry1 = d.owners[sid1]
-		entry2 = d.owners[sid2]
+		if entry1 == nil {
+			if e := d.owners[sid1]; e != nil && e.Owner != nil {
+				entry1 = e
+			}
+		}
+		if entry2 == nil {
+			if e := d.owners[sid2]; e != nil && e.Owner != nil {
+				entry2 = e
+			}
+		}
 		d.mu.RUnlock()
-		if entry1 != nil && entry1.Owner != nil && entry2 != nil && entry2.Owner != nil {
+		if entry1 != nil && entry2 != nil {
 			break
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	if entry1 == nil || entry1.Owner == nil {
-		t.Fatal("sid1 not found in d.owners after partial handoff (polled 2s)")
+	if entry1 == nil {
+		t.Fatal("sid1 never appeared in d.owners after partial handoff (polled 2s)")
 	}
-	if entry2 == nil || entry2.Owner == nil {
-		t.Fatal("sid2 not found in d.owners after partial handoff (polled 2s)")
+	if entry2 == nil {
+		t.Fatal("sid2 never appeared in d.owners after partial handoff (polled 2s)")
 	}
 
 	// sid1: transferred via handoff → classification_source == "handoff"

--- a/muxcore/daemon/snapshot_reattach_test.go
+++ b/muxcore/daemon/snapshot_reattach_test.go
@@ -1,0 +1,190 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/thebtf/mcp-mux/muxcore/classify"
+	mcpsnapshot "github.com/thebtf/mcp-mux/muxcore/snapshot"
+)
+
+func TestLoadSnapshot_Reattach_HappyPath(t *testing.T) {
+	os.Remove(SnapshotPath())
+
+	sid := "aabbccdd-happy-reattach-test"
+	snapshot := DaemonSnapshot{
+		Version:   mcpsnapshot.SnapshotVersion,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Owners: []mcpsnapshot.OwnerSnapshot{
+			{
+				ServerID:       sid,
+				Command:        "echo",
+				Args:           []string{"hello"},
+				Cwd:            t.TempDir(),
+				Mode:           "global",
+				Classification: classify.ModeShared,
+				CachedInit:     "e30=",
+				CachedTools:    "e30=",
+			},
+		},
+	}
+	data, err := json.Marshal(snapshot)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	if err := os.WriteFile(SnapshotPath(), data, 0o644); err != nil {
+		t.Fatalf("WriteFile snapshot: %v", err)
+	}
+	defer os.Remove(SnapshotPath())
+
+	// Write a handoff token file.
+	tokenFile, err := os.CreateTemp("", "mcp-mux-handoff-*.tok")
+	if err != nil {
+		t.Fatalf("CreateTemp token: %v", err)
+	}
+	tokenFile.Close()
+	const testToken = "happy-path-test-token"
+	if err := os.WriteFile(tokenFile.Name(), []byte(testToken), 0o600); err != nil {
+		t.Fatalf("WriteFile token: %v", err)
+	}
+	defer os.Remove(tokenFile.Name())
+
+	// Create real pipes — AttachFromFDs requires non-zero FDs.
+	// stdinR/stdinW: upstream reads from stdinR; we write to stdinW (not used in test).
+	// stdoutR/stdoutW: upstream writes to stdoutW; we read from stdoutR (not used in test).
+	stdinR, stdinW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe stdin: %v", err)
+	}
+	defer stdinR.Close()
+	defer stdinW.Close()
+
+	stdoutR, stdoutW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe stdout: %v", err)
+	}
+	defer stdoutR.Close()
+	defer stdoutW.Close()
+
+	// Prepare mock conn pair: oldDaemonConn (sender) <--> successorConn (receiver).
+	oldDaemonConn, successorConn := newMockFDConnPair()
+
+	// Run the old-daemon (sender) side in a background goroutine.
+	// Transfer stdinR.Fd() as StdinFD and stdoutW.Fd() as StdoutFD.
+	// These are the pipe ends the upstream process would read/write.
+	go func() {
+		upstreams := []HandoffUpstream{
+			{
+				ServerID: sid,
+				Command:  "echo",
+				PID:      os.Getpid(), // valid PID > 0; not verified by AttachFromFDs
+				StdinFD:  stdinR.Fd(),
+				StdoutFD: stdoutW.Fd(),
+			},
+		}
+		ctx := context.Background()
+		_, _ = performHandoff(ctx, oldDaemonConn, testToken, upstreams)
+	}()
+
+	// Install dialHandoffHook to return the successor side of the mock conn pair.
+	origHook := dialHandoffHook
+	dialHandoffHook = func(_ string, _ time.Duration) (fdConn, error) {
+		return successorConn, nil
+	}
+	defer func() { dialHandoffHook = origHook }()
+
+	// Set handoff env vars.
+	t.Setenv("MCPMUX_HANDOFF_TOKEN_PATH", tokenFile.Name())
+	t.Setenv("MCPMUX_HANDOFF_SOCKET", "/mock/socket") // intercepted by hook
+
+	d := testDaemon(t)
+	restored := d.loadSnapshot()
+	if restored != 1 {
+		t.Fatalf("loadSnapshot() restored %d owners, want 1", restored)
+	}
+
+	d.mu.RLock()
+	entry := d.owners[sid]
+	d.mu.RUnlock()
+
+	if entry == nil || entry.Owner == nil {
+		t.Fatal("owner not found in d.owners after handoff reattach")
+	}
+
+	// Verify owner was constructed via handoff path: classification_source == "handoff".
+	status := entry.Owner.Status()
+	classSource, _ := status["classification_source"].(string)
+	if classSource != "handoff" {
+		t.Errorf("classification_source = %q, want %q (handoff path not used)", classSource, "handoff")
+	}
+}
+
+func TestLoadSnapshot_Reattach_SocketUnreachable(t *testing.T) {
+	os.Remove(SnapshotPath())
+
+	sid := "aabbccdd-fallback-reattach-test"
+	snapshot := DaemonSnapshot{
+		Version:   mcpsnapshot.SnapshotVersion,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Owners: []mcpsnapshot.OwnerSnapshot{
+			{
+				ServerID:    sid,
+				Command:     "echo",
+				Args:        []string{"fallback"},
+				Cwd:         t.TempDir(),
+				Mode:        "global",
+				CachedInit:  "e30=",
+				CachedTools: "e30=",
+			},
+		},
+	}
+	data, err := json.Marshal(snapshot)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	if err := os.WriteFile(SnapshotPath(), data, 0o644); err != nil {
+		t.Fatalf("WriteFile snapshot: %v", err)
+	}
+	defer os.Remove(SnapshotPath())
+
+	// Write handoff token pointing at a valid file.
+	tokenFile, err := os.CreateTemp("", "mcp-mux-handoff-fallback-*.tok")
+	if err != nil {
+		t.Fatalf("CreateTemp token: %v", err)
+	}
+	tokenFile.Close()
+	if err := os.WriteFile(tokenFile.Name(), []byte("some-token"), 0o600); err != nil {
+		t.Fatalf("WriteFile token: %v", err)
+	}
+	defer os.Remove(tokenFile.Name())
+
+	// Set env vars with an invalid socket path (guaranteed to fail dial).
+	t.Setenv("MCPMUX_HANDOFF_TOKEN_PATH", tokenFile.Name())
+	t.Setenv("MCPMUX_HANDOFF_SOCKET", "/nonexistent/path/to/socket.sock")
+
+	d := testDaemon(t)
+	restored := d.loadSnapshot()
+
+	// FR-8 fallback: must restore owner via legacy path (SpawnUpstreamBackground).
+	if restored != 1 {
+		t.Fatalf("loadSnapshot() restored %d owners (want 1); FR-8 fallback failed", restored)
+	}
+
+	d.mu.RLock()
+	entry := d.owners[sid]
+	d.mu.RUnlock()
+
+	if entry == nil || entry.Owner == nil {
+		t.Fatal("owner not found in d.owners after FR-8 fallback")
+	}
+
+	// Owner must NOT have been reattached via handoff (socket was unreachable).
+	status := entry.Owner.Status()
+	classSource, _ := status["classification_source"].(string)
+	if classSource == "handoff" {
+		t.Error("classification_source = 'handoff' but socket was unreachable; expected legacy path")
+	}
+}

--- a/muxcore/daemon/snapshot_reattach_test.go
+++ b/muxcore/daemon/snapshot_reattach_test.go
@@ -106,12 +106,19 @@ func TestLoadSnapshot_Reattach_HappyPath(t *testing.T) {
 		t.Fatalf("loadSnapshot() restored %d owners, want 1", restored)
 	}
 
-	d.mu.RLock()
-	entry := d.owners[sid]
-	d.mu.RUnlock()
-
+	var entry *OwnerEntry
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		d.mu.RLock()
+		entry = d.owners[sid]
+		d.mu.RUnlock()
+		if entry != nil && entry.Owner != nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 	if entry == nil || entry.Owner == nil {
-		t.Fatal("owner not found in d.owners after handoff reattach")
+		t.Fatal("owner not found in d.owners after handoff reattach (polled 2s)")
 	}
 
 	// Verify owner was constructed via handoff path: classification_source == "handoff".
@@ -173,12 +180,19 @@ func TestLoadSnapshot_Reattach_SocketUnreachable(t *testing.T) {
 		t.Fatalf("loadSnapshot() restored %d owners (want 1); FR-8 fallback failed", restored)
 	}
 
-	d.mu.RLock()
-	entry := d.owners[sid]
-	d.mu.RUnlock()
-
+	var entry *OwnerEntry
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		d.mu.RLock()
+		entry = d.owners[sid]
+		d.mu.RUnlock()
+		if entry != nil && entry.Owner != nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 	if entry == nil || entry.Owner == nil {
-		t.Fatal("owner not found in d.owners after FR-8 fallback")
+		t.Fatal("owner not found in d.owners after FR-8 fallback (polled 2s)")
 	}
 
 	// Owner must NOT have been reattached via handoff (socket was unreachable).


### PR DESCRIPTION
Phase 4 of engram #109 — T022 successor-side wiring.

## Scope

When a new daemon is spawned as a handoff successor (env vars `MCPMUX_HANDOFF_TOKEN_PATH` + `MCPMUX_HANDOFF_SOCKET` set by T021's `spawnSuccessor`), it must **receive** transferred FDs from the old daemon instead of respawning upstreams fresh from the snapshot. T022 wires this path.

### Flow

1. `loadSnapshot` calls new `tryHandoffReceive(ctx)`:
   - Reads env vars. If either missing → returns nil (legacy path).
   - Reads token via `readHandoffToken(path)`.
   - Dials handoff socket (2s timeout) via new `dialHandoff` helper — platform-split to `dialHandoffUnix` (unix) / `dialHandoffPipe` (windows).
   - Calls `receiveHandoff(ctx, conn, token)` with 30s deadline.
   - Returns `map[serverID]HandoffUpstream` on success.
   - **FR-8 fallback**: any failure (token read, dial, protocol) → log `handoff.receive.fail reason=…` → return nil → caller falls through to `SpawnUpstreamBackground` for ALL owners.

2. Per-owner loop in `loadSnapshot`:
   - If `serverID` in received map → construct via `owner.NewOwnerFromHandoff(cfg, payload)` (merged in #76).
   - Else (not in map) → spawn fresh via `SpawnUpstreamBackground` (FR-7 per-upstream fallback).

3. `defer deleteHandoffToken(tokenPath)` on the first successful env-var read — idempotent cleanup.

## New artefacts

- `dialHandoff` platform helper + `dialHandoffHook` test-injection var
- `tryHandoffReceive` method on `Daemon`
- `snapshot_reattach_test.go` — 2 tests: mock receiver happy path + unreachable socket FR-8 fallback

## Part of engram #109 arc

Depends on T023 (#76 merged — `NewOwnerFromHandoff`) and T021 (#78 merged — `HandleGracefulRestart` wire-in). Siblings: T024 (#77 merged). Successor of: T025 (sibling, WIP — structured logging + counters).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Новые возможности**
  * Восстановление демона расширено путем повторного присоединения через handoff, позволяя реattach существующих сеансов вместо их повторного запуска.

* **Улучшения поведения**
  * Сохранён надёжный fallback: при недоступности handoff используется прежний путь восстановления.
  * Поддержка частичного handoff — некоторые сеансы могут быть восстановлены через handoff, остальные — через legacy-путь.

* **Тесты**
  * Добавлены тесты для успешного reattach, недоступного сокета и частичного handoff с проверкой логов.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->