### PR TITLE
refactor(owner): inject UpstreamWriter for pure-method tests (engram #145)

### DIFF
--- a/muxcore/owner/coverage_test.go
+++ b/muxcore/owner/coverage_test.go
@@ -699,120 +699,181 @@ func TestRunClient_DialFailure(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// respondToRootsList — triggered via roots/list request from upstream
-// (need a mock upstream that sends roots/list)
-// We call the method directly as it's on an owner with a fake upstream pipe.
+// respondToRootsList — pure JSON-building method tests via writer injection.
+// No subprocess spawned: UpstreamWriter captures output into a bytes.Buffer.
+// This eliminates the "go run mock_server.go" subprocess-timing flake class
+// (NewOwner used to return before `go run` had attached stdin, causing the
+// first writeUpstream to race the compile with "file already closed").
 // ---------------------------------------------------------------------------
 
 func TestRespondToRootsList_WithCwd(t *testing.T) {
 	ipcPath := testIPCPath(t)
 	cwd := t.TempDir()
 
+	var buf bytes.Buffer
 	owner, err := NewOwner(OwnerConfig{
-		Command: "go",
-		Args:    []string{"run", "../../testdata/mock_server.go"},
-		IPCPath: ipcPath,
-		Cwd:     cwd,
-		Logger:  testLogger(t),
+		UpstreamWriter: &buf,
+		IPCPath:        ipcPath,
+		Cwd:            cwd,
+		Logger:         testLogger(t),
 	})
 	if err != nil {
-		t.Fatalf("NewOwner() error: %v", err)
+		t.Fatalf("NewOwner: %v", err)
 	}
 	defer owner.Shutdown()
 
-	// Call respondToRootsList directly
 	id := json.RawMessage(`1`)
-	// Retry briefly: on macOS `go run mock_server.go` may still be compiling
-	// when NewOwner returns, so upstream stdin can race as "file already closed".
-	// Probing via respondToRootsList is idempotent — it builds JSON and writes to upstream.
-	deadline := time.Now().Add(1 * time.Second)
-	var lastErr error
-	for time.Now().Before(deadline) {
-		lastErr = owner.respondToRootsList(id)
-		if lastErr == nil {
-			break
-		}
-		time.Sleep(25 * time.Millisecond)
+	if err := owner.respondToRootsList(id); err != nil {
+		t.Fatalf("respondToRootsList: %v", err)
 	}
-	if lastErr != nil {
-		t.Errorf("respondToRootsList (after readiness retries): %v", lastErr)
+
+	var parsed struct {
+		JSONRPC string          `json:"jsonrpc"`
+		ID      json.RawMessage `json:"id"`
+		Result  struct {
+			Roots []struct {
+				URI  string `json:"uri"`
+				Name string `json:"name,omitempty"`
+			} `json:"roots"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &parsed); err != nil {
+		t.Fatalf("malformed JSON: %v\npayload: %s", err, buf.String())
+	}
+	if parsed.JSONRPC != "2.0" {
+		t.Errorf("jsonrpc=%q, want 2.0", parsed.JSONRPC)
+	}
+	if len(parsed.Result.Roots) == 0 {
+		t.Fatalf("no roots in response")
+	}
+	if parsed.Result.Roots[0].URI == "" {
+		t.Errorf("empty URI in first root entry")
 	}
 }
 
 func TestRespondToRootsList_EmptyCwd(t *testing.T) {
 	ipcPath := testIPCPath(t)
 
+	var buf bytes.Buffer
 	owner, err := NewOwner(OwnerConfig{
-		Command: "go",
-		Args:    []string{"run", "../../testdata/mock_server.go"},
-		IPCPath: ipcPath,
-		Cwd:     "", // empty — should use os.Getwd()
-		Logger:  testLogger(t),
+		UpstreamWriter: &buf,
+		IPCPath:        ipcPath,
+		Cwd:            "", // empty — respondToRootsList falls back to os.Getwd()
+		Logger:         testLogger(t),
 	})
 	if err != nil {
-		t.Fatalf("NewOwner() error: %v", err)
+		t.Fatalf("NewOwner: %v", err)
 	}
 	defer owner.Shutdown()
 
 	id := json.RawMessage(`2`)
-	// Retry briefly: on macOS `go run mock_server.go` may still be compiling
-	// when NewOwner returns, so upstream stdin can race as "file already closed".
-	// Probing via respondToRootsList is idempotent — it builds JSON and writes to upstream.
-	deadline := time.Now().Add(1 * time.Second)
-	var lastErr error
-	for time.Now().Before(deadline) {
-		lastErr = owner.respondToRootsList(id)
-		if lastErr == nil {
-			break
-		}
-		time.Sleep(25 * time.Millisecond)
+	if err := owner.respondToRootsList(id); err != nil {
+		t.Fatalf("respondToRootsList (empty cwd): %v", err)
 	}
-	if lastErr != nil {
-		t.Errorf("respondToRootsList (empty cwd) (after readiness retries): %v", lastErr)
+
+	var parsed struct {
+		JSONRPC string          `json:"jsonrpc"`
+		ID      json.RawMessage `json:"id"`
+		Result  struct {
+			Roots []struct {
+				URI  string `json:"uri"`
+				Name string `json:"name,omitempty"`
+			} `json:"roots"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &parsed); err != nil {
+		t.Fatalf("malformed JSON: %v\npayload: %s", err, buf.String())
+	}
+	if parsed.JSONRPC != "2.0" {
+		t.Errorf("jsonrpc=%q, want 2.0", parsed.JSONRPC)
+	}
+	if len(parsed.Result.Roots) == 0 {
+		t.Fatalf("no roots in response (empty-cwd fallback to os.Getwd() should produce one)")
+	}
+	if parsed.Result.Roots[0].URI == "" {
+		t.Errorf("empty URI in first root entry")
 	}
 }
 
 // ---------------------------------------------------------------------------
-// respondWithError and respondToElicitationCancel — call directly
+// respondWithError and respondToElicitationCancel — writer-injection path.
 // ---------------------------------------------------------------------------
 
 func TestRespondWithError(t *testing.T) {
 	ipcPath := testIPCPath(t)
 
+	var buf bytes.Buffer
 	owner, err := NewOwner(OwnerConfig{
-		Command: "go",
-		Args:    []string{"run", "../../testdata/mock_server.go"},
-		IPCPath: ipcPath,
-		Logger:  testLogger(t),
+		UpstreamWriter: &buf,
+		IPCPath:        ipcPath,
+		Logger:         testLogger(t),
 	})
 	if err != nil {
-		t.Fatalf("NewOwner() error: %v", err)
+		t.Fatalf("NewOwner: %v", err)
 	}
 	defer owner.Shutdown()
 
 	id := json.RawMessage(`5`)
 	if err := owner.respondWithError(id, -32603, "test error"); err != nil {
-		t.Errorf("respondWithError: %v", err)
+		t.Fatalf("respondWithError: %v", err)
+	}
+
+	var parsed struct {
+		JSONRPC string          `json:"jsonrpc"`
+		ID      json.RawMessage `json:"id"`
+		Error   struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &parsed); err != nil {
+		t.Fatalf("malformed JSON: %v\npayload: %s", err, buf.String())
+	}
+	if parsed.JSONRPC != "2.0" {
+		t.Errorf("jsonrpc=%q, want 2.0", parsed.JSONRPC)
+	}
+	if parsed.Error.Code != -32603 {
+		t.Errorf("error.code=%d, want -32603", parsed.Error.Code)
+	}
+	if parsed.Error.Message != "test error" {
+		t.Errorf("error.message=%q, want %q", parsed.Error.Message, "test error")
 	}
 }
 
 func TestRespondToElicitationCancel(t *testing.T) {
 	ipcPath := testIPCPath(t)
 
+	var buf bytes.Buffer
 	owner, err := NewOwner(OwnerConfig{
-		Command: "go",
-		Args:    []string{"run", "../../testdata/mock_server.go"},
-		IPCPath: ipcPath,
-		Logger:  testLogger(t),
+		UpstreamWriter: &buf,
+		IPCPath:        ipcPath,
+		Logger:         testLogger(t),
 	})
 	if err != nil {
-		t.Fatalf("NewOwner() error: %v", err)
+		t.Fatalf("NewOwner: %v", err)
 	}
 	defer owner.Shutdown()
 
 	id := json.RawMessage(`6`)
 	if err := owner.respondToElicitationCancel(id); err != nil {
-		t.Errorf("respondToElicitationCancel: %v", err)
+		t.Fatalf("respondToElicitationCancel: %v", err)
+	}
+
+	var parsed struct {
+		JSONRPC string          `json:"jsonrpc"`
+		ID      json.RawMessage `json:"id"`
+		Result  struct {
+			Action string `json:"action"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &parsed); err != nil {
+		t.Fatalf("malformed JSON: %v\npayload: %s", err, buf.String())
+	}
+	if parsed.JSONRPC != "2.0" {
+		t.Errorf("jsonrpc=%q, want 2.0", parsed.JSONRPC)
+	}
+	if parsed.Result.Action != "cancel" {
+		t.Errorf("result.action=%q, want %q", parsed.Result.Action, "cancel")
 	}
 }
 

--- a/muxcore/owner/owner.go
+++ b/muxcore/owner/owner.go
@@ -101,6 +101,7 @@ type Owner struct {
 	env            map[string]string                                                  // upstream env captured at spawn (for background respawn)
 	handlerFunc    func(ctx context.Context, stdin io.Reader, stdout io.Writer) error // in-process MCP handler (nil = subprocess)
 	sessionHandler muxcore.SessionHandler                                             // structured in-process handler (nil = pipe or subprocess)
+	upstreamWriter io.Writer                                                          // injected writer (non-nil = skip subprocess, write directly; tests only)
 	serverID       string                                                             // server identity hash
 	listener       net.Listener
 	logger         *log.Logger
@@ -219,6 +220,17 @@ type OwnerConfig struct {
 	// instead of routing through a pipe or subprocess.
 	// Mutually exclusive with HandlerFunc and Command/Args.
 	SessionHandler muxcore.SessionHandler
+
+	// UpstreamWriter, when non-nil, overrides the subprocess upstream.
+	// NewOwner will skip spawning Command and writeUpstream will route bytes
+	// into this writer instead. Intended for tests that exercise pure
+	// JSON-building methods (e.g. respondToRootsList) without the
+	// subprocess-timing flake class introduced by "go run mock_server.go".
+	//
+	// Zero value (nil) preserves the normal subprocess-upstream path used by
+	// production and by integration tests that need a real upstream lifecycle
+	// (crash loop, reap, snapshot reattach).
+	UpstreamWriter io.Writer
 
 	// CachedClassification, if non-empty, skips the upstream classification
 	// round-trip. Used by NewOwnerFromHandoff when restoring from daemon
@@ -469,9 +481,15 @@ func NewOwner(cfg OwnerConfig) (*Owner, error) {
 		logger = log.Default()
 	}
 
-	// Spawn upstream — either in-process handler, subprocess, or neither (SessionHandler-only).
+	// Spawn upstream — either in-process handler, subprocess, injected writer, or neither (SessionHandler-only).
 	var proc *upstream.Process
-	if cfg.SessionHandler != nil && cfg.HandlerFunc == nil {
+	if cfg.UpstreamWriter != nil {
+		// Writer-injection mode: skip subprocess spawn entirely.
+		// writeUpstream routes bytes directly into the caller's writer.
+		// Intended for tests that exercise pure JSON-building methods without
+		// the subprocess-timing flake class. No upstream process, no exit event.
+		logger.Printf("owner: writer-injection mode (no subprocess)")
+	} else if cfg.SessionHandler != nil && cfg.HandlerFunc == nil {
 		// SessionHandler-only: no upstream process needed.
 		// Requests dispatch directly via dispatchToSessionHandler.
 		logger.Printf("owner: SessionHandler-only mode (no upstream process)")
@@ -505,6 +523,7 @@ func NewOwner(cfg OwnerConfig) (*Owner, error) {
 		env:                    cfg.Env,
 		handlerFunc:            cfg.HandlerFunc,
 		sessionHandler:         cfg.SessionHandler,
+		upstreamWriter:         cfg.UpstreamWriter,
 		serverID:               cfg.ServerID,
 		listener:               ln,
 		logger:                 logger,
@@ -2276,8 +2295,21 @@ func (o *Owner) touchActivity() {
 // SessionHandler-only owners never call writeUpstream — requests dispatch
 // directly via dispatchToSessionHandler, and notification forwarding
 // returns early when o.upstream == nil.
+//
+// Writer-injection mode (upstreamWriter != nil): bytes are written directly
+// to the injected writer followed by a newline, mirroring upstream.WriteLine
+// semantics. Used by tests to capture output without a subprocess.
 func (o *Owner) writeUpstream(data []byte) error {
 	o.touchActivity()
+	if o.upstreamWriter != nil {
+		if _, err := o.upstreamWriter.Write(data); err != nil {
+			return fmt.Errorf("upstream writer: write: %w", err)
+		}
+		if _, err := o.upstreamWriter.Write([]byte("\n")); err != nil {
+			return fmt.Errorf("upstream writer: write newline: %w", err)
+		}
+		return nil
+	}
 	return o.upstream.WriteLine(data)
 }
 


### PR DESCRIPTION
## Summary

Architectural fix for engram #145 — replaces the `go run mock_server.go` subprocess in tests that only exercise pure JSON-building methods with writer-injection.

### Problem

`muxcore/owner/coverage_test.go` tests that wanted to assert `respondToRootsList`, `respondToElicitationCancel`, etc. spawned a real subprocess via `go run ../../testdata/mock_server.go`. On macOS and Windows the `go run` parent returns to the caller BEFORE compilation + subprocess spawn completes, so the first `writeUpstream` call raced the pipe setup with `"file already closed"`. Flake class, not just one test — it's structural coupling of pure-logic tests to subprocess timing.

Previous workaround: commit `906875c` added a 1-second readiness-retry wrapper in two tests. Masks the race, doesn't fix it.

### Fix

- `OwnerConfig.UpstreamWriter io.Writer` — when non-nil, `NewOwner` skips the subprocess spawn and `writeUpstream` routes bytes directly into the injected writer. Zero value preserves existing behaviour.
- Migrated pure-method tests to `&bytes.Buffer{}` upstream. Each now asserts emitted JSON structure, not just no-error.
- Removed the 1s retry loop from `TestRespondToRootsList_WithCwd` / `_EmptyCwd` — no longer needed.

### Not migrated

Tests that legitimately need a real subprocess stay on the spawn path:
- Crash circuit breaker
- Reap-after-exit
- Snapshot reattach

### Verification

- `go test -count=10 ./muxcore/owner/` green — 10x stress on the migrated tests with no flake.
- `go test -count=1 ./...` green — no regression in other packages.

### Back-compat

Additive API. Zero behaviour change when `UpstreamWriter` is nil (production, integration tests).

### Closes

engram://mcp-mux#145

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **Tests**
  * Переработаны и оптимизированы процессы тестирования ключевых компонентов для повышения надежности проверок.

* **Refactor**
  * Улучшена архитектура внутренних компонентов системы для повышения гибкости и качества кода.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->