### PR TITLE
docs: spelling + log filename fixes from Gemini post-merge review

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ The daemon updates on next natural restart.
 ## Upstream Lifecycle — Survives Daemon Restart (v0.21.0+)
 
 Starting in v0.21.0, an upstream MCP server process **survives daemon restart without losing
-in-flight requests**. This restores the "drop-in MCP process manager" contract: behavioural
+in-flight requests**. This restores the "drop-in MCP process manager" contract: behavioral
 equivalence to running the server as a direct child of the stdio client (the CC baseline).
 
 ### The contract
@@ -422,7 +422,7 @@ kill-and-respawn path — **no upstream is lost, zero-deployment-impact guarante
 - Protocol version mismatch (`ErrProtocolVersionMismatch`)
 - Any other `performHandoff` error
 
-All paths log `handoff.fallback reason=…` — search `mcp-mux.log` for operator diagnostics.
+All paths log `handoff.fallback reason=…` — search `mcp-muxd-debug.log` for operator diagnostics.
 After fallback the successor daemon respawns upstreams from snapshot; `drainOrphanedInflight`
 returns JSON-RPC errors to in-flight callers (same as v0.20.x).
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -351,7 +351,7 @@ mcp-mux upgrade
 daemon автоматически откатывается на kill-and-respawn путь v0.20.x. **Ни один upstream
 не теряется, гарантия нулевого влияния при деплое (FR-9).**
 
-Все пути логируют `handoff.fallback reason=…` — ищите в `mcp-mux.log` для диагностики.
+Все пути логируют `handoff.fallback reason=…` — ищите в `mcp-muxd-debug.log` для диагностики.
 
 ### Видимость для оператора
 


### PR DESCRIPTION
Three Gemini-flagged fixes that came back on PR #82 after it was already merged:

1. `behavioural` → `behavioral` (American English consistency with surrounding text)
2. `mcp-mux.log` → `mcp-muxd-debug.log` in English doc (correct log filename — verified against `cmd/mcp-mux/daemon.go:61`)
3. Same log filename fix in Russian doc

3 lines across 2 files. Docs-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **Документация**
  * Обновлена документация по сценариям деградации FR-8 для корректного указания диагностического лог-файла при устранении неисправностей
  * Улучшена точность и ясность формулировок в документации на английском и русском языках

<!-- end of auto-generated comment: release notes by coderabbit.ai -->