### PR TITLE
feat(v0.21.0-phase5): verify-handoff post-deploy scripts (T036)

### DIFF
--- a/scripts/verify-handoff.ps1
+++ b/scripts/verify-handoff.ps1
@@ -1,0 +1,150 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Post-deploy verification for upstream-survives-daemon-restart (T036).
+
+.DESCRIPTION
+    Asserts that `mcp-mux upgrade --restart` preserves every upstream PID
+    across the daemon restart (v0.21.0+ handoff path) OR documents the
+    legacy fallback path when the old daemon predates the handoff protocol.
+
+.PARAMETER Binary
+    Path to the mcp-mux binary. Defaults to 'mcp-mux' on PATH.
+
+.PARAMETER TimeoutSeconds
+    Seconds to wait for the successor daemon to become ready after restart.
+    Defaults to 15.
+
+.OUTPUTS
+    Exit code:
+      0 = PASS (all upstream PIDs survived OR FR-8 fallback path observed)
+      1 = FAIL (PIDs diverged without a fallback signal — regression)
+      2 = SETUP ERROR (binary missing, daemon not running, etc.)
+
+.EXAMPLE
+    ./scripts/verify-handoff.ps1
+    ./scripts/verify-handoff.ps1 -Binary 'C:\tools\mcp-mux.exe' -TimeoutSeconds 30
+#>
+
+[CmdletBinding()]
+param(
+    [string] $Binary = $(if ($env:MCP_MUX_BINARY) { $env:MCP_MUX_BINARY } else { 'mcp-mux' }),
+    [int]    $TimeoutSeconds = $(if ($env:VERIFY_TIMEOUT) { [int]$env:VERIFY_TIMEOUT } else { 15 })
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Write-Step { param($Msg) Write-Host "[verify-handoff] $Msg" }
+function Invoke-Die  { param($Msg) Write-Host "[verify-handoff] FATAL: $Msg"; exit 2 }
+function Invoke-Fail { param($Msg) Write-Host "[verify-handoff] FAIL: $Msg";  exit 1 }
+
+if (-not (Get-Command $Binary -ErrorAction SilentlyContinue)) {
+    Invoke-Die "mcp-mux binary not found: $Binary"
+}
+
+function Get-Status {
+    try {
+        $raw = & $Binary status 2>$null
+        if ($LASTEXITCODE -ne 0 -or -not $raw) {
+            throw "mcp-mux status exited $LASTEXITCODE"
+        }
+        return ($raw | ConvertFrom-Json -Depth 10)
+    }
+    catch {
+        Invoke-Die "mcp-mux status failed — is the daemon running? ($_)"
+    }
+}
+
+function Get-PidsSnapshot {
+    param($Status)
+    $rows = @()
+    foreach ($server in ($Status.servers | Where-Object { $_.pid })) {
+        $rows += [pscustomobject]@{
+            Sid     = $server.server_id
+            Pid     = [int]$server.pid
+            Command = $server.command
+        }
+    }
+    return $rows | Sort-Object Sid
+}
+
+function Get-HandoffCounter {
+    param($Status, [string]$Key)
+    if ($Status.handoff -and $Status.handoff.PSObject.Properties[$Key]) {
+        return [int64]$Status.handoff.$Key
+    }
+    return [int64]0
+}
+
+Write-Step "step 1/5: capturing pre-restart state"
+$statusBefore = Get-Status
+$before       = Get-PidsSnapshot $statusBefore
+if ($before.Count -eq 0) {
+    Invoke-Die "no upstream PIDs reported before restart — start at least one upstream before verifying"
+}
+$beforeAttempted   = Get-HandoffCounter $statusBefore 'attempted'
+$beforeTransferred = Get-HandoffCounter $statusBefore 'transferred'
+$beforeFallback    = Get-HandoffCounter $statusBefore 'fallback'
+Write-Step ("  observed {0} upstream(s); pre counters: attempted={1} transferred={2} fallback={3}" -f `
+    $before.Count, $beforeAttempted, $beforeTransferred, $beforeFallback)
+
+Write-Step "step 2/5: invoking mcp-mux upgrade --restart"
+& $Binary upgrade --restart
+if ($LASTEXITCODE -ne 0) {
+    Invoke-Fail "mcp-mux upgrade --restart exited $LASTEXITCODE"
+}
+
+Write-Step "step 3/5: waiting up to ${TimeoutSeconds}s for successor daemon ready"
+$elapsed = 0
+$ready   = $false
+while ($elapsed -lt $TimeoutSeconds) {
+    try {
+        $null = & $Binary status 2>$null
+        if ($LASTEXITCODE -eq 0) {
+            $ready = $true
+            Write-Step "  daemon ready after ${elapsed}s"
+            break
+        }
+    }
+    catch { }
+    Start-Sleep -Seconds 1
+    $elapsed++
+}
+if (-not $ready) {
+    Invoke-Fail "successor daemon did not come up within ${TimeoutSeconds}s"
+}
+
+Write-Step "step 4/5: capturing post-restart state"
+$statusAfter      = Get-Status
+$after            = Get-PidsSnapshot $statusAfter
+$afterAttempted   = Get-HandoffCounter $statusAfter 'attempted'
+$afterTransferred = Get-HandoffCounter $statusAfter 'transferred'
+$afterFallback    = Get-HandoffCounter $statusAfter 'fallback'
+Write-Step ("  observed {0} upstream(s); post counters: attempted={1} transferred={2} fallback={3}" -f `
+    $after.Count, $afterAttempted, $afterTransferred, $afterFallback)
+
+Write-Step "step 5/5: comparing PID sets"
+$diff = Compare-Object -ReferenceObject $before -DifferenceObject $after -Property Sid,Pid -PassThru
+if (-not $diff) {
+    Write-Step ("PASS: all {0} upstream PIDs survived the restart" -f $after.Count)
+    Write-Step ("       handoff counters delta: attempted+{0} transferred+{1} fallback+{2}" -f `
+        ($afterAttempted - $beforeAttempted),
+        ($afterTransferred - $beforeTransferred),
+        ($afterFallback - $beforeFallback))
+    exit 0
+}
+
+# PIDs diverged. If fallback counter incremented, that's FR-8 — expected for legacy.
+if ($afterFallback -gt $beforeFallback) {
+    Write-Step ("PASS (fallback): handoff_fallback incremented by {0}" -f ($afterFallback - $beforeFallback))
+    Write-Step "       this is the FR-8 zero-deployment-impact path (old daemon had no handoff code,"
+    Write-Step "       or protocol versions mismatched). Upstreams were respawned — next restart"
+    Write-Step "       will use the handoff path."
+    Write-Step "PID changes:"
+    $diff | Format-Table -AutoSize | Out-String | Write-Host
+    exit 0
+}
+
+Write-Step "PID diff (unexpected — no fallback counter bump):"
+$diff | Format-Table -AutoSize | Out-String | Write-Host
+Invoke-Fail "upstream PIDs diverged without a fallback signal — handoff regression suspected"

--- a/scripts/verify-handoff.sh
+++ b/scripts/verify-handoff.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env sh
+# verify-handoff.sh — post-deploy verification for upstream-survives-daemon-restart (T036).
+#
+# Asserts that `mcp-mux upgrade --restart` preserves every upstream PID across
+# the daemon restart (v0.21.0+ handoff path) OR documents the legacy fallback
+# path when the old daemon predates the handoff protocol.
+#
+# Exit codes:
+#   0 = PASS (all upstream PIDs survived OR operator explicitly ran against
+#            legacy daemon — FR-9 zero-deployment-impact guarantee held)
+#   1 = FAIL (PIDs diverged without an FR-8 fallback signal — regression)
+#   2 = SETUP ERROR (mcp-mux not on PATH, no daemon running, jq missing, etc.)
+#
+# Usage:
+#   scripts/verify-handoff.sh                     # use default mcp-mux binary
+#   MCP_MUX_BINARY=/opt/mcp-mux scripts/verify-handoff.sh
+#   VERIFY_TIMEOUT=30 scripts/verify-handoff.sh   # wait-for-ready budget in seconds
+
+set -eu
+
+BINARY="${MCP_MUX_BINARY:-mcp-mux}"
+TIMEOUT="${VERIFY_TIMEOUT:-15}"
+
+log()  { printf '[verify-handoff] %s\n' "$*" >&2; }
+die()  { log "FATAL: $*"; exit 2; }
+fail() { log "FAIL: $*"; exit 1; }
+
+command -v "$BINARY" >/dev/null 2>&1 || die "mcp-mux binary not found: $BINARY"
+command -v jq        >/dev/null 2>&1 || die "jq not found on PATH (required for JSON parsing)"
+
+status_json() {
+  "$BINARY" status 2>/dev/null || die "mcp-mux status failed — is the daemon running?"
+}
+
+# Snapshot of pid<->server_id pairs, sorted by sid for stable diff.
+pids_snapshot() {
+  status_json | jq -r '
+    (.servers // [])
+    | map(select(.pid != null) | {sid: .server_id, pid: .pid, cmd: .command})
+    | sort_by(.sid)
+    | .[]
+    | "\(.sid)\t\(.pid)\t\(.cmd)"
+  '
+}
+
+handoff_counter() {
+  status_json | jq -r --arg k "$1" '(.handoff // {})[$k] // 0'
+}
+
+log "step 1/5: capturing pre-restart state"
+BEFORE="$(pids_snapshot)"
+if [ -z "$BEFORE" ]; then
+  die "no upstream PIDs reported before restart — start at least one upstream before verifying"
+fi
+BEFORE_ATTEMPTED="$(handoff_counter attempted)"
+BEFORE_TRANSFERRED="$(handoff_counter transferred)"
+BEFORE_FALLBACK="$(handoff_counter fallback)"
+BEFORE_COUNT="$(printf '%s\n' "$BEFORE" | wc -l | tr -d ' ')"
+log "  observed $BEFORE_COUNT upstream(s); pre counters: attempted=$BEFORE_ATTEMPTED transferred=$BEFORE_TRANSFERRED fallback=$BEFORE_FALLBACK"
+
+log "step 2/5: invoking mcp-mux upgrade --restart"
+"$BINARY" upgrade --restart
+
+log "step 3/5: waiting up to ${TIMEOUT}s for successor daemon ready"
+ELAPSED=0
+while [ "$ELAPSED" -lt "$TIMEOUT" ]; do
+  if "$BINARY" status >/dev/null 2>&1; then
+    log "  daemon ready after ${ELAPSED}s"
+    break
+  fi
+  sleep 1
+  ELAPSED=$((ELAPSED + 1))
+done
+[ "$ELAPSED" -lt "$TIMEOUT" ] || fail "successor daemon did not come up within ${TIMEOUT}s"
+
+log "step 4/5: capturing post-restart state"
+AFTER="$(pids_snapshot)"
+AFTER_ATTEMPTED="$(handoff_counter attempted)"
+AFTER_TRANSFERRED="$(handoff_counter transferred)"
+AFTER_FALLBACK="$(handoff_counter fallback)"
+AFTER_COUNT="$(printf '%s\n' "$AFTER" | wc -l | tr -d ' ')"
+log "  observed $AFTER_COUNT upstream(s); post counters: attempted=$AFTER_ATTEMPTED transferred=$AFTER_TRANSFERRED fallback=$AFTER_FALLBACK"
+
+log "step 5/5: comparing PID sets"
+DIFF="$(diff -u <(printf '%s\n' "$BEFORE") <(printf '%s\n' "$AFTER") || true)"
+if [ -z "$DIFF" ]; then
+  log "PASS: all $AFTER_COUNT upstream PIDs survived the restart"
+  log "       handoff counters delta: attempted+$((AFTER_ATTEMPTED - BEFORE_ATTEMPTED)) transferred+$((AFTER_TRANSFERRED - BEFORE_TRANSFERRED)) fallback+$((AFTER_FALLBACK - BEFORE_FALLBACK))"
+  exit 0
+fi
+
+# PIDs diverged. If the fallback counter increased, that's FR-8 — expected for legacy.
+if [ "$AFTER_FALLBACK" -gt "$BEFORE_FALLBACK" ]; then
+  log "PASS (fallback): handoff_fallback incremented by $((AFTER_FALLBACK - BEFORE_FALLBACK))"
+  log "       this is the FR-8 zero-deployment-impact path (old daemon had no handoff code,"
+  log "       or protocol versions mismatched). Upstreams were respawned — next restart"
+  log "       will use the handoff path."
+  log "PID changes:"
+  printf '%s\n' "$DIFF" | sed 's/^/  /' >&2
+  exit 0
+fi
+
+log "PID diff (unexpected — no fallback counter bump):"
+printf '%s\n' "$DIFF" | sed 's/^/  /' >&2
+fail "upstream PIDs diverged without a fallback signal — handoff regression suspected"


### PR DESCRIPTION
T036 — post-deploy verification scripts for the handoff upgrade path.

Ships two platform-specific scripts exercising `mcp-mux upgrade --restart` and asserting upstream PID survival:

- `scripts/verify-handoff.sh` — POSIX (Linux, macOS, *BSD). Requires `jq`.
- `scripts/verify-handoff.ps1` — Windows PowerShell 5.1+.

## Flow (both scripts)

1. Snapshot upstream PIDs + handoff counters via `mcp-mux status` (JSON → parsed)
2. Invoke `mcp-mux upgrade --restart`
3. Wait up to `VERIFY_TIMEOUT` / `-TimeoutSeconds` (default 15s) for successor daemon ready
4. Snapshot PIDs again
5. Assert PID set survived **OR** `handoff_fallback` counter incremented (FR-8 path — expected on first upgrade after v0.20.x → v0.21.0)

## Exit codes

| Code | Meaning |
|---|---|
| 0 | PASS — all PIDs survived OR FR-8 fallback took over (zero-deployment-impact guarantee held) |
| 1 | FAIL — PIDs diverged with no fallback counter bump (handoff regression suspected) |
| 2 | Setup error — binary missing, daemon not running, or `jq` missing on POSIX |

## Configuration

| POSIX env | PowerShell param | Default |
|---|---|---|
| `MCP_MUX_BINARY` | `-Binary` | `mcp-mux` (from PATH) |
| `VERIFY_TIMEOUT` | `-TimeoutSeconds` | `15` |

Referenced from the "Post-deploy verification" subsection added to README.md / README.ru.md by PR #82 (T033).

## Why this matters

Operators running `mcp-mux upgrade --restart` on production need a mechanical signal that the handoff is working as designed. Without a script:

- Silent regressions to the FR-8 fallback path look identical to success from the outside
- PID churn during a restart is invisible without `status` snapshots before/after
- The `handoff_*` counter interpretation requires deep familiarity with the spec

These scripts make the v0.21.0 contract self-verifying in a single command.

## Testing

- Script logic is straightforward JSON inspection — relies only on `mcp-mux status` output format (stable since v0.6.0, with `handoff` sub-map added in v0.21.0 via #81).
- Full runtime verification will happen post-release during v0.21.0 rollout to local mcp-mux deployment.
- Windows script follows PSScriptAnalyzer defaults (Verb-Noun, approved verbs, `-ErrorAction Stop`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **Новые возможности**
  * Добавлены сценарии для проверки целостности обновления и успешного сохранения активных процессов при перезагрузке.
  * Реализована автоматическая верификация процесса миграции и передачи состояния системы.
  * Включена встроенная проверка корректности работы компонентов и обновления.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->