### PR TITLE
chore(release): bump muxcore require to v0.21.0 (arc #109 complete)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/thebtf/mcp-mux
 
 go 1.25.4
 
-require github.com/thebtf/mcp-mux/muxcore v0.20.4
+require github.com/thebtf/mcp-mux/muxcore v0.21.0
 
 require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect


### PR DESCRIPTION
Version bump for muxcore/v0.21.0 + mcp-mux/v0.10.0 — the upstream-survives-daemon-restart arc (engram #109).

## What this PR does

1. Bumps root `go.mod` `require` from `v0.20.4` → `v0.21.0` to pin the new muxcore semver.

That's the entire diff — 1 line. The actual feature work is already on master via 12 PRs (#73–#84).

## After merge

Immediately after this PR merges, the following tags and releases get cut from master HEAD:

- `muxcore/v0.21.0` — annotated, release notes from `.agent/data/release-notes-muxcore-v0.21.0-final.md`
- `v0.10.0` — annotated, bundles the mcp-mux binary shipping this arc

Then:
- `gh release create muxcore/v0.21.0 --notes-file …`
- `gh release create v0.10.0 --notes "bundles muxcore/v0.21.0 — see that release for details"`
- Engram #109 — comment with tag + transition to resolved
- Engram #130 — acknowledged in muxcore/v0.21.0 notes (public API shipped)

## Scope

Why MAJOR is justified — lifecycle contract change for upstream processes:

> Prior to v0.21.0, every daemon-level operation (`upgrade --restart`, graceful restart, reaper-driven `Remove`, `daemon.Shutdown`) destroyed all upstream processes and respawned them. In-flight JSON-RPC requests were lost.
>
> From v0.21.0 on, planned daemon restarts hand OFF upstream file descriptors to the successor daemon without killing the upstream. In-flight requests survive the restart.

All v0.20.x public APIs remain source-compatible. Consumers (aimux, engram) upgrade without code changes.

## Arc summary

Phase 1 (#73) + Phase 2 (#74) + Phase 3 (#75) + Phase 4 (#76, #77, #78, #80, #81, #84) + Phase 5 (#79, #82, #83, #85).

Detailed PR-by-PR breakdown lives in `.agent/data/release-notes-muxcore-v0.21.0-final.md`.
