### PR TITLE
fix(upgrade,ipc): prevent split-state during upgrade --restart

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,6 +207,18 @@ Key changes:
 
 - Adds read-only accessors to the `engine.Engine` type for observability and testing: `OwnerCount()`, `SessionCount()`, `HandleStatus()`, and `Entry(serverID)`. No breaking changes; all additive.
 
+### v0.21.4 — Defensive ipc.Listen + upgrade --restart split-state fix
+
+- **`ipc.Listen` now refuses to rebind an actively-served path.** Before removing the stale socket file and calling `sockperm.Listen`, `Listen` calls `IsAvailable`. If a live listener is detected, it returns `"ipc: listener already active at <path> (another process is serving)"`. Callers that previously relied on silent socket-steal semantics will now receive a loud error instead. This is a breaking behavioural change, but such reliance was always a bug — a second `Listen` on an active path would have silently disconnected all existing clients. The guard turns that into a diagnosable failure; the caller (snapshot restore, owner startup) can log and skip the conflicting owner rather than corrupting it.
+
+- **`upgrade --restart` fallback-shutdown branch now waits for old daemon exit.** Before spawning the new daemon, `runUpgrade` mirrors the graceful-restart branch's 20×500 ms `isDaemonRunning` poll into both fallback sub-branches (`graceful-restart not available` and `graceful-restart failed`). Prevents the race where the new daemon rebinds per-owner sockets via `ipc.Listen` while the old daemon's Owner structs and `sessionMgr` are still live, causing shim handshake tokens registered in the new daemon to be routed to the old daemon's accept loop and rejected.
+
+- **No API changes.** Both fixes are additive or strictly defensive. `ipc.Listen` signature is unchanged; callers that passed a stale-file path continue to work. The poll loop in `runUpgrade` is internal to the binary.
+
+- **Bundled release:** muxcore/v0.21.4 + v0.21.4 binary.
+
+- **Investigation:** `.agent/debug/upgrade-restart-split-state/investigation.md`
+
 ### v0.21.3 — OwnerConfig.UpstreamWriter (proposed in PR #93)
 
 - `owner.OwnerConfig.UpstreamWriter io.Writer` — optional field that, when set, replaces the default subprocess stdout pipe with a caller-supplied writer. Enables in-process upstream implementations that do not want to go through a subprocess. PR #93 is open at time of writing; adopt after merge.

--- a/cmd/mcp-mux/main.go
+++ b/cmd/mcp-mux/main.go
@@ -559,44 +559,13 @@ func runUpgrade(restart bool) {
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "  warning: shutdown failed: %v\n", err)
 			}
-			fmt.Fprintf(os.Stderr, "  Waiting for old daemon to exit...")
-			for i := 0; i < 20; i++ {
-				time.Sleep(500 * time.Millisecond)
-				if !isDaemonRunning(ctlPath) {
-					fmt.Fprintln(os.Stderr, " done.")
-					break
-				}
-				if i == 19 {
-					fmt.Fprintln(os.Stderr, " timeout (daemon may still be shutting down).")
-				}
-			}
+			waitForDaemonExit(ctlPath, "  Waiting for old daemon to exit...")
 		} else if !resp.OK {
 			fmt.Fprintf(os.Stderr, "  graceful-restart failed: %s, falling back to shutdown\n", resp.Message)
 			control.Send(ctlPath, control.Request{Cmd: "shutdown"})
-			fmt.Fprintf(os.Stderr, "  Waiting for old daemon to exit...")
-			for i := 0; i < 20; i++ {
-				time.Sleep(500 * time.Millisecond)
-				if !isDaemonRunning(ctlPath) {
-					fmt.Fprintln(os.Stderr, " done.")
-					break
-				}
-				if i == 19 {
-					fmt.Fprintln(os.Stderr, " timeout (daemon may still be shutting down).")
-				}
-			}
+			waitForDaemonExit(ctlPath, "  Waiting for old daemon to exit...")
 		} else {
-			fmt.Fprintf(os.Stderr, "  snapshot written. Waiting for daemon to exit...")
-			// Poll until old daemon is fully dead.
-			for i := 0; i < 20; i++ {
-				time.Sleep(500 * time.Millisecond)
-				if !isDaemonRunning(ctlPath) {
-					fmt.Fprintln(os.Stderr, " done.")
-					break
-				}
-				if i == 19 {
-					fmt.Fprintln(os.Stderr, " timeout (daemon may still be shutting down).")
-				}
-			}
+			waitForDaemonExit(ctlPath, "  snapshot written. Waiting for daemon to exit...")
 		}
 
 		// Clean up stale daemon control socket — old daemon may not have removed it.
