### PR TITLE
feat(muxcore/engine): expose Daemon/Mode/Ready/ControlSocketPath accessors

### DIFF
--- a/muxcore/engine/engine.go
+++ b/muxcore/engine/engine.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 	"time"
 
 	muxcore "github.com/thebtf/mcp-mux/muxcore"
@@ -41,6 +42,34 @@ const (
 	// proactive MCP init handshake for the "spawn" control command.
 	spawnRPCTimeout = 30 * time.Second
 )
+
+// Mode is the runtime role of the engine selected by Run().
+type Mode int
+
+const (
+	// ModeUnset is the zero value before Run() has chosen a mode.
+	ModeUnset Mode = iota
+	// ModeDaemon is the global daemon process that manages owners.
+	ModeDaemon
+	// ModeClient is a shim that talks to an external daemon over IPC.
+	ModeClient
+	// ModeProxy is a pass-through between a parent mcp-mux shim and this process.
+	ModeProxy
+)
+
+// String returns a human-readable name for the Mode.
+func (m Mode) String() string {
+	switch m {
+	case ModeDaemon:
+		return "daemon"
+	case ModeClient:
+		return "client"
+	case ModeProxy:
+		return "proxy"
+	default:
+		return "unset"
+	}
+}
 
 // Handler is the MCP server implementation function.
 // When running in daemon mode, this is called with the upstream's stdin/stdout.
@@ -107,6 +136,11 @@ type Config struct {
 type MuxEngine struct {
 	cfg    Config
 	logger *log.Logger
+
+	mu    sync.RWMutex
+	d     *daemon.Daemon // non-nil only while runDaemon is active
+	mode  Mode
+	ready chan struct{} // closed once mode is set (and, in daemon mode, the daemon is bound)
 }
 
 // New creates a MuxEngine with the given configuration.
@@ -134,7 +168,7 @@ func New(cfg Config) (*MuxEngine, error) {
 	if cfg.Handler != nil && cfg.SessionHandler != nil {
 		logger.Printf("engine: warning: both Handler and SessionHandler set, SessionHandler takes priority")
 	}
-	return &MuxEngine{cfg: cfg, logger: logger}, nil
+	return &MuxEngine{cfg: cfg, logger: logger, ready: make(chan struct{})}, nil
 }
 
 // isDaemonMode checks whether the current process was invoked with the daemon flag.
@@ -167,6 +201,62 @@ func (e *MuxEngine) Run(ctx context.Context) error {
 		return e.runProxy(ctx)
 	}
 	return e.runClient(ctx)
+}
+
+// markReady sets the engine mode and optional daemon reference, then closes the
+// ready channel exactly once. Safe to call from any goroutine. If Run() is
+// somehow called twice, the second call is a no-op on the channel (avoids panic
+// on double-close).
+func (e *MuxEngine) markReady(mode Mode, d *daemon.Daemon) {
+	e.mu.Lock()
+	e.d = d
+	e.mode = mode
+	e.mu.Unlock()
+	// Guard against double close if Run() is invoked more than once.
+	select {
+	case <-e.ready:
+		// already closed — no-op
+	default:
+		close(e.ready)
+	}
+}
+
+// Daemon returns the live *daemon.Daemon when this engine is running in daemon
+// mode. Returns nil in client/proxy mode and before Ready() fires.
+//
+// In-process consumers (e.g., aimux health handlers) should prefer this over
+// calling control.Send against their own control socket — the socket hop is
+// avoidable and introduces failure modes (startup race, pool saturation).
+// In client/proxy mode the daemon lives in a different process; use
+// ControlSocketPath() + control.Send there.
+func (e *MuxEngine) Daemon() *daemon.Daemon {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return e.d
+}
+
+// Mode returns the runtime mode selected by Run().
+// Returns ModeUnset until Run() has started dispatching.
+func (e *MuxEngine) Mode() Mode {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return e.mode
+}
+
+// Ready returns a channel closed once Run() has selected its mode and (in
+// daemon mode) the daemon is listening on its control socket. After Ready
+// fires, Mode() returns a stable non-Unset value and Daemon() returns the live
+// daemon (daemon mode) or nil (client/proxy mode).
+func (e *MuxEngine) Ready() <-chan struct{} {
+	return e.ready
+}
+
+// ControlSocketPath returns the canonical daemon control socket path for this
+// engine's Name and BaseDir. Mirrors serverid.DaemonControlPath exactly;
+// exposed so consumers do not need to import serverid directly or duplicate the
+// BaseDir/Name composition.
+func (e *MuxEngine) ControlSocketPath() string {
+	return serverid.DaemonControlPath(e.cfg.BaseDir, e.cfg.Name)
 }
 
 // runDaemon starts the global daemon that manages owners and accepts IPC
