### PR TITLE
feat(engine): expose StdinEOFPolicy + upgrade identity guard (#157)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ dist/
 *.exe.old.*
 coverage.out
 coverage.html
+.gomodcache/
 .agent/*
 !.agent/specs
 !.agent/arch

--- a/cmd/mcp-mux/main.go
+++ b/cmd/mcp-mux/main.go
@@ -18,6 +18,7 @@
 package main
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -501,6 +502,18 @@ func runUpgrade(restart bool) {
 		os.Exit(1)
 	}
 
+	// Guard: verify staged binary differs from current to prevent no-op upgrades.
+	// go build -o mcp-mux.exe silently fails when the daemon holds the file lock,
+	// leaving the staged binary identical to the running one.
+	if sameFile(exe, pendingPath) {
+		fmt.Fprintln(os.Stderr, "error: staged binary is identical to current binary (no-op upgrade).")
+		fmt.Fprintln(os.Stderr, "This usually means `go build -o mcp-mux.exe` failed silently because")
+		fmt.Fprintln(os.Stderr, "the daemon process holds a lock on the file. Build to the staging path:")
+		fmt.Fprintf(os.Stderr, "  go build -o %s ./cmd/mcp-mux\n", pendingPath)
+		fmt.Fprintln(os.Stderr, "Then run: mcp-mux upgrade --restart")
+		os.Exit(1)
+	}
+
 	// Zero-downtime upgrade: rename-swap binary WITHOUT stopping daemon or killing connections.
 	//
 	// On Windows, a running exe CAN be renamed (not deleted/overwritten).
@@ -620,6 +633,37 @@ func waitForDaemonExit(ctlPath, prefix string) {
 		time.Sleep(500 * time.Millisecond)
 	}
 	fmt.Fprintln(os.Stderr, " timeout (daemon may still be shutting down).")
+}
+
+// sameFile returns true if two files have the same size and SHA-256 hash.
+func sameFile(a, b string) bool {
+	infoA, errA := os.Stat(a)
+	infoB, errB := os.Stat(b)
+	if errA != nil || errB != nil {
+		return false
+	}
+	if infoA.Size() != infoB.Size() {
+		return false
+	}
+	hashA, errA := fileHash(a)
+	hashB, errB := fileHash(b)
+	if errA != nil || errB != nil {
+		return false
+	}
+	return hashA == hashB
+}
+
+func fileHash(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
 }
 
 // collectEnv returns the current process environment as a map.

--- a/muxcore/engine/engine.go
+++ b/muxcore/engine/engine.go
@@ -130,6 +130,12 @@ type Config struct {
 	// Set to true for ephemeral daemons (tests, one-shot tools) that should
 	// not rehydrate state from prior runs.
 	SkipSnapshot bool
+
+	// StdinEOFPolicy controls shim behavior when stdin returns EOF.
+	// Default (zero value): EagerExit — drain in-flight requests, then exit.
+	// Set to owner.StdinEOFWaitForDisconnect for engine consumers where
+	// stdin is an internal pipe (not a CC shutdown signal).
+	StdinEOFPolicy owner.StdinEOFPolicy
 }
 
 // MuxEngine manages the muxcore multiplexer lifecycle.
@@ -378,6 +384,7 @@ func (e *MuxEngine) runClient(ctx context.Context) error {
 		InitialIPCPath: ipcPath,
 		Token:          token,
 		Reconnect:      reconnectFn,
+		StdinEOFPolicy: e.cfg.StdinEOFPolicy,
 		Logger:         e.logger,
 	})
 }


### PR DESCRIPTION
## Summary

Two additive fixes. Closes engram #157.

### 1. engine.Config.StdinEOFPolicy passthrough

Engine consumers call `engine.New(Config{...})` — they don't construct `ResilientClientConfig` directly. The engine's `runClient` now propagates `StdinEOFPolicy` from Config to `RunResilientClient`.

**Aimux adoption:**
```go
e, _ := engine.New(engine.Config{
    Name:           "aimux",
    StdinEOFPolicy: owner.StdinEOFWaitForDisconnect,
    // ...
})
```

### 2. upgrade: sameFile identity guard

`go build -o mcp-mux.exe` silently fails when the daemon holds a file lock. The staged binary (`mcp-mux.exe~`) ends up identical to the running one. `upgrade --restart` then swaps the same binary — no-op upgrade that appears successful.

Fix: SHA-256 comparison of staged vs current binary before swap. If identical, exit with diagnostic message explaining the cause and correct workflow.

### Files changed

- `muxcore/engine/engine.go` — `StdinEOFPolicy` field + passthrough (+6 lines)
- `cmd/mcp-mux/main.go` — `sameFile` + `fileHash` helpers + guard in `runUpgrade` (+45 lines)

### Tests

Full muxcore suite: 20/20 PASS. Engine tests: 18/18 PASS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Заметки о выпуске

* **Bug Fixes**
  * Исправлена проблема, при которой процесс обновления мог повторяться без необходимости при отсутствии изменений в бинарном файле.

* **New Features**
  * Добавлена новая опция конфигурации для управления поведением при достижении конца потока входных данных.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->