@@ -630,6 +599,21 @@ func runUpgrade(restart bool) {
 	} else {
 		fmt.Fprintln(os.Stderr, "Daemon will start with new code on next tool call.")
 	}
+}
+
+// waitForDaemonExit polls isDaemonRunning until it returns false or 10s elapse.
+// Prints prefix on entry, " done." on success, " timeout (...)" on timeout.
+// Checks before sleeping, so a daemon that already exited returns immediately.
+func waitForDaemonExit(ctlPath, prefix string) {
+	fmt.Fprint(os.Stderr, prefix)
+	for i := 0; i < 20; i++ {
+		if !isDaemonRunning(ctlPath) {
+			fmt.Fprintln(os.Stderr, " done.")
+			return
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	fmt.Fprintln(os.Stderr, " timeout (daemon may still be shutting down).")
 }
 
 // collectEnv returns the current process environment as a map.

--- a/cmd/mcp-mux/main.go
+++ b/cmd/mcp-mux/main.go
@@ -559,9 +559,31 @@ func runUpgrade(restart bool) {
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "  warning: shutdown failed: %v\n", err)
 			}
+			fmt.Fprintf(os.Stderr, "  Waiting for old daemon to exit...")
+			for i := 0; i < 20; i++ {
+				time.Sleep(500 * time.Millisecond)
+				if !isDaemonRunning(ctlPath) {
+					fmt.Fprintln(os.Stderr, " done.")
+					break
+				}
+				if i == 19 {
+					fmt.Fprintln(os.Stderr, " timeout (daemon may still be shutting down).")
+				}
+			}
 		} else if !resp.OK {
 			fmt.Fprintf(os.Stderr, "  graceful-restart failed: %s, falling back to shutdown\n", resp.Message)
 			control.Send(ctlPath, control.Request{Cmd: "shutdown"})
+			fmt.Fprintf(os.Stderr, "  Waiting for old daemon to exit...")
+			for i := 0; i < 20; i++ {
+				time.Sleep(500 * time.Millisecond)
+				if !isDaemonRunning(ctlPath) {
+					fmt.Fprintln(os.Stderr, " done.")
+					break
+				}
+				if i == 19 {
+					fmt.Fprintln(os.Stderr, " timeout (daemon may still be shutting down).")
+				}
+			}
 		} else {
 			fmt.Fprintf(os.Stderr, "  snapshot written. Waiting for daemon to exit...")
 			// Poll until old daemon is fully dead.

--- a/muxcore/ipc/ipc_test.go
+++ b/muxcore/ipc/ipc_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -225,3 +226,60 @@ func TestMultipleClients(t *testing.T) {
 func createFile(path string) (*os.File, error) {
 	return os.Create(path)
 }
+
+func TestListen_RefusesWhenAlreadyActive(t *testing.T) {
+	path := socketPath(t)
+
+	// First Listen — must succeed.
+	ln1, err := Listen(path)
+	if err != nil {
+		t.Fatalf("first Listen() error: %v", err)
+	}
+	defer ln1.Close()
+
+	// Accept connections so IsAvailable's Dial can complete the handshake.
+	go func() {
+		for {
+			conn, err := ln1.Accept()
+			if err != nil {
+				return
+			}
+			conn.Close()
+		}
+	}()
+
+	// Second Listen on the same active path — must fail.
+	ln2, err := Listen(path)
+	if err == nil {
+		ln2.Close()
+		t.Fatal("second Listen() expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "listener already active") {
+		t.Errorf("expected 'listener already active' in error, got: %v", err)
+	}
+
+	// First listener must still work after the refused second attempt.
+	conn, err := Dial(path)
+	if err != nil {
+		t.Fatalf("Dial() after refused second Listen() error: %v", err)
+	}
+	conn.Close()
+}
+
+func TestListen_SucceedsOnStalePath(t *testing.T) {
+	path := socketPath(t)
+
+	// Write a stale file at path (nothing is listening on it).
+	if err := os.WriteFile(path, []byte{}, 0600); err != nil {
+		t.Fatalf("WriteFile stale: %v", err)
+	}
+
+	// Listen must succeed: IsAvailable returns false (nothing to connect to),
+	// then Remove strips the stale file, then the real listener binds.
+	ln, err := Listen(path)
+	if err != nil {
+		t.Fatalf("Listen() on stale path error: %v", err)
+	}
+	ln.Close()
+}
+

--- a/muxcore/ipc/transport.go
+++ b/muxcore/ipc/transport.go
@@ -18,7 +18,12 @@ const dialTimeout = 500 * time.Millisecond
 
 // Listen creates an IPC listener at the given path.
 // Any stale socket file is removed before listening.
+// Returns an error if another process is actively serving on path.
 func Listen(path string) (net.Listener, error) {
+	if IsAvailable(path) {
+		return nil, fmt.Errorf("ipc: listener already active at %s (another process is serving)", path)
+	}
+
 	// Remove stale socket file if it exists
 	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 		return nil, fmt.Errorf("ipc: remove stale socket %s: %w", path, err)


### PR DESCRIPTION
## Summary

Two-layer fix for the `upgrade --restart` split-state bug. Investigation: [.agent/debug/upgrade-restart-split-state/investigation.md](../blob/worktree-fix-upgrade-restart-split-state/.agent/debug/upgrade-restart-split-state/investigation.md) (local to reporter).

## Symptom

After `mcp-mux upgrade --restart`:
- `graceful-restart not available: i/o timeout, falling back to shutdown` → `Starting new daemon... New daemon ready.`
- `/mcp reconnect` fails for multiple MCP servers (`time`, `pr`, …)
- `mux_list` shows mixed `mux_version` — some owners on pre-upgrade build, some on post-upgrade
- Daemon log bursts: `accept: rejected connection from pid=-1 (invalid/missing token)`

## Root Cause

`runUpgrade` fallback-shutdown branch (`cmd/mcp-mux/main.go:558-578`) sent `control.Send(shutdown)` and **immediately** called `startDaemonProcess` — no `isDaemonRunning` poll. The graceful-restart happy path already had this poll at lines 566-577 but the fallback branches didn't.

Under Windows (and any platform where `HandleShutdown` returns RPC OK while async drain stalls), the old daemon stayed alive during new daemon startup. The new daemon ran `loadSnapshot` → `NewOwnerFromSnapshot` → `ipc.Listen(cfg.IPCPath)`. `ipc.Listen` unconditionally did `os.Remove(path)` + `net.Listen`, silently stripping the socket path from the still-live old process.

Result: split-state where
- New daemon owns `mcp-muxd.ctl.sock` and per-owner socket names
- Old daemon still runs with its in-memory Owner structs + fresh `sessionMgr`
- Shim → spawn RPC → new daemon registers token → receives `ipcPath` → dials → but old daemon's kernel-level accept loop is still alive on the original fd → old `sessionMgr.IsPreRegistered(token)` = false → reject

Hypothesis H5 was confirmed via `mux_restart <stale_server_id>`: replacing a stale owner with a fresh one in the new daemon recovered 4 CC sessions instantly, matching the prediction exactly.

## Fix — Layer 1: Binary (`cmd/mcp-mux/main.go`)

Mirror the graceful-restart 20×500ms `isDaemonRunning` poll into both fallback sub-branches:
- `if err != nil` (`graceful-restart not available`)
- `else if !resp.OK` (`graceful-restart failed`)

Output prefix: `"  Waiting for old daemon to exit..."`. Timeout prints `" timeout (daemon may still be shutting down)."` but does NOT abort — the stale-socket cleanup at line 581 already handles leftover state.

## Fix — Layer 2: muxcore (`muxcore/ipc/transport.go`)

Added `IsAvailable` guard at the top of `Listen()`:

```go
func Listen(path string) (net.Listener, error) {
    if IsAvailable(path) {
        return nil, fmt.Errorf("ipc: listener already active at %s (another process is serving)", path)
    }
    // existing Remove + sockperm.Listen unchanged
}
```

Defense-in-depth. Turns silent socket-steal into a loud error that `snapshot.go:231-233` already handles via `continue` + log. Catches races with any future split-state bug, not just this one.

**Trade-off:** one `Dial` probe per `Listen` (500ms max timeout). Normal case — nothing listening — fails fast (ECONNREFUSED / ENOENT, microseconds). Only worst-case when a competing listener actually responds.

**Breaking behavioural change** — callers that relied on silent socket-steal semantics will now receive an error. But such reliance was always a latent bug (a second `Listen` on an active path would have disconnected all existing clients).

## Regression tests

`muxcore/ipc/ipc_test.go`:
- `TestListen_RefusesWhenAlreadyActive` — second `Listen` on active path returns "listener already active" error; first listener still works after refusal
- `TestListen_SucceedsOnStalePath` — stale file (no listener) → `Listen` removes it and binds successfully

Binary-layer unit test skipped: `runUpgrade` calls `os.Exit`, making unit testing impractical without invasive refactoring. The muxcore IsAvailable guard provides the same defense-in-depth coverage.

## Validation

- `go build ./...` — clean
- `go build -o mcp-mux.exe ./cmd/mcp-mux` — clean
- `go vet ./...` — clean
- `go test ./...` + muxcore `go test ./...` — all green (muxcore including `ipc`, `daemon`, `owner`, `engine`, `upgrade`)

## Versioning

Per user rule "muxcore и mcp-mux versions must be synchronized":
- `muxcore/v0.21.4` — library release with `ipc.Listen` guard
- `v0.21.4` — binary release with `runUpgrade` fallback poll (catches up from `v0.21.1`)

Bundled. Both tagged post-merge.

## Files changed

- `cmd/mcp-mux/main.go` (+22 / −0)
- `muxcore/ipc/transport.go` (+5 / −0)
- `muxcore/ipc/ipc_test.go` (+58 / −0, one new import)
- `AGENTS.md` (+12 / −0, v0.21.4 release notes)

## Related

- Resolves the split-state symptom observed 2026-04-20 on workstation
- Does NOT address the upstream question "why did graceful-restart i/o timeout in the first place?" — tracked as separate follow-up (Fix Option C from investigation)
- Previous release: [v0.21.3 muxcore](https://github.com/thebtf/mcp-mux/releases/tag/muxcore/v0.21.3) / [v0.21.1 binary](https://github.com/thebtf/mcp-mux/releases/tag/v0.21.1)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Примечания к выпуску

* **Исправления ошибок**
  * Явно предотвращено перехватывание уже обслуживаемых сокетов с понятным сообщением об ошибке.
  * Перезапуск демона теперь ждёт завершения старого процесса перед запуском нового, уменьшая гонки состояний.

* **Тесты**
  * Добавлены тесты для сценариев повторной привязки к сокету и обработки устаревших файлов сокета.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->