### PR TITLE
feat(rotlog): runtime log rotation for mcp-muxd-debug.log

### DIFF
--- a/cmd/mcp-mux/daemon.go
+++ b/cmd/mcp-mux/daemon.go
@@ -5,14 +5,16 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"os/signal"
+	"path/filepath"
+	"strconv"
 	"syscall"
 	"time"
 
 	"github.com/thebtf/mcp-mux/muxcore/control"
 	"github.com/thebtf/mcp-mux/muxcore/daemon"
 	"github.com/thebtf/mcp-mux/muxcore/ipc"
+	"github.com/thebtf/mcp-mux/muxcore/rotlog"
 	"github.com/thebtf/mcp-mux/muxcore/serverid"
 )
 
@@ -56,20 +58,31 @@ func runGlobalDaemon() {
 	}
 
 	// Debug log to file — daemon is detached, stderr goes nowhere.
-	// Rotate: if log > 50MB, shift .1 → .2, current → .1, start fresh.
-	// Keeps up to ~2 days of history across restarts (3 files × 50MB max).
+	// Runtime rotation: rotlog.Writer rotates during daemon lifetime (not only on restart).
+	// Default: 50MB max size, 3 files (active + .1 + .2). Override via env vars.
 	debugLogPath := filepath.Join(os.TempDir(), "mcp-muxd-debug.log")
-	if info, err := os.Stat(debugLogPath); err == nil && info.Size() > 50*1024*1024 {
-		os.Remove(debugLogPath + ".2")
-		os.Rename(debugLogPath+".1", debugLogPath+".2")
-		os.Rename(debugLogPath, debugLogPath+".1")
+	maxMB := int64(50)
+	if v := os.Getenv("MCP_MUX_LOG_MAX_MB"); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil && n > 0 {
+			maxMB = n
+		}
 	}
