### PR TITLE
test(postmerge): t026 fallback test quality polish

### DIFF
--- a/muxcore/daemon/handoff_fallback_test.go
+++ b/muxcore/daemon/handoff_fallback_test.go
@@ -7,6 +7,22 @@ import (
 	"time"
 )
 
+// setupTestHandoffTimeouts overrides the package-level handoff timeout
+// variables to 50 ms so tests exercise the timeout/fallback path quickly
+// without relying on production-scale delays.  The original values are
+// restored automatically via t.Cleanup.
+func setupTestHandoffTimeouts(t *testing.T) {
+	t.Helper()
+	origAccept := handoffAcceptTimeout
+	origTotal := handoffTotalTimeout
+	handoffAcceptTimeout = 50 * time.Millisecond
+	handoffTotalTimeout = 50 * time.Millisecond
+	t.Cleanup(func() {
+		handoffAcceptTimeout = origAccept
+		handoffTotalTimeout = origTotal
+	})
+}
+
 // TestHandoffFallbackOnAcceptTimeout verifies that HandleGracefulRestart returns
 // a valid snapshot path and nil error even when no successor daemon connects
 // within the accept timeout — i.e. the FR-8 fallback path is transparent to
@@ -22,15 +38,7 @@ import (
 //  2. snapshotPath is non-empty — snapshot serialization succeeded.
 //  3. The daemon continues to the Shutdown path (go d.Shutdown()) regardless.
 func TestHandoffFallbackOnAcceptTimeout(t *testing.T) {
-	// Override timeouts so the test completes quickly.
-	origAccept := handoffAcceptTimeout
-	origTotal := handoffTotalTimeout
-	handoffAcceptTimeout = 50 * time.Millisecond
-	handoffTotalTimeout = 50 * time.Millisecond
-	t.Cleanup(func() {
-		handoffAcceptTimeout = origAccept
-		handoffTotalTimeout = origTotal
-	})
+	setupTestHandoffTimeouts(t)
 
 	d := testDaemon(t) // helper defined in daemon_test.go
 
@@ -56,14 +64,7 @@ func TestHandoffFallbackOnAcceptTimeout(t *testing.T) {
 // Uses testDaemonWithLog (helper added in F80-4 / T022) to capture daemon
 // log output into a thread-safe buffer and grep it after the call returns.
 func TestHandoffFallback_LogMarker(t *testing.T) {
-	origAccept := handoffAcceptTimeout
-	origTotal := handoffTotalTimeout
-	handoffAcceptTimeout = 50 * time.Millisecond
-	handoffTotalTimeout = 50 * time.Millisecond
-	t.Cleanup(func() {
-		handoffAcceptTimeout = origAccept
-		handoffTotalTimeout = origTotal
-	})
+	setupTestHandoffTimeouts(t)
 
 	d, logBuf := testDaemonWithLog(t)
 
@@ -104,14 +105,7 @@ func TestHandoffFallback_LogMarker(t *testing.T) {
 // but asserts the counter delta in HandleStatus output rather than log
 // content.
 func TestHandoffFallback_CounterIncrement(t *testing.T) {
-	origAccept := handoffAcceptTimeout
-	origTotal := handoffTotalTimeout
-	handoffAcceptTimeout = 50 * time.Millisecond
-	handoffTotalTimeout = 50 * time.Millisecond
-	t.Cleanup(func() {
-		handoffAcceptTimeout = origAccept
-		handoffTotalTimeout = origTotal
-	})
+	setupTestHandoffTimeouts(t)
 
 	d := testDaemon(t)
 
@@ -153,14 +147,7 @@ func TestHandoffFallback_CounterIncrement(t *testing.T) {
 // TestHandoffFallback_StatusCountersExposed verifies the counters reach
 // HandleStatus output (the API verify-handoff.sh / .ps1 rely on).
 func TestHandoffFallback_StatusCountersExposed(t *testing.T) {
-	origAccept := handoffAcceptTimeout
-	origTotal := handoffTotalTimeout
-	handoffAcceptTimeout = 50 * time.Millisecond
-	handoffTotalTimeout = 50 * time.Millisecond
-	t.Cleanup(func() {
-		handoffAcceptTimeout = origAccept
-		handoffTotalTimeout = origTotal
-	})
+	setupTestHandoffTimeouts(t)
 
 	d := testDaemon(t)
 
@@ -183,7 +170,10 @@ func TestHandoffFallback_StatusCountersExposed(t *testing.T) {
 	t.Cleanup(func() { _ = os.Remove(snapshotPath) })
 
 	after := d.HandleStatus()
-	hoff1, _ := after["handoff"].(map[string]any)
+	hoff1, ok := after["handoff"].(map[string]any)
+	if !ok {
+		t.Fatalf("HandleStatus missing 'handoff' sub-map after restart; got %T", after["handoff"])
+	}
 
 	// attempted and fallback both visible via HandleStatus as uint64 (json-safe).
 	attemptedVal, _ := hoff1["attempted"].(uint64)
@@ -202,14 +192,7 @@ func TestHandoffFallback_StatusCountersExposed(t *testing.T) {
 // restore from. Without this, a handoff failure would lose both in-flight
 // requests AND the cached init/tools templates.
 func TestHandoffFallback_SnapshotAlwaysWritten(t *testing.T) {
-	origAccept := handoffAcceptTimeout
-	origTotal := handoffTotalTimeout
-	handoffAcceptTimeout = 50 * time.Millisecond
-	handoffTotalTimeout = 50 * time.Millisecond
-	t.Cleanup(func() {
-		handoffAcceptTimeout = origAccept
-		handoffTotalTimeout = origTotal
-	})
+	setupTestHandoffTimeouts(t)
 
 	d := testDaemon(t)
 


### PR DESCRIPTION
Postmerge quality fixes from Gemini review on PR #84.

## 2 test-quality findings, both medium

1. **Extract `setupTestHandoffTimeouts(t)` helper** — the 4 new tests + 1 pre-existing baseline each repeated 7 lines of accept/total timeout override boilerplate. Helper uses `t.Helper()` + `t.Cleanup` for restoration.

2. **Use two-value type assertion on `HandleStatus.handoff` sub-map**. Previously `hoff1, _ := after["handoff"].(map[string]any)` — the `_` discarded the assertion result, silently masking an unexpected value type. Now: `hoff1, ok := …; if !ok { t.Fatalf("…; got %T", after["handoff"]) }`.

All 5 `TestHandoffFallback*` tests still pass locally.

File diff: +25 -42 lines, no behavior change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **Tests**
  * Улучшена организация тестового кода через введение общего вспомогательного инструмента для управления таймаутами.
  * Сокращено дублирование в нескольких тестовых случаях путем повторного использования общего вспомогательного инструмента.
  * Усилены проверки в тестовых утверждениях для повышения надежности валидации.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->