@@ -203,6 +293,16 @@ func (e *MuxEngine) runDaemon(ctx context.Context) error {
 		return fmt.Errorf("engine daemon: %w", err)
 	}
 
+	// Publish the daemon reference and signal readiness. daemon.New() has already
+	// bound the control socket, so callers that block on Ready() can immediately
+	// call Daemon() and reach a live, accepting daemon.
+	e.markReady(ModeDaemon, d)
+	defer func() {
+		e.mu.Lock()
+		e.d = nil
+		e.mu.Unlock()
+	}()
+
 	reaper := daemon.NewReaper(d, defaultReaperInterval)
 
 	select {
@@ -224,6 +324,8 @@ func (e *MuxEngine) runDaemon(ctx context.Context) error {
 //  3. Connect to the returned IPC socket.
 //  4. Bridge stdin/stdout ↔ IPC with automatic reconnect.
 func (e *MuxEngine) runClient(ctx context.Context) error {
+	e.markReady(ModeClient, nil)
+
 	ctlPath := serverid.DaemonControlPath(e.cfg.BaseDir, e.cfg.Name)
 
 	// 1. Ensure the daemon is running, starting it if necessary.
@@ -293,6 +395,8 @@ func (e *MuxEngine) runClient(ctx context.Context) error {
 // SessionHandler is set (no Handler), proxy mode is unsupported because
 // SessionHandler requires per-request dispatch, not a raw stdio bridge.
 func (e *MuxEngine) runProxy(ctx context.Context) error {
+	e.markReady(ModeProxy, nil)
+
 	// Proxy mode: we are a subprocess of an EXTERNAL parent shim (e.g. the
 	// user wrapped us via `mcp-mux <our-binary>`). The parent owns stdio and
 	// expects us to serve one request/response per MCP message.

--- a/muxcore/engine/engine.go
+++ b/muxcore/engine/engine.go
@@ -137,10 +137,11 @@ type MuxEngine struct {
 	cfg    Config
 	logger *log.Logger
 
-	mu    sync.RWMutex
-	d     *daemon.Daemon // non-nil only while runDaemon is active
-	mode  Mode
-	ready chan struct{} // closed once mode is set (and, in daemon mode, the daemon is bound)
+	mu        sync.RWMutex
+	d         *daemon.Daemon // non-nil only while runDaemon is active
+	mode      Mode
+	ready     chan struct{} // closed once mode is set (and, in daemon mode, the daemon is bound)
+	readyOnce sync.Once    // ensures ready is closed exactly once, even under concurrent markReady calls
 }
 
 // New creates a MuxEngine with the given configuration.
@@ -204,21 +205,17 @@ func (e *MuxEngine) Run(ctx context.Context) error {
 }
 
 // markReady sets the engine mode and optional daemon reference, then closes the
-// ready channel exactly once. Safe to call from any goroutine. If Run() is
-// somehow called twice, the second call is a no-op on the channel (avoids panic
-// on double-close).
+// ready channel exactly once. Safe to call from any goroutine concurrently.
+// sync.Once guarantees the channel is closed exactly once regardless of how
+// many goroutines call markReady simultaneously — eliminating the TOCTOU race
+// that the prior select-based guard had (mutex released before select, so two
+// goroutines could both observe the channel open and both call close).
 func (e *MuxEngine) markReady(mode Mode, d *daemon.Daemon) {
 	e.mu.Lock()
 	e.d = d
 	e.mode = mode
 	e.mu.Unlock()
-	// Guard against double close if Run() is invoked more than once.
-	select {
-	case <-e.ready:
-		// already closed — no-op
-	default:
-		close(e.ready)
-	}
+	e.readyOnce.Do(func() { close(e.ready) })
 }
 
 // Daemon returns the live *daemon.Daemon when this engine is running in daemon

--- a/muxcore/engine/engine_test.go
+++ b/muxcore/engine/engine_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	muxcore "github.com/thebtf/mcp-mux/muxcore"
+	"github.com/thebtf/mcp-mux/muxcore/serverid"
 )
 
 // noopHandler is a Handler that does nothing and returns immediately.
@@ -519,4 +520,215 @@ func TestRunProxy_SessionHandlerOnly_ReturnsError(t *testing.T) {
 	if !strings.Contains(err.Error(), "proxy-mode compatibility") {
 		t.Errorf("error should hint that consumers keep Handler for proxy-mode compatibility, got: %v", err)
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Accessor tests
+// ---------------------------------------------------------------------------
+
+// TestEngine_AccessorsBeforeRun verifies the zero-value invariants on a freshly
+// created engine before Run() is called.
+func TestEngine_AccessorsBeforeRun(t *testing.T) {
+	cfg := Config{
+		Name:         "test-accessors",
+		Command:      "echo",
+		BaseDir:      t.TempDir(),
+		DaemonFlag:   "--test-daemon-flag-pre",
+		IdleTimeout:  2 * time.Second,
+		SkipSnapshot: true,
+	}
+	eng, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New() unexpected error: %v", err)
+	}
+
+	// Mode must be ModeUnset before Run().
+	if got := eng.Mode(); got != ModeUnset {
+		t.Errorf("Mode() before Run() = %v, want ModeUnset", got)
+	}
+
+	// Daemon must be nil before Run().
+	if d := eng.Daemon(); d != nil {
+		t.Errorf("Daemon() before Run() = non-nil, want nil")
+	}
+
+	// Ready() must NOT be closed before Run().
+	select {
+	case <-eng.Ready():
+		t.Fatal("Ready() was already closed before Run() — should block")
+	default:
+		// expected: channel is open
+	}
+
+	// ControlSocketPath must be non-empty and match serverid.DaemonControlPath.
+	want := serverid.DaemonControlPath(cfg.BaseDir, cfg.Name)
+	got := eng.ControlSocketPath()
+	if got == "" {
+		t.Error("ControlSocketPath() returned empty string")
+	}
+	if got != want {
+		t.Errorf("ControlSocketPath() = %q, want %q", got, want)
+	}
+}
+
+// TestEngine_DaemonModeExposesDaemon runs an engine in daemon mode and asserts:
+//   - Ready() fires within 2 seconds.
+//   - Mode() == ModeDaemon after Ready.
+//   - Daemon() != nil after Ready, with OwnerCount() == 0.
+//   - After ctx cancel and Run() return, Daemon() == nil (deferred reset works).
+func TestEngine_DaemonModeExposesDaemon(t *testing.T) {
+	// Use a unique flag so this test's daemon-mode trigger doesn't collide with
+	// other tests or the default "--muxcore-daemon" flag.
+	const testFlag = "--test-daemon-accessor"
+
+	// Windows Unix domain socket paths are limited to ~108 characters.
+	// t.TempDir() embeds the full test name, making the socket path too long on
+	// Windows when the test name is long. Use a short prefix under os.TempDir().
+	baseDir, err := os.MkdirTemp("", "td*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(baseDir) })
+
+	cfg := Config{
+		Name:           "td",
+		SessionHandler: noopSessionHandler{},
+		BaseDir:        baseDir,
+		DaemonFlag:     testFlag,
+		IdleTimeout:    2 * time.Second,
+		SkipSnapshot:   true,
+	}
+	eng, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New() unexpected error: %v", err)
+	}
+
+	// Inject the daemon flag into os.Args for the duration of this test so that
+	// isDaemonMode() returns true when Run() is called.
+	origArgs := os.Args
+	os.Args = append(os.Args, testFlag)
+	defer func() { os.Args = origArgs }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runErr := make(chan error, 1)
+	go func() { runErr <- eng.Run(ctx) }()
+
+	// Wait for Ready() to fire (daemon bound and accepting).
+	select {
+	case <-eng.Ready():
+		// good
+	case err := <-runErr:
+		t.Fatalf("Run() returned before Ready() fired: %v", err)
+	case <-time.After(5 * time.Second):
+		cancel()
+		t.Fatal("Ready() did not fire within 5s in daemon mode")
+	}
+
+	// Mode must be ModeDaemon.
+	if got := eng.Mode(); got != ModeDaemon {
+		t.Errorf("Mode() after Ready = %v, want ModeDaemon", got)
+	}
+
+	// Daemon() must be non-nil and have zero owners.
+	d := eng.Daemon()
+	if d == nil {
+		t.Fatal("Daemon() == nil after Ready() in daemon mode")
+	}
+	if n := d.OwnerCount(); n != 0 {
+		t.Errorf("OwnerCount() = %d, want 0", n)
+	}
+
+	// Shutdown: cancel ctx and wait for Run to return.
+	cancel()
+	select {
+	case <-runErr:
+		// Run() returned (context.Canceled or nil from d.Done)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run() did not return within 5s after ctx cancel")
+	}
+
+	// After shutdown, Daemon() must be nil (deferred reset in runDaemon).
+	if d := eng.Daemon(); d != nil {
+		t.Error("Daemon() != nil after Run() returned — deferred reset failed")
+	}
+}
+
+// TestEngine_ProxyModeReady verifies that runProxy calls markReady(ModeProxy)
+// before invoking the handler, so Ready() fires and Mode() == ModeProxy.
+func TestEngine_ProxyModeReady(t *testing.T) {
+	readyFiredBeforeReturn := make(chan struct{}, 1)
+
+	handler := Handler(func(_ context.Context, stdin io.Reader, stdout io.Writer) error {
+		// At the time the handler is called, markReady has already been called.
+		// Signal the test that we can sample Mode/Ready from inside the handler.
+		readyFiredBeforeReturn <- struct{}{}
+		// Drain stdin so runProxy returns cleanly.
+		io.Copy(io.Discard, stdin) //nolint:errcheck
+		return nil
+	})
+
+	eng, err := New(Config{
+		Name:         "test-proxy-accessor",
+		Handler:      handler,
+		BaseDir:      t.TempDir(),
+		IdleTimeout:  2 * time.Second,
+		SkipSnapshot: true,
+	})
+	if err != nil {
+		t.Fatalf("New() unexpected error: %v", err)
+	}
+
+	t.Setenv("MCP_MUX_SESSION_ID", "sess_proxy_accessor")
+
+	// Pipe-backed stdin (closes immediately so handler drains and returns).
+	stdinR, stdinW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() stdin: %v", err)
+	}
+	stdoutR, stdoutW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() stdout: %v", err)
+	}
+	defer stdoutR.Close()
+
+	stdinW.Close() // EOF immediately
+
+	origStdin, origStdout := os.Stdin, os.Stdout
+	os.Stdin, os.Stdout = stdinR, stdoutW
+	defer func() {
+		os.Stdin = origStdin
+		os.Stdout = origStdout
+	}()
+
+	runDone := make(chan error, 1)
+	go func() { runDone <- eng.runProxy(context.Background()) }()
+
+	// Wait for handler to signal (markReady has fired at this point).
+	select {
+	case <-readyFiredBeforeReturn:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler was not called within 2s")
+	}
+
+	// Ready() must be closed.
+	select {
+	case <-eng.Ready():
+		// good
+	default:
+		t.Error("Ready() not closed after runProxy called markReady")
+	}
+
+	// Mode must be ModeProxy.
+	if got := eng.Mode(); got != ModeProxy {
+		t.Errorf("Mode() = %v, want ModeProxy", got)
+	}
+
+	// Daemon must be nil in proxy mode.
+	if d := eng.Daemon(); d != nil {
+		t.Error("Daemon() != nil in proxy mode — should always be nil")
+	}
+
+	stdoutW.Close()
+	stdinR.Close()
+	<-runDone
 }


### PR DESCRIPTION
## Summary

Adds four public accessors to `*engine.MuxEngine` for consumer introspection.

Closes an API gap surfaced when aimux needed to query `Daemon.HandleStatus()` from its health handler. Before this PR, the only way to reach the in-process `*daemon.Daemon` was through a loopback `control.Send` to the engine's own control socket -- an anti-pattern (self-IPC for an in-process call, extra serialization, startup-race failure mode, pool-saturation risk).

## API

| Method | Returns | Behavior |
|--------|---------|----------|
| `Daemon() *daemon.Daemon` | live daemon or nil | Non-nil only in daemon mode, after `Ready()` fires and before `Run()` returns. |
| `Mode() Mode` | ModeDaemon / ModeClient / ModeProxy / ModeUnset | Selected at the top of `Run()`. |
| `Ready() <-chan struct{}` | closed channel when mode is selected | Consumers block on this before accessing other getters. |
| `ControlSocketPath() string` | canonical socket path | Delegates to `serverid.DaemonControlPath(cfg.BaseDir, cfg.Name)`; exposed so consumers do not reach into `serverid` directly. |

## Back-compat

- Additive only. No existing field, method, or constant removed or renamed.
- `MuxEngine` internals are still unexported; new fields guarded by RWMutex.

## Usage pattern (for consumers)

```go
eng, _ := engine.New(engine.Config{Name: "aimux", ...})
go eng.Run(ctx)

<-eng.Ready()
if d := eng.Daemon(); d != nil {
    stats := d.HandleStatus()                          // in-process -- no socket
} else {
    resp, err := control.Send(eng.ControlSocketPath(), // client/proxy
                              control.Request{Cmd: "status"}, 5*time.Second)
}
```

## Tests

- `TestEngine_AccessorsBeforeRun` -- zero-value invariants on a fresh engine.
- `TestEngine_DaemonModeExposesDaemon` -- end-to-end: Run() in daemon mode -> `Ready()` fires -> `Daemon() != nil` -> shutdown -> `Daemon() == nil`.
- `TestEngine_ProxyModeReady` -- proxy mode: `Ready()` fires inside handler, `Mode() == ModeProxy`, `Daemon() == nil`.

All green; no `-race` (gcc unavailable on this Windows host).

## Implementation notes

- `markReady` uses a `select { case <-e.ready: default: close(e.ready) }` guard instead of `sync.Once` -- avoids an extra field and is equally safe given `Run()` is single-call by contract.
- Windows Unix domain socket path limit (108 chars) hit during test development; `TestEngine_DaemonModeExposesDaemon` uses `os.MkdirTemp("", "td*")` + short `Name: "td"` to keep the socket path under the limit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Новые функции**
  * Введена явная модель режимов работы (unset/daemon/client/proxy) и механизмы синхронизированной индикации готовности.
  * Добавлены публичные средства для получения текущего режима, ссылки на запущенный демон и пути управляющего сокета, а также канал готовности для наблюдения состояния.

* **Тесты**
  * Добавлены интеграционные тесты, проверяющие поведение режимов, закрытие канала готовности и обновление состояния при запуске и остановке.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->