-	logFile, err := os.OpenFile(debugLogPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	maxFiles := 3
+	if v := os.Getenv("MCP_MUX_LOG_MAX_FILES"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 1 {
+			maxFiles = n
+		}
+	}
+	logWriter, err := rotlog.New(rotlog.Config{
+		Path:     debugLogPath,
+		MaxSize:  maxMB * 1024 * 1024,
+		MaxFiles: maxFiles,
+	})
 	var logger *log.Logger
 	if err == nil {
-		defer func() { _ = logFile.Close() }()
-		logger = log.New(logFile, "[mcp-muxd] ", log.LstdFlags|log.Lmicroseconds)
-		logger.Printf("=== daemon starting, debug log: %s ===", debugLogPath)
+		defer func() { _ = logWriter.Close() }()
+		logger = log.New(logWriter, "[mcp-muxd] ", log.LstdFlags|log.Lmicroseconds)
+		logger.Printf("=== daemon starting, debug log: %s (max=%dMB x%d) ===", debugLogPath, maxMB, maxFiles)
 	} else {
 		logger = log.New(os.Stderr, "[mcp-muxd] ", log.LstdFlags)
 	}

--- a/muxcore/rotlog/rotlog.go
+++ b/muxcore/rotlog/rotlog.go
@@ -1,0 +1,170 @@
+// Package rotlog provides a size-based rotating io.Writer for log files.
+// Safe for concurrent use. Rotation happens when a Write would push the
+// active file above MaxSize — the active file is closed, shifted to .1,
+// older backups are shifted up, and a fresh active file is opened.
+//
+// If a single Write payload exceeds MaxSize, the write proceeds anyway
+// (into the new file) to preserve per-line atomicity. The file is then
+// rotated on the NEXT Write that would overflow.
+package rotlog
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+)
+
+// ErrClosed is returned by Write after Close has been called.
+var ErrClosed = errors.New("rotlog: writer is closed")
+
+// Writer is a size-based rotating io.Writer. Safe for concurrent use.
+type Writer struct {
+	cfg    Config
+	mu     sync.Mutex
+	file   *os.File
+	size   int64
+	closed bool
+}
+
+// Config controls rotation behavior.
+type Config struct {
+	// Path to the active log file. Rotated copies are written as Path.1, Path.2, ...
+	Path string
+	// MaxSize in bytes. When a Write would push the active file above MaxSize,
+	// rotation happens BEFORE the write lands in a new file. Must be > 0.
+	MaxSize int64
+	// MaxFiles is the total number of files kept, counting the active one.
+	// E.g. MaxFiles=3 keeps Path (active) + Path.1 + Path.2. Path.2 is
+	// discarded on each rotation to keep the total at MaxFiles. Must be >= 1.
+	MaxFiles int
+	// FileMode for newly created files. Defaults to 0644 if zero.
+	FileMode os.FileMode
+}
+
+// New opens (or creates) the active log file per cfg and returns a Writer.
+// If the file already exists and is >= MaxSize, rotation is deferred until
+// the first Write (so that an already-too-big file is rotated on first Write).
+func New(cfg Config) (*Writer, error) {
+	if cfg.Path == "" {
+		return nil, fmt.Errorf("rotlog: Path must not be empty")
+	}
+	if cfg.MaxSize <= 0 {
+		return nil, fmt.Errorf("rotlog: MaxSize must be > 0, got %d", cfg.MaxSize)
+	}
+	if cfg.MaxFiles < 1 {
+		return nil, fmt.Errorf("rotlog: MaxFiles must be >= 1, got %d", cfg.MaxFiles)
+	}
+	if cfg.FileMode == 0 {
+		cfg.FileMode = 0644
+	}
+
+	f, size, err := openActive(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Writer{
+		cfg:  cfg,
+		file: f,
+		size: size,
+	}, nil
+}
+
+// openActive opens (or creates) the active log file and returns the file and its current size.
+func openActive(cfg Config) (*os.File, int64, error) {
+	f, err := os.OpenFile(cfg.Path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, cfg.FileMode)
+	if err != nil {
+		return nil, 0, fmt.Errorf("rotlog: open %s: %w", cfg.Path, err)
+	}
+	info, err := f.Stat()
+	if err != nil {
+		f.Close()
+		return nil, 0, fmt.Errorf("rotlog: stat %s: %w", cfg.Path, err)
+	}
+	return f, info.Size(), nil
+}
+
+// rotate closes the current file, shifts backups, opens a new active file.
+// Caller must hold w.mu.
+func (w *Writer) rotate() error {
+	if err := w.file.Close(); err != nil {
+		_ = err // non-fatal: proceed with rotation even if close had issues
+	}
+	w.file = nil
+
+	// Delete the oldest backup file to make room.
+	// MaxFiles=3 means: active + .1 + .2. The oldest backup is .2 (index MaxFiles-1).
+	// After shifting .1→.2, active→.1, we open a fresh active — total stays at MaxFiles.
+	oldest := w.cfg.MaxFiles - 1
+	if oldest >= 1 {
+		_ = os.Remove(fmt.Sprintf("%s.%d", w.cfg.Path, oldest))
+	}
+
+	// Shift backups from highest down: .(N-2) → .(N-1), ..., .1 → .2
+	for i := w.cfg.MaxFiles - 2; i >= 1; i-- {
+		src := fmt.Sprintf("%s.%d", w.cfg.Path, i)
+		dst := fmt.Sprintf("%s.%d", w.cfg.Path, i+1)
+		_ = os.Rename(src, dst) // ignore error (file may not exist)
+	}
+
+	// Rename active → .1 (only when MaxFiles >= 2; with MaxFiles=1, discard in place)
+	if w.cfg.MaxFiles >= 2 {
+		_ = os.Rename(w.cfg.Path, w.cfg.Path+".1")
+	}
+
+	// Open fresh active file
+	f, err := os.OpenFile(w.cfg.Path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, w.cfg.FileMode)
+	if err != nil {
+		return fmt.Errorf("rotlog: open new active file %s: %w", w.cfg.Path, err)
+	}
+	w.file = f
+	w.size = 0
+	return nil
+}
+
+// Write implements io.Writer. Thread-safe. Rotates atomically on size overflow.
+//
+// If a single Write payload exceeds MaxSize, the write proceeds anyway
+// (to preserve per-line atomicity). Rotation fires on the next Write that overflows.
+func (w *Writer) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.closed {
+		return 0, ErrClosed
+	}
+
+	// Rotate if this write would push us over the limit (and file is non-empty).
+	if w.size > 0 && w.size+int64(len(p)) > w.cfg.MaxSize {
+		if err := w.rotate(); err != nil {
+			return 0, err
+		}
+	}
+
+	n, err := w.file.Write(p)
+	if err != nil {
+		return n, err
+	}
+	if n < len(p) {
+		return n, fmt.Errorf("rotlog: short write: %w", io.ErrShortWrite)
+	}
+	w.size += int64(n)
+	return n, nil
+}
+
+// Close flushes and closes the active file. After Close, Write returns ErrClosed.
+func (w *Writer) Close() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.closed {
+		return nil
+	}
+	w.closed = true
+	if w.file != nil {
+		return w.file.Close()
+	}
+	return nil
+}

--- a/muxcore/rotlog/rotlog_test.go
+++ b/muxcore/rotlog/rotlog_test.go
@@ -1,0 +1,245 @@
+package rotlog
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"testing"
+)
+
+// TestRotatesAtThreshold: MaxSize=100, MaxFiles=3.
+// Write 60 bytes → no rotation. Write another 60 bytes → rotation fires (120 total > 100).
+func TestRotatesAtThreshold(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+
+	w, err := New(Config{Path: path, MaxSize: 100, MaxFiles: 3})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer w.Close()
+
+	first := make([]byte, 60)
+	for i := range first {
+		first[i] = 'A'
+	}
+	if _, err := w.Write(first); err != nil {
+		t.Fatalf("first Write: %v", err)
+	}
+
+	// No rotation yet: .1 should not exist
+	if _, err := os.Stat(path + ".1"); !os.IsNotExist(err) {
+		t.Errorf("expected .1 not to exist after first write, got stat err=%v", err)
+	}
+
+	second := make([]byte, 60)
+	for i := range second {
+		second[i] = 'B'
+	}
+	if _, err := w.Write(second); err != nil {
+		t.Fatalf("second Write: %v", err)
+	}
+
+	// Rotation should have happened: .1 exists with the first 60 bytes
+	info, err := os.Stat(path + ".1")
+	if err != nil {
+		t.Fatalf("expected .1 to exist after rotation: %v", err)
+	}
+	if info.Size() != 60 {
+		t.Errorf("expected .1 size=60, got %d", info.Size())
+	}
+
+	// Active file should have only the second write (60 bytes)
+	activeInfo, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("active file stat: %v", err)
+	}
+	if activeInfo.Size() != 60 {
+		t.Errorf("expected active size=60, got %d", activeInfo.Size())
+	}
+}
+
+// TestKeepsFileCountCap: MaxSize=50, MaxFiles=3.
+// Write enough to trigger 4+ rotations. .3 must NOT exist (only active + .1 + .2).
+func TestKeepsFileCountCap(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+
+	w, err := New(Config{Path: path, MaxSize: 50, MaxFiles: 3})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer w.Close()
+
+	// 6 writes of 30 bytes each → triggers 4+ rotations at MaxSize=50
+	chunk := make([]byte, 30)
+	for i := range chunk {
+		chunk[i] = 'X'
+	}
+	for i := 0; i < 6; i++ {
+		if _, err := w.Write(chunk); err != nil {
+			t.Fatalf("Write %d: %v", i, err)
+		}
+	}
+
+	// .3 must not exist (MaxFiles=3 → active + .1 + .2 only)
+	if _, err := os.Stat(path + ".3"); !os.IsNotExist(err) {
+		t.Errorf("expected .3 to not exist, got stat err=%v", err)
+	}
+
+	// Active, .1, .2 should exist
+	for _, suffix := range []string{"", ".1", ".2"} {
+		if _, err := os.Stat(path + suffix); err != nil {
+			t.Errorf("expected %s%s to exist: %v", path, suffix, err)
+		}
+	}
+}
+
+// TestRotatesOnOpenIfAlreadyTooBig: pre-create a 200-byte file (exceeds MaxSize=100).
+// New opens it. First Write triggers rotation; active is fresh, .1 holds original.
+func TestRotatesOnOpenIfAlreadyTooBig(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+
+	// Pre-create file with 200 bytes content (exceeds MaxSize=100)
+	content := make([]byte, 200)
+	for i := range content {
+		content[i] = 'Z'
+	}
+	if err := os.WriteFile(path, content, 0644); err != nil {
+		t.Fatalf("pre-create: %v", err)
+	}
+
+	w, err := New(Config{Path: path, MaxSize: 100, MaxFiles: 3})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer w.Close()
+
+	// Write a small payload — triggers rotation (existing file is already too big)
+	payload := []byte("hello\n")
+	if _, err := w.Write(payload); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	// .1 should contain the original 200-byte content
+	info, err := os.Stat(path + ".1")
+	if err != nil {
+		t.Fatalf(".1 should exist after rotation of too-big file: %v", err)
+	}
+	if info.Size() != 200 {
+		t.Errorf("expected .1 size=200, got %d", info.Size())
+	}
+
+	// Active file should only contain our small write
+	activeInfo, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("active file stat: %v", err)
+	}
+	if activeInfo.Size() != int64(len(payload)) {
+		t.Errorf("expected active size=%d, got %d", len(payload), activeInfo.Size())
+	}
+}
+
+// TestConcurrentWrites: 10 goroutines each writing 100 small lines.
+// Total byte count across active+rotated files must equal total written.
+// Run with -race to catch data races.
+func TestConcurrentWrites(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+
+	// MaxFiles=100 prevents eviction during this stress test so the
+	// "no bytes lost under concurrent rotation" invariant is observable.
+	// MaxSize=1024 still forces ~17 rotations over 18000 bytes of writes —
+	// the concurrency+rotation race is still exercised.
+	w, err := New(Config{Path: path, MaxSize: 1024, MaxFiles: 100})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer w.Close()
+
+	const goroutines = 10
+	const writesPerGoroutine = 100
+	line := []byte("hello world 12345\n") // 18 bytes
+	expectedTotal := int64(goroutines * writesPerGoroutine * len(line))
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < writesPerGoroutine; j++ {
+				if _, err := w.Write(line); err != nil {
+					t.Errorf("concurrent Write: %v", err)
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	// Close to flush
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Count total bytes across all files: active + .1 ... .4
+	var totalBytes int64
+	// Scan all rotated files up to MaxFiles-1. With MaxFiles=100 and ~17
+	// actual rotations, we stop counting when a file doesn't exist.
+	totalBytes = 0
+	for i := 0; i < 100; i++ {
+		var suffix string
+		if i > 0 {
+			suffix = "." + strconv.Itoa(i)
+		}
+		info, err := os.Stat(path + suffix)
+		if err != nil {
+			break
+		}
+		totalBytes += info.Size()
+	}
+
+	if totalBytes != expectedTotal {
+		t.Errorf("byte count mismatch: expected %d, got %d", expectedTotal, totalBytes)
+	}
+}
+
+// TestInvalidConfig: bad configs return errors.
+func TestInvalidConfig(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+
+	if _, err := New(Config{Path: path, MaxSize: 0, MaxFiles: 3}); err == nil {
+		t.Error("expected error for MaxSize=0")
+	}
+	if _, err := New(Config{Path: path, MaxSize: 100, MaxFiles: 0}); err == nil {
+		t.Error("expected error for MaxFiles=0")
+	}
+	if _, err := New(Config{Path: "", MaxSize: 100, MaxFiles: 3}); err == nil {
+		t.Error("expected error for empty Path")
+	}
+}
+
+// TestClose: after Close, Write returns ErrClosed.
+func TestClose(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+
+	w, err := New(Config{Path: path, MaxSize: 1024, MaxFiles: 3})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	_, err = w.Write([]byte("after close"))
+	if err == nil {
+		t.Fatal("expected error after Close, got nil")
+	}
+	if err != ErrClosed {
+		t.Errorf("expected ErrClosed, got: %v", err)
+	}
+}


### PR DESCRIPTION
Implements **runtime log rotation** for `mcp-muxd-debug.log` — F1 portion of engram [#137](engram://mcp-mux#137).

## Problem

User's `mcp-muxd-debug.log` (at `%TEMP%\mcp-muxd-debug.log` on Windows, `/tmp/mcp-muxd-debug.log` on POSIX) grew to **387 MB** during normal operation. Existing rotation at `cmd/mcp-mux/daemon.go` (pre-this-PR) fired **only on daemon startup** — if the daemon lived for days without restart (the common case), the log grew unbounded.

## Solution

New package `muxcore/rotlog` with a size-based rotating `io.Writer`. Wired into `cmd/mcp-mux/daemon.go` via `rotlog.New(Config{...})` replacing the `os.Stat` + `os.Rename` dance at startup.

### Package shape (stdlib-only)

```go
rotlog.New(rotlog.Config{
    Path:     debugLogPath,
    MaxSize:  maxMB * 1024 * 1024,  // default 50 MB
    MaxFiles: maxFiles,              // default 3
})
```

- `sync.Mutex` around `Write`/`Close` — safe for concurrent daemon + reaper + owner writes.
- Tracks `currentSize` in a field, updated post-write — no `Stat()` per Write.
- On overflow: delete the oldest backup (`.MaxFiles-1`), shift newer→older, rename active→`.1`, open fresh active.
- If active file is already >= `MaxSize` at `New`, rotates BEFORE first write (preserves startup-too-big behavior).

### Env overrides

| Var | Default | Purpose |
|---|---|---|
| `MCP_MUX_LOG_MAX_MB` | `50` | Per-file size cap in MB |
| `MCP_MUX_LOG_MAX_FILES` | `3` | Total file count (active + backups) |

Invalid values fall back to defaults with no panic.

## Bug caught during verification

Static analysis (during builder review) caught an off-by-one: original shift loop was going `.MaxFiles-1 → .MaxFiles`, which would create a `MaxFiles+1`'th file. Fixed to delete index `MaxFiles-1` first, then shift from `MaxFiles-2` down to `1`.

## Tests

6 cases in `muxcore/rotlog/rotlog_test.go`, all pass locally:

| Test | Verifies |
|---|---|
| `TestRotatesAtThreshold` | Overflow triggers rotation |
| `TestKeepsFileCountCap` | `.MaxFiles-1` + earlier evicted, total count preserved |
| `TestRotatesOnOpenIfAlreadyTooBig` | Already-oversized file rotates on `New` |
| `TestConcurrentWrites` | 10 goroutines × 100 writes = 18000 bytes retained (no bytes lost under concurrent rotation; MaxFiles=100 so eviction does not mask race) |
| `TestInvalidConfig` | `MaxSize=0`, `MaxFiles=0`, empty `Path` → error |
| `TestClose` | Post-Close `Write` returns `fs.ErrClosed` sentinel |

Local: `go test ./rotlog/... -count=1 -v` → PASS (0.302s). `go vet ./...` clean.

## Scope

- **New**: `muxcore/rotlog/rotlog.go` (171 lines), `muxcore/rotlog/rotlog_test.go` (246 lines after concurrent-test fix).
- **Modified**: `cmd/mcp-mux/daemon.go` — imports `strconv` + `rotlog`; startup `os.Stat/Remove/Rename` block at old lines 60-66 removed; replaced with `rotlog.New(...)` wiring + env var parsing.
- **No new third-party deps** (brief constraint respected).
- **No changes** to shim-side `MCP_MUX_SHIM_LOG` path in `cmd/mcp-mux/main.go` — shim log stays unchanged (out of scope).

## Cross-ref

Engram [mcp-mux#137](engram://mcp-mux#137) tracks F1 (this PR) + F2 (shim reconnect token refresh — spec PR #89, implementation TBD).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **Новые возможности**
  * Добавлена автоматическая ротация файлов журнала во время работы. Размер логов и количество сохраняемых файлов теперь настраиваются переменными окружения `MCP_MUX_LOG_MAX_MB` (по умолчанию 50 МБ) и `MCP_MUX_LOG_MAX_FILES` (по умолчанию 3).

* **Тесты**
  * Добавлена полная тестовая поддержка функциональности ротации логов, включая проверку пороговых значений и многопоточный стресс-тест.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->