### PR TITLE
muxcore v0.22.0 — multi-tenant FS isolation + Persistent propagation (#102, #103)

### DIFF
--- a/.agent/specs/muxcore-multi-tenant-isolation/architecture.md
+++ b/.agent/specs/muxcore-multi-tenant-isolation/architecture.md
@@ -96,7 +96,7 @@ Key invariant: **socket file prefix = engine.Name**. Three coexisting consumers 
 
 - **L0 (serverid):** pure functions, no I/O. Owns the FS namespace contract. No engine/daemon imports. After change, every path-producing function takes the engine name explicitly — no defaulting to `"mcp-mux"` inside L0 (defaulting is L2's responsibility).
 - **L1 (daemon, owner):** in-memory state for the live process. Crosses to FS via `serverid` only. Adopts new signatures.
-- **L2 (engine):** consumer-facing facade. Owns `Config` validation and default substitution (e.g. empty `Name` → error or default to binary name via `os.Args[0]`). Does NOT leak `serverid` into consumer API.
+- **L2 (engine):** consumer-facing facade. Owns `Config` validation: empty `Name` returns a hard error from `engine.New` (resolved in Q1, see clarifications/2026-04-27-auto.md and FR-2). No silent defaulting. Does NOT leak `serverid` into the consumer API.
 - **L3 (consumers):** import `muxcore` at the engine level, never reach into `serverid` directly. Existing direct calls in `cmd/mcp-mux/daemon.go` (`serverid.DaemonControlPath("", "")`) are L3-violations and get refactored: pass an explicit `Name="mcp-mux"`.
 
 ## 6. Data Flow

--- a/.agent/specs/muxcore-multi-tenant-isolation/architecture.md
+++ b/.agent/specs/muxcore-multi-tenant-isolation/architecture.md
@@ -1,0 +1,260 @@
+# Architecture — muxcore Multi-Tenant FS Isolation
+
+**Slug:** `muxcore-multi-tenant-isolation`
+**Date:** 2026-04-27
+**Author:** orchestrator (in-session)
+**Replaces / amends:** N/A (new arc covering issues #102 + #103)
+
+## 1. Project Type
+
+Go monorepo: **library/SDK + CLI consumer + control-plane MCP server**.
+
+Detected signals:
+- `go.mod` at root (Go module)
+- `muxcore/` submodule (library, semver-tagged independently as `muxcore/vX.Y.Z`)
+- `cmd/mcp-mux/` (CLI binary)
+- `internal/mcpserver/` (control-plane MCP server bundled with the binary)
+- External consumers: aimux, engram, third-party (open-source library)
+
+Type confirmation: `muxcore` is a public Go library imported by multiple downstream binaries; `mcp-mux` is one consumer among several. Architecture must treat muxcore as a **multi-tenant library** where each consumer instance shares the same host filesystem.
+
+## 2. Problem Statement (verbatim from triage)
+
+`muxcore/serverid/serverid.go:189-201` hardcodes the literal string `"mcp-mux-"` as the prefix for owner IPC, control, and lock socket files:
+
+```go
+func IPCPath(id, baseDir string) string  → "mcp-mux-{id}.sock"
+func ControlPath(id, baseDir string) string  → "mcp-mux-{id}.ctl.sock"
+func LockPath(id, baseDir string) string  → "mcp-mux-{id}.lock"
+```
+
+Every muxcore consumer (mcp-mux, aimux, engram, future third-party) creates owner sockets under this shared prefix in `os.TempDir()`. Two failure modes follow:
+
+- **Issue #102** — `mcp-mux serve`'s `mux_list` scans `TEMP/mcp-mux-*.ctl.sock` and finds aimux daemon's owner sockets, presents them to the operator as mcp-mux-managed. `mux_restart` on a foreign socket-id kills the wrong process.
+- **Issue #103** — `engine.Config.Persistent` is declared but never propagated into `OwnerEntry`. SessionHandler-only topology (aimux's `engine.New(Config{Persistent: true, SessionHandler: ...})`) gets reaped after `IdleTimeout` despite the documented contract.
+
+Both surface in the same SessionHandler-only topology where muxcore is embedded inside another binary. Both are class symptoms of one root: **muxcore does not isolate per-engine state when multiple engine instances coexist on one host.**
+
+## 3. Architecture Diagram
+
+```mermaid
+graph TB
+    subgraph "muxcore library v0.22.0+"
+        S[serverid pkg<br/>name-scoped FS paths]
+        D[daemon pkg<br/>OwnerEntry hydration<br/>from Config]
+        E[engine pkg<br/>Config.Name + Persistent<br/>fully propagated]
+        S --> D
+        E --> D
+        E --> S
+    end
+
+    subgraph "Consumer A: mcp-mux"
+        CA1[cmd/mcp-mux<br/>CLI + shim]
+        CA2[internal/mcpserver<br/>mux_list / mux_stop / mux_restart]
+        CA1 -.scoped sockets.-> FS1[mcp-mux-NNN.sock<br/>mcp-mux-NNN.ctl.sock]
+        CA2 -.via daemon control.-> CA1
+    end
+
+    subgraph "Consumer B: aimux"
+        CB[aimux engine.New<br/>Name=aimux-dev]
+        CB -.scoped sockets.-> FS2[aimux-dev-NNN.sock<br/>aimux-dev-NNN.ctl.sock]
+    end
+
+    subgraph "Consumer C: engram"
+        CC[engram engine.New<br/>Name=engram]
+        CC -.scoped sockets.-> FS3[engram-NNN.sock<br/>engram-NNN.ctl.sock]
+    end
+
+    subgraph "Shared filesystem (os.TempDir)"
+        FS1
+        FS2
+        FS3
+    end
+
+    CA1 --> E
+    CB --> E
+    CC --> E
+```
+
+Key invariant: **socket file prefix = engine.Name**. Three coexisting consumers produce three disjoint FS namespaces. `mux_list` in mcp-mux only enumerates `mcp-mux-*` sockets and therefore cannot see aimux/engram owners.
+
+## 4. Component Map
+
+| Component | Responsibility | Dependencies | Layer | Change |
+|-----------|---------------|-------------|-------|--------|
+| `muxcore/serverid` | FS path primitives for sockets/locks. Deterministic hashes for server identity. | stdlib only | L0 (FS namespace) | **Breaking — add `name` parameter to `IPCPath/ControlPath/LockPath`** |
+| `muxcore/daemon` | Owner registry, Spawn, Reaper, snapshot. | `serverid`, `owner`, `control`, `session` | L1 (orchestration) | Hydrate `OwnerEntry` from engine `Config.Persistent`; pass `Name` through to FS path calls |
+| `muxcore/engine` | Public consumer entry — Config, Run, Mode, Ready. | `daemon`, `serverid`, `control`, `ipc` | L2 (consumer API) | Propagate `Config.Name` to all `serverid.*Path` calls; propagate `Config.Persistent` into daemon Config |
+| `muxcore/owner` | Per-upstream lifecycle, IPC accept loop, init cache. | `serverid`, `ipc`, `control` | L1 | Adopt new `serverid.*Path` signatures |
+| `cmd/mcp-mux/main.go` | CLI shim, daemon spawn, status/stop/upgrade. | `muxcore/*` | L3 (consumer) | Replace hardcoded `"mcp-mux-"` filters with calls querying the daemon's owner registry |
+| `cmd/mcp-mux/daemon.go` | Daemon process bootstrap. | `muxcore/daemon`, `muxcore/engine` | L3 | Pass `Name="mcp-mux"` to engine Config explicitly |
+| `internal/mcpserver` | MCP server exposing `mux_list`/`mux_stop`/`mux_restart` to CC agents. | `muxcore/control`, `muxcore/ipc` | L3 | **Stop scanning TEMP**. Query the local mcp-mux daemon's `list_owners` control RPC. Filter is now ownership-based, not pattern-based. |
+| aimux (`engine.New(Config{Name: "aimux-dev", ...})`) | External consumer | muxcore | L3 | Bump muxcore dep to v0.22.0; verify `Persistent: true` survives reaper after IdleTimeout |
+| engram (`engine.New(Config{Name: "engram", ...})`) | External consumer | muxcore | L3 | Bump muxcore dep to v0.22.0 |
+
+## 5. Layer Boundaries
+
+- **L0 (serverid):** pure functions, no I/O. Owns the FS namespace contract. No engine/daemon imports. After change, every path-producing function takes the engine name explicitly — no defaulting to `"mcp-mux"` inside L0 (defaulting is L2's responsibility).
+- **L1 (daemon, owner):** in-memory state for the live process. Crosses to FS via `serverid` only. Adopts new signatures.
+- **L2 (engine):** consumer-facing facade. Owns `Config` validation and default substitution (e.g. empty `Name` → error or default to binary name via `os.Args[0]`). Does NOT leak `serverid` into consumer API.
+- **L3 (consumers):** import `muxcore` at the engine level, never reach into `serverid` directly. Existing direct calls in `cmd/mcp-mux/daemon.go` (`serverid.DaemonControlPath("", "")`) are L3-violations and get refactored: pass an explicit `Name="mcp-mux"`.
+
+## 6. Data Flow
+
+### 6.1 Owner socket creation (post-change)
+
+```
+engine.New(Config{Name: "aimux-dev"})
+  → engine.runDaemon
+      → daemon.New(Config{Name: "aimux-dev", ...})
+          → daemon.Spawn(req)
+              → serverid.IPCPath(baseDir, "aimux-dev", sid)
+                  → "aimux-dev-{sid}.sock"
+              → serverid.ControlPath(baseDir, "aimux-dev", sid)
+                  → "aimux-dev-{sid}.ctl.sock"
+```
+
+### 6.2 mux_list (post-change)
+
+```
+CC agent → tools/call mux_list
+  → mcpserver.toolMuxList
+      → control.Send(mcp-mux-muxd.ctl.sock, Cmd: "list_owners")
+          → daemon.HandleListOwners
+              → iterate d.owners (in-memory)
+              → return [{ServerID, Command, Args, Cwd, Sessions, ...}, ...]
+      → format result, return to CC
+```
+
+No FS scan. Result is authoritative — the daemon returns owners IT manages. Foreign engine instances on the same host are invisible.
+
+### 6.3 Persistent propagation (#103 path)
+
+```
+engine.New(Config{Name: "aimux", Persistent: true, SessionHandler: ...})
+  → engine.runDaemon
+      → daemon.New(Config{Name: "aimux", Persistent: true, ...})
+          → daemon.Spawn (SessionHandler topology)
+              → OwnerEntry{Persistent: cfg.Persistent, ...}
+                  → reaper.go:151 sees entry.Persistent=true
+                  → reaper.go:232 returns evictionDecision{} (skip evict)
+```
+
+Reaper now respects the documented contract for in-process handlers.
+
+### 6.4 Error paths
+
+- Unknown engine name (`Config.Name == ""`) → engine.Run returns hard error. No silent default. (Choice in ADR-002.)
+- Pre-v0.22 stale sockets on disk after a v0.21 → v0.22 upgrade → `daemon.cleanStaleSockets` only removes sockets matching this engine's prefix (`{cfg.Name}-*`), leaves foreign-prefix sockets alone.
+- aimux v5.0.2 (still on v0.21.x muxcore) running concurrently with mcp-mux v0.22 → no collision. Each daemon's `cleanStaleSockets` ignores foreign prefixes; FS namespace is partitioned.
+
+## 7. Deployment Strategy
+
+Three rollout phases:
+
+### Phase 1 — muxcore/v0.22.0 (breaking lib release)
+- New `serverid.{IPC,Control,Lock}Path(baseDir, name, id)` signatures.
+- New `daemon.Config.Name string` field, propagated from engine.
+- `OwnerEntry` hydrated from `engine.Config.Persistent` (#103 fix folded in).
+- `cleanStaleSockets` parameterized by daemon name.
+- `daemon.HandleListOwners` new control RPC for ownership-authoritative enumeration.
+
+### Phase 2 — mcp-mux v0.22.0 (consumer adoption + tools refactor)
+- Adopts muxcore v0.22.0.
+- `internal/mcpserver` switches `mux_list/mux_stop/mux_restart` from FS scan to daemon `list_owners` RPC.
+- `cmd/mcp-mux` keeps the `"mcp-mux-"` filter only inside its OWN `cleanStaleSockets`-equivalent fallback; primary path uses daemon RPC.
+
+### Phase 3 — aimux + engram adoption
+- aimux: `go get muxcore@v0.22.0`; `engine.New(Config{Name: "aimux-dev", Persistent: true})` now actually persists. Verify with mcp-launcher persist mode — ought to PASS where it currently FAILs.
+- engram: `go get muxcore@v0.22.0`. No code changes expected (already passes Name).
+- Document migration in muxcore release notes + AGENTS.md.
+
+Migration safety: phases 2 and 3 are independently deployable. A v0.21.x consumer continues to work after the muxcore upgrade *only if* it never adopts v0.22 — but if it stays on v0.21, it cannot be a consumer of v0.22. Pinning is honoured by Go modules.
+
+Cross-version coexistence on a single host: an old aimux still on v0.21 produces `mcp-mux-*` sockets. New mcp-mux v0.22 ignores them (its `cleanStaleSockets` is now scoped). Until aimux upgrades, the operator sees orphan-looking sockets in TEMP — cosmetic, not functional.
+
+## 8. ADR List
+
+### ADR-010: Breaking change to `serverid` path signatures
+**Status:** Accepted
+**Context:** `serverid.{IPC,Control,Lock}Path` hardcodes `"mcp-mux-"` prefix. Multi-consumer host (aimux, engram, mcp-mux all on one machine) shares one FS namespace. mcp-mux's `mux_list` and `cleanStaleSockets` cannot distinguish own vs. foreign sockets, leading to misleading UI (#102) and risk of killing foreign processes via `mux_restart`. The same root pattern (Config field not propagated to FS / OwnerEntry layer) causes #103 (Persistent dead).
+**Decision:** Add `name string` parameter to `IPCPath`, `ControlPath`, `LockPath`. New format: `{name}-{id}.{sock|ctl.sock|lock}`. Empty `name` is REJECTED at L2 (engine), not silently defaulted at L0 (serverid). muxcore version bump: **v0.22.0** (breaking).
+**Consequences:**
+- *Positive:* FS namespace becomes engine-scoped. mcp-mux, aimux, engram coexist cleanly on one host. Future third-party consumers automatically isolated.
+- *Negative:* All call sites of the three functions must be updated. Internal call sites (~10 in this repo) are mechanical. External consumers (aimux, engram) need version-pin bump.
+- *Migration:* Clean break, not deprecation cycle — `serverid` is library-internal in spirit (consumers should go through engine). The few L3 violations in `cmd/mcp-mux` (`serverid.DaemonControlPath("", "")`) are repaired in this same release.
+
+**Reversibility:** `IRREVERSIBLE` once shipped — public Go signature change. User confirmation required before tagging.
+
+### ADR-011: `daemon.Config.Name` field added; engine propagates `cfg.Name`
+**Status:** Accepted
+**Context:** Daemon currently receives only `ControlPath` from engine. Owner sockets are created via `serverid.{IPC,Control}Path(sid, "")` — no name awareness. To honour ADR-010 the daemon needs the name explicitly.
+**Decision:** Add `Name string` to `daemon.Config`. `engine.runDaemon` passes `cfg.Name`. Daemon stores it on `*Daemon` and uses it in every `serverid.*Path` call internally (Spawn, snapshot.go restore, cleanStaleSockets, owner spawn).
+**Consequences:** Additive on `daemon.Config` — non-breaking field add. Internal daemon code touched in ~5 places.
+**Reversibility:** `REVERSIBLE` — additive field; could be defaulted to `"mcp-mux"` if rolled back, restoring v0.21 behaviour.
+
+### ADR-012: `mux_list/mux_stop/mux_restart` query daemon, do not FS-scan
+**Status:** Accepted
+**Context:** Even after ADR-010, `internal/mcpserver/server.go` keeps a `strings.HasPrefix(name, "mcp-mux-")` FS scan in toolMuxList/toolMuxStop/toolMuxRestart. The scan is fundamentally less authoritative than asking the daemon — daemon knows its owner set; FS only knows what files happen to exist. Two daemons in the same project (test fixture leftover, half-restarted upgrade) would still confuse the FS scan even after ADR-010.
+**Decision:** Add `daemon.HandleListOwners` control RPC returning `[{ServerID, Command, Args, Cwd, Sessions, ClassMode, MuxVersion, ...}]`. `toolMuxList` calls `control.Send(daemonCtl, "list_owners")` and trusts the response. `toolMuxStop`/`toolMuxRestart` resolve `server_id` to a target via the same RPC, then dispatch.
+**Consequences:**
+- *Positive:* mux tools are ownership-authoritative. No way for a foreign socket on disk to be misclassified.
+- *Negative:* Tools fail closed if the local mcp-mux daemon is down (instead of returning partial via FS scan). Acceptable: when the daemon is down there are no mcp-mux-managed servers anyway.
+- *Negative:* New control RPC — addition to muxcore daemon API surface. Documented as part of v0.22.0.
+**Reversibility:** `PARTIALLY REVERSIBLE` — RPC can be removed in a later release if a different design wins; the `internal/mcpserver` switch is a one-way change in mcp-mux.
+
+### ADR-013: `OwnerEntry.Persistent` hydrated from `engine.Config.Persistent`
+**Status:** Accepted
+**Context:** Issue #103 — `engine.Config.Persistent` is declared but `grep -rn Persistent muxcore/engine/` shows zero reads. `OwnerEntry.Persistent` is consulted by reaper but never set in SessionHandler topology. Documented contract violated.
+**Decision:** `daemon.Config` already carries `Name` (ADR-011); add `Persistent bool` to it. Engine passes `cfg.Persistent`. Daemon stores it; in `Spawn` (or wherever `OwnerEntry` is constructed for SessionHandler topology) the new `OwnerEntry` is initialized with `Persistent: d.cfg.Persistent`. Subprocess topology continues to honour the existing `x-mux.persistent` capability path (`classify.ParsePersistent`); the two paths converge — engine.Config wins for in-process handlers, capability wins for subprocess handlers, both end up in `OwnerEntry.Persistent` before the reaper reads it.
+**Consequences:**
+- *Positive:* Documented contract honoured. aimux and any other in-process daemon get correct persistence.
+- *Negative:* None — additive code path. Existing subprocess tests unchanged.
+**Reversibility:** `REVERSIBLE` — additive.
+
+### ADR-014: One spec arc, two issues, single muxcore release
+**Status:** Accepted
+**Context:** #102 and #103 are independently filed but share root: muxcore-side propagation gap from Config to FS / OwnerEntry. Splitting into two PRs duplicates the daemon.Config / engine.runDaemon edits.
+**Decision:** Single spec arc `muxcore-multi-tenant-isolation`. Single muxcore release `v0.22.0` ships both fixes plus mux_list refactor. mcp-mux v0.22.0 adopts in same arc.
+**Consequences:** Larger blast radius per release; offset by smaller total churn (one bump for downstream consumers instead of two).
+**Reversibility:** `REVERSIBLE` — could split if later needed.
+
+## 9. Reusability Awareness
+
+Components evaluated for library extraction:
+
+- **`serverid` after refactor** — already a stable, dependency-free library inside muxcore. After the rename it remains a thin pure-function pkg. Not a candidate for extraction to a separate repo (rule of three not met — only one consumer of socket-naming patterns: muxcore itself).
+- **`daemon.HandleListOwners` RPC contract** — single-consumer (mcp-mux's `internal/mcpserver`) at this time. Not a library candidate. Re-evaluate if a third consumer surfaces.
+- **OwnerEntry Config-hydration pattern** — internal to daemon. Not extractable.
+
+No reusability candidates emitted from this arc. (Empty list IS valid evidence per FR-1; the library-boundary question was asked for every component.)
+
+## 10. Domain Modeling
+
+DDD evaluated — not needed. muxcore is infrastructure code; entities are stateless FS primitives and process-lifecycle records, not domain objects with invariants. No bounded contexts beyond the existing `serverid` / `daemon` / `engine` / `owner` packages, which are already correct partitioning. Rationale: <3 project-owned domain entities; no aggregate roots; contexts are purely technical.
+
+## 11. Patterns Selected
+
+- **Namespace-per-tenant** — engine.Name as the FS-namespace tenant key. Standard multi-tenant SaaS pattern adapted to single-host filesystem.
+- **Authoritative state via owner not scanner** — `mux_list` consults the daemon's owner registry rather than scanning FS, mirroring `kubectl get pods` over `ls /var/lib/kubelet/pods`. Inverts the data-flow direction toward the source of truth.
+- **Config hydration through layered facade** — `engine.Config → daemon.Config → OwnerEntry`, no field disappears at any boundary. Closes the propagation gap that produced #103.
+
+## 12. Verification (acceptance gates for the arc)
+
+- [ ] Every internal call site of `serverid.{IPC,Control,Lock}Path` updated to pass `name`.
+- [ ] No occurrence of `"mcp-mux-"` literal outside (a) `serverid` defaulting logic, (b) tests that explicitly validate the mcp-mux engine name.
+- [ ] `daemon.Config.Name` and `daemon.Config.Persistent` round-trip through `engine.Config` with regression tests (R1 from #103 issue body).
+- [ ] Reaper does not evict `Persistent: true` SessionHandler-topology owners past IdleTimeout (R2 from #103).
+- [ ] mcp-launcher persist regression (R3 from #103) PASSes against a binary built on muxcore v0.22.0.
+- [ ] `mux_list` against a host with both mcp-mux and aimux daemons running shows ONLY mcp-mux-managed servers (#102 acceptance).
+- [ ] `mux_restart <foreign-id>` returns "not found" instead of killing the process (#102 acceptance).
+
+## 13. Open Questions
+
+- **Q1:** Should empty `Config.Name` hard-error or default to `"mcp-mux"` for backward compatibility? Current ADR-010 says hard-error at L2. Backward-compat default is tempting but reintroduces the bug for any consumer that forgot to set Name. Recommend hard-error + clear message naming the field. Confirm before nvmd-tasks.
+- **Q2:** Should `cleanStaleSockets` v0.22 also clean orphan `mcp-mux-*` sockets left by a previous v0.21 mcp-mux daemon if no v0.21 daemon is alive? Default: yes — they are unambiguously stale-pre-upgrade. Risk: a v0.21 aimux running concurrently produces sockets the v0.22 mcp-mux would prematurely clean. Mitigation: probe each `mcp-mux-*.ctl.sock` for liveness before removing; only remove unreachable ones. (This is the existing logic — works correctly post-rename.)
+- **Q3:** mux_list compatibility with consumer's daemon down — return empty list or surface an error to the CC agent? Recommend empty + a one-line note in the result text ("local mcp-mux daemon not running"). Avoids the agent hallucinating servers.
+
+## 14. Handoff
+
+Next: `/nvmd-specify` to convert this architecture into a feature contract (functional/non-functional requirements + acceptance scenarios). The spec ingests this doc as Phase-0 input; questions Q1-Q3 above become clarification candidates for `/nvmd-clarify`.

--- a/.agent/specs/muxcore-multi-tenant-isolation/clarifications/2026-04-27-auto.md
+++ b/.agent/specs/muxcore-multi-tenant-isolation/clarifications/2026-04-27-auto.md
@@ -1,0 +1,40 @@
+# Clarifications — 2026-04-27 (autopilot auto-accept)
+
+**Mode:** auto-accept of architect-recommended answers per `/nvmd-specify --дальше автоматически`.
+**Source:** spec.md Open Questions Q1-Q3, ADR-010 / ADR-013 in architecture.md.
+
+## Q1 — Empty `Config.Name` policy
+
+**Question:** Should empty `engine.Config.Name` hard-error or silently default to `"mcp-mux"`?
+
+**Resolution:** **HARD-ERROR.** `engine.New` returns `fmt.Errorf("muxcore: engine.Config.Name is required (was empty); pass a name unique to this binary, e.g. \"aimux\", \"mcp-mux\", \"engram\")`. No silent default.
+
+**Rationale:** Silent defaulting to `"mcp-mux"` is exactly the v0.21 behaviour that produced the bug. Any future consumer who forgets `Name` would silently inherit mcp-mux's namespace and reproduce #102. Explicit error fails fast with a clear remediation in the error message itself.
+
+**Spec impact:** FR-2 finalized. NFR-4 already covers diagnostic message.
+
+## Q2 — `cleanStaleSockets` cross-prefix cleanup
+
+**Question:** v0.22 mcp-mux daemon finds orphan `mcp-mux-*.ctl.sock` files in TEMP. No live v0.21 mcp-mux daemon is responsive. Should it clean them?
+
+**Resolution:** **CLEAN ONLY IF LIVENESS PROBE FAILS.** The existing logic in `cleanStaleSockets` already does this (`control.Send(ctlPath, "ping")` → if error → remove). It is correct after the rename: the function is now scoped by `cfg.Name` for OWN-prefix sockets (FR-7), but the liveness gate is per-file regardless. Foreign-prefix sockets are skipped because they no longer match own-prefix pattern.
+
+**Rationale:** Liveness is the authoritative signal. A v0.21 aimux running concurrently produces sockets the v0.22 mcp-mux would NOT touch (foreign prefix). A dead v0.21 mcp-mux's leftovers MATCH own prefix and fail liveness — safe to clean.
+
+**Spec impact:** FR-7 stands as written. Edge cases section already lists this scenario.
+
+## Q3 — `mux_list` UX when local mcp-mux daemon is down
+
+**Question:** mcp-mux serve is invoked by CC, but no live mcp-mux daemon exists yet. `mux_list` is called. Return empty list with note vs. explicit error?
+
+**Resolution:** **EMPTY LIST + ONE-LINE NOTE.** Result text contains a `[]` JSON body plus a leading note: `"local mcp-mux daemon not running — start it with mcp-mux daemon or invoke any mcp-mux-wrapped tool to auto-spawn"`.
+
+**Rationale:** Matches the "scoped to managed owners" mental model after FR-5. An error would push CC agents to handle a failure mode that does not actually mean "something broke" — it just means "nothing is being managed yet". Agents have already shown a tendency to misinterpret partial data as authoritative; preventing that is the entire point of FR-5.
+
+**Spec impact:** US1 acceptance criterion 5 (already specifies this exact behaviour) is the binding contract. FR-5 stands.
+
+## Outcome
+
+All three open questions resolved with architect-recommended answers. Spec is unblocked for `/nvmd-plan`.
+
+No new questions surfaced during this clarification pass. spec.md `Open Questions` section is empty post-clarify (questions migrated to this file as resolved).

--- a/.agent/specs/muxcore-multi-tenant-isolation/clarifications/2026-04-27-auto.md
+++ b/.agent/specs/muxcore-multi-tenant-isolation/clarifications/2026-04-27-auto.md
@@ -37,4 +37,4 @@
 
 All three open questions resolved with architect-recommended answers. Spec is unblocked for `/nvmd-plan`.
 
-No new questions surfaced during this clarification pass. spec.md `Open Questions` section is empty post-clarify (questions migrated to this file as resolved).
+No new questions surfaced during this clarification pass. spec.md still carries the original `Open Questions` block as a historical record; resolutions here are the binding contract for implementation, and FR-2 + ADR-010 + ADR-013 reflect the resolved state.

--- a/.agent/specs/muxcore-multi-tenant-isolation/plan.md
+++ b/.agent/specs/muxcore-multi-tenant-isolation/plan.md
@@ -1,0 +1,135 @@
+---
+feature_id: F-021
+slug: muxcore-multi-tenant-isolation
+plan_version: 1
+created: 2026-04-27
+spec_ref: spec.md
+arch_ref: architecture.md
+clarifications_ref: clarifications/2026-04-27-auto.md
+---
+
+# Plan — muxcore Multi-Tenant FS Isolation
+
+## Strategy
+
+One arc, one muxcore breaking release (`muxcore/v0.22.0`), one mcp-mux binary release (`v0.22.0`), shipped together. Two failure modes (#102 + #103) collapse into one PR because the propagation gap is the same in both. Three implementation phases, gated by green CI; phase 4 (downstream adoption) is post-merge and runs against external repos.
+
+## Implementation Phases
+
+### Phase 1 — `muxcore/serverid` rename + `daemon.Config` extension (foundation)
+
+**Scope:**
+- `muxcore/serverid/serverid.go`:
+  - Change signatures: `IPCPath(baseDir, name, id)`, `ControlPath(baseDir, name, id)`, `LockPath(baseDir, name, id)`. Format: `"{name}-{id}.{ext}"`.
+  - Empty `name` is allowed at L0 (`serverid` stays a pure pkg). Validation lives at L2.
+- `muxcore/daemon/daemon.go`:
+  - Add `Config.Name string`, `Config.Persistent bool`.
+  - Internal `*Daemon` stores `name string`. Replace every `serverid.{IPC,Control}Path(sid, "")` call with `serverid.{IPC,Control}Path(d.baseDir, d.name, sid)`.
+  - Spawn path constructs `OwnerEntry{Persistent: d.cfg.Persistent || classifyResult.Persistent, ...}` for SessionHandler topology.
+  - `cleanStaleSockets` accepts the daemon's name and only matches own-prefix files.
+- `muxcore/daemon/snapshot.go`: same call-site updates as daemon.go for serverid functions.
+- `muxcore/owner/resilient_client.go:570` — `TrimPrefix("mcp-mux-")` becomes `TrimPrefix(name + "-")` parameterized.
+- `muxcore/engine/engine.go`:
+  - `engine.New` validates `cfg.Name != ""` → return error.
+  - Pass `cfg.Name` and `cfg.Persistent` into `daemon.Config{Name, Persistent}` in `runDaemon`.
+- New control RPC `daemon.HandleListOwners(req control.Request) ([]control.OwnerInfo, error)` — returns ALL owners the daemon manages, in stable iteration order.
+
+**Deliverables:**
+- Updated source files + `muxcore/control/protocol.go` extended with `OwnerInfo` schema and `Cmd: "list_owners"`.
+- Migration block at top of `muxcore/serverid/serverid.go` with one-paragraph "Why the breaking signature".
+- Unit tests:
+  - `serverid_test.go` covers new format, empty-name behaviour at L0 (returns `"-{id}.ext"` — invalid but library is pure; engine layer is the gate).
+  - `engine_test.go` confirms `Config.Name == ""` returns error from `engine.New`.
+  - `engine_test.go` confirms `Config.Persistent: true` arrives at `OwnerEntry.Persistent` (R1 from #103).
+  - `reaper_test.go` confirms reaper does not evict `OwnerEntry{Persistent: true}` past IdleTimeout (R2 from #103).
+  - `daemon_test.go` confirms `cleanStaleSockets` only removes own-prefix unreachable sockets when called against a daemon with `Name="aimux-test"` and pre-seeded `mcp-mux-stale-X.ctl.sock` (foreign-prefix, must NOT be touched).
+
+**Gate:** all `go test ./muxcore/...` green; existing tests untouched outside the rename.
+
+### Phase 2 — mcp-mux consumer adoption + `internal/mcpserver` refactor
+
+**Scope:**
+- `cmd/mcp-mux/main.go` and `cmd/mcp-mux/daemon.go`:
+  - Replace every `serverid.DaemonControlPath("", "")` with `serverid.DaemonControlPath("", "mcp-mux")`. Pass `Name: "mcp-mux"` explicitly to engine Config.
+  - Replace every `serverid.IPCPath(sid, "")` and `serverid.ControlPath(sid, "")` with the three-arg form including name `"mcp-mux"`.
+  - Remove FS-scan filter logic (`strings.HasPrefix(name, "mcp-mux-")`) at lines 396, 401, 438, 446, 710, 715, 742, 749. Where the operation is "list / stop / restart", route through the new daemon `list_owners` RPC. Where the operation is "cleanup" (e.g. `mcp-mux stop --all`), keep filtering but parameterize prefix from a single source.
+- `internal/mcpserver/server.go`:
+  - `toolMuxList`: replace TEMP scan with `control.Send(daemonCtl, Cmd: "list_owners")`. Render result. If RPC fails (daemon down): return `[]` + `note: "local mcp-mux daemon not running ..."`.
+  - `toolMuxStop`: resolve `server_id`/`name` via `list_owners`, then `control.Send(ownerCtl, Cmd: "shutdown")` only if the owner appears in the daemon's own list.
+  - `toolMuxRestart`: same resolve-then-act pattern. Use new `daemon` RPC `restart_owner` (or compose stop + spawn through the daemon control plane).
+  - Session-cwd filter (existing `ownerHasCwd` logic) operates on RPC result, not on raw socket files — same filter logic, different data source.
+
+**Deliverables:**
+- Updated source files.
+- `internal/mcpserver/server_test.go` — existing `mux_list`/`mux_stop`/`mux_restart` tests rewritten against a fake daemon control endpoint instead of TEMP fixtures.
+- New integration test: spin up two mcp-mux daemons in distinct `BaseDir`s; first daemon's `mux_list` returns ONLY its own owners; second daemon's owners are invisible.
+
+**Gate:** `go test ./...` green; manual smoke (`mcp-mux serve` → `mux_list` against this workstation's TEMP) shows only mcp-mux-managed entries.
+
+### Phase 3 — release + ship + verify
+
+**Scope:**
+- AGENTS.md `## muxcore Library API` block:
+  - Add v0.22.0 entry with breaking-changes table (signatures, daemon.Config additions, list_owners RPC).
+  - Migration steps for aimux + engram (one-paragraph each).
+  - Bump "Upgrade" snippet to `go get github.com/thebtf/mcp-mux/muxcore@v0.22.0`.
+- README.md:
+  - Update "Commands" section if it mentions FS scan or `mcp-mux-` literal prefix. (Audit pass.)
+  - "Session-scoped control plane" subsection: confirm wording aligns with daemon-RPC reality.
+- Tag + push:
+  - `git tag muxcore/v0.22.0 -m "muxcore v0.22.0 — breaking: engine-name-scoped FS namespace + Persistent propagation"`.
+  - `git tag v0.22.0 -m "mcp-mux v0.22.0 — adopts muxcore/v0.22.0; mux_list now daemon-authoritative"`.
+  - Both with `git push --follow-tags`.
+- GitHub releases (both tags) with body derived from spec + ADRs.
+- Close GitHub issues #102 + #103 with commit + tag references.
+- Engram store: decision + adoption matrix.
+- Workstation deploy: `mcp-mux upgrade --restart` with the new binary; verify `mux_list` no longer shows aimux entries.
+
+**Gate:** both tags live on GitHub Releases; both issues closed with verified-fix evidence; engram observation stored.
+
+### Phase 4 — downstream adoption (post-merge, external repos)
+
+**Out-of-arc but tracked here for handoff:**
+- aimux: bump muxcore dep, run `mcp-launcher persist` regression, post comment on #103 confirming PASS.
+- engram: bump muxcore dep, smoke test, no code change expected.
+- Update CONTINUITY.md across all three repos when each adoption completes.
+
+## Risk Analysis
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| `daemon.HandleListOwners` returns inconsistent shape vs. existing `status` RPC | MED | New schema declared explicitly in `control/protocol.go`; reuse existing per-owner status fields rather than inventing new ones. |
+| Phase 2 refactor of `internal/mcpserver` breaks the cwd-scoping behaviour (`ownerHasCwd`) | MED | RPC result includes `cwd_set` per owner (already present in status); filter logic moves verbatim from current site. |
+| Snapshot restore from v0.21 onto v0.22 daemon | LOW | Snapshot version stamp already exists; bump it; v0.22 rejects mismatched snapshot and starts fresh. Snapshot is perf optimization. |
+| aimux v5.0.2 keeps breaking on stale `mcp-mux-*` sockets after upgrade because aimux still on v0.21 | LOW | Phase 4 closes; until then, aimux's own daemon's cleanup logic handles its own files. |
+| Two regression tests (R1 + R2) over-fit to current daemon internals | LOW | Tests assert observable behaviour (`OwnerEntry.Persistent` value; reaper.go log absence), not implementation details. |
+| TOCTOU between `list_owners` response and subsequent `mux_stop` on a vanished owner | LOW | Daemon `HandleStop(server_id)` already handles "not found" gracefully; mux_stop tool surfaces "not found" to the agent without retry. |
+
+## Test Strategy
+
+- **Unit tests:** all serverid renames + propagation paths (Phase 1 coverage targets above).
+- **Integration tests:**
+  - `daemon_list_owners_integration_test.go` — spawn daemon, register 3 owners with distinct cwds, call `list_owners`, assert shape + cwd filtering.
+  - `mux_list_cross_engine_test.go` (new file under `internal/mcpserver/`) — start two engines with names `"mcp-mux"` and `"aimux-test"`, both spawn an owner with the same upstream binary, run `toolMuxList` against the mcp-mux daemon, assert only `"mcp-mux"`-engine owners are returned.
+- **End-to-end:**
+  - `mcp-launcher persist -binary aimux-test.exe -mode persist -watch 30` against a freshly built aimux-test using muxcore/v0.22.0. PASS line required.
+  - Workstation manual: `mux_list` from CC, observe absence of foreign aimux entries.
+- **Coverage gates:**
+  - `go test -cover ./muxcore/serverid/...` ≥ 90%.
+  - `go test -cover ./muxcore/daemon/...` ≥ 75% (existing baseline).
+  - `internal/mcpserver/...` regression suite green.
+
+## Pipeline-Internal Mode Detection
+
+Mode hints (Sonnet vs. Codex routing for task-builder):
+- Phase 1 = mostly mechanical signature change + new field hydration → Sonnet handles cleanly.
+- Phase 2 = `internal/mcpserver` refactor + new RPC client logic → Codex (TDD-friendly, multi-file).
+- Phase 3 = orchestrator-only (release management) → no delegation.
+
+## Done Definition
+
+All FRs map to passing tests. All NFRs measurable via at least one CI gate or smoke procedure. spec.md `## Success Criteria` checklist 6/6 ticked before Phase 3 ships.
+
+## Pipeline Forward
+
+Next: `/nvmd-tasks muxcore-multi-tenant-isolation` to break this plan into atomic, dependency-ordered tasks with acceptance criteria.

--- a/.agent/specs/muxcore-multi-tenant-isolation/spec.md
+++ b/.agent/specs/muxcore-multi-tenant-isolation/spec.md
@@ -1,0 +1,261 @@
+---
+feature_id: F-021
+slug: muxcore-multi-tenant-isolation
+title: muxcore Multi-Tenant FS Isolation
+status: ACTIVE
+created: 2026-04-27
+updated: 2026-04-27
+authors:
+  - orchestrator
+parent_specs: []
+linked_issues:
+  - thebtf/mcp-mux#102
+  - thebtf/mcp-mux#103
+linked_artifacts:
+  - architecture.md
+  - user_job_statement.md
+muxcore_release_target: muxcore/v0.22.0
+mcp_mux_release_target: v0.22.0
+breaking: true
+---
+
+# Feature: muxcore Multi-Tenant FS Isolation
+
+**Slug:** muxcore-multi-tenant-isolation
+**Created:** 2026-04-27
+**Status:** ACTIVE (CR-001 Initial Scope)
+**Author:** orchestrator (in-session)
+
+> **Provenance:** Specified by orchestrator (Opus 4.7) on 2026-04-27.
+> Evidence from: GitHub issues #102 + #103, aimux investigation session `019dcf25-d22c-7893-91bb-6e958f05bd02`, mcp-launcher persist reproducer (`thebtf/mcp-launcher@d8f9f7c`), in-session FS verification (`TEMP` socket inventory of host `D:\Dev\mcp-mux`), source grep of `muxcore/serverid/serverid.go:189-201` and call-site enumeration (Serena `find_referencing_symbols`).
+> Confidence: VERIFIED — every claim traces to a tool call this session.
+
+## Overview
+
+muxcore must isolate per-engine state on the shared host filesystem so multiple muxcore-based binaries (mcp-mux, aimux, engram, future third-party) coexist without cross-tenant interference. Today every consumer creates owner sockets under the literal prefix `"mcp-mux-"`, hardcoded in `muxcore/serverid/serverid.go:189-201`. mcp-mux's control-plane tools (`mux_list`/`mux_stop`/`mux_restart`) walk that shared namespace and treat any matching file as their own. Operators kill foreign processes by accident; downstream consumers (aimux) cannot honour their own `engine.Config.Persistent` contract because the same propagation gap that hides ownership also drops the persistence flag.
+
+This arc fixes both symptoms by making engine.Name authoritative for FS namespacing, propagating engine.Config fields fully to OwnerEntry, and replacing pattern-based FS scans with daemon-authoritative ownership queries. Ships as muxcore/v0.22.0 (breaking) + mcp-mux v0.22.0 (consumer adoption).
+
+## Context
+
+mcp-mux is open-source infrastructure that several downstream binaries embed via the `muxcore` Go library. Two of those binaries — aimux and engram — are developed in this user's ecosystem; third-party adopters are anticipated.
+
+Today the public muxcore engine API accepts `Config.Name` (used for daemon control socket names) but does NOT use that name when constructing per-owner sockets. Per-owner sockets fall back to a hardcoded `"mcp-mux-"` prefix at the L0 (`serverid` package) layer. The result is a single shared FS namespace across all engine instances on a host.
+
+Two production failures observed during 2026-04 sprint:
+
+1. **Operator footgun (#102):** mcp-mux's `mux_list` enumerates `TEMP/mcp-mux-*.ctl.sock` and presents the results as mcp-mux-managed. On the user's workstation this list contains aimux's own owner sockets. `mux_restart <foreign-id>` kills the aimux process; the CC session attached to that aimux dies; user must `/mcp → Reconnect` manually.
+2. **Documented contract violated (#103):** `engine.Config.Persistent: true` is documented as "the daemon stays alive even with zero sessions". Source inspection (`grep -rn Persistent muxcore/engine/`) shows the field is declared in `engine.go:113` and read nowhere. aimux daemon dies five minutes after every Ctrl+C in CC, contradicting the contract.
+
+> **Evidence anchor:** Verbatim quotes from `user_job_statement.md`:
+> - "`mux_restart` on this `server_id` **kills** the CC-owned process, breaking the CC session" (#102)
+> - "documented public API contract not honored" (#103)
+> - "Production aimux daemon kept dying after CC Ctrl+C → reconnects required" (aimux investigation)
+
+Both symptoms share a root: muxcore does not propagate engine identity (Name) and engine intent (Persistent) through the layered facade (`engine.Config → daemon.Config → OwnerEntry → FS path`). Every Config field that is supposed to influence runtime behaviour must reach the layer where that behaviour is enforced.
+
+## Domain Modeling
+
+DDD evaluated — not needed. muxcore is infrastructure; entities are stateless filesystem primitives (paths, sockets, locks) and process-lifecycle records (`OwnerEntry`, `Daemon`). No bounded contexts beyond the existing `serverid` / `daemon` / `engine` / `owner` package partitioning. <3 project-owned domain entities; no aggregate roots; existing technical decomposition is the correct one.
+
+## Functional Requirements
+
+### FR-1: Engine-name-scoped owner socket paths
+
+`muxcore/serverid` MUST construct owner socket paths as `{name}-{id}.{sock|ctl.sock|lock}` where `{name}` is the engine.Name passed by the engine. The literal prefix `"mcp-mux-"` MUST NOT appear in `serverid` outputs except when an engine instance was explicitly named `"mcp-mux"`.
+
+> Evidence anchors: `user_job_statement.md` Current Struggle ("operator thinks mcp-mux manages the server, uses mux tools, causes damage") + Friend-Summary ("each tenant gets their own labeled prefix").
+
+### FR-2: Empty engine name is rejected, not defaulted
+
+If `engine.Config.Name == ""` at `engine.New` or `engine.Run`, the engine MUST return an error naming the missing field. Silent defaulting to `"mcp-mux"` is forbidden — that is the v0.21 behaviour that produced the bug.
+
+> Evidence anchors: `user_job_statement.md` Workaround ("none clean. Three half-measures") + Friend-Summary ("contract that says 'don't auto-empty this box' must be read at the building level").
+
+### FR-3: `engine.Config.Persistent` propagates to `OwnerEntry.Persistent`
+
+Every `OwnerEntry` created in SessionHandler topology MUST have its `Persistent` field initialized from the live engine `Config.Persistent`. The reaper (`muxcore/daemon/reaper.go`) consults `entry.Persistent` and is unchanged.
+
+> Evidence anchors: `user_job_statement.md` Current Struggle ("documented public API contract not honored") + Workaround ("`AIMUX_NO_ENGINE=1` environment override … bypasses muxcore engine entirely").
+
+### FR-4: Subprocess topology persistence path is preserved
+
+For subprocess (non-SessionHandler) topology, `OwnerEntry.Persistent` continues to be derived from the upstream's `x-mux.persistent` capability via `classify.ParsePersistent`. FR-3 is additive — both paths converge on `OwnerEntry.Persistent` before reaper reads it.
+
+> Evidence anchors: `user_job_statement.md` Current Struggle (per #103: "The capability-based path … does NOT cover this topology"); architecture.md ADR-013.
+
+### FR-5: `mux_list` reads from daemon, not from FS
+
+`internal/mcpserver/server.go` `toolMuxList` MUST query the local mcp-mux daemon via a new `list_owners` control RPC and return only the owners the daemon reports. The TEMP-directory scan MUST be removed from the primary path.
+
+> Evidence anchors: `user_job_statement.md` Current Struggle ("operators are advised — informally, in chat — 'don't trust `mux_list` on a host with aimux'") + Friend-Summary ("Tenant A only sees Tenant A's boxes").
+
+### FR-6: `mux_stop` and `mux_restart` resolve targets via daemon
+
+`toolMuxStop` and `toolMuxRestart` MUST resolve `server_id` and `name` arguments through the same daemon `list_owners` RPC, then dispatch the action. They MUST NOT operate on a socket file unless the daemon confirms ownership.
+
+> Evidence anchors: `user_job_statement.md` Current Struggle ("`mux_restart` on this `server_id` **kills** the CC-owned process") + Friend-Summary ("trash Tenant B's mail").
+
+### FR-7: `cleanStaleSockets` is daemon-name-scoped
+
+`muxcore/daemon.cleanStaleSockets` MUST only consider socket files whose prefix matches the daemon's own `cfg.Name`. Foreign-prefix sockets (e.g. an aimux daemon's `aimux-dev-*.sock` files when mcp-mux daemon runs cleanup) MUST be left untouched.
+
+> Evidence anchors: `user_job_statement.md` Friend-Summary ("each tenant gets their own labeled prefix") + Workaround ("manual, fragile, and fails when an aimux owner has the same age as an mcp-mux owner").
+
+### FR-8: New `daemon.HandleListOwners` control RPC
+
+`muxcore/daemon` MUST expose a new control command `"list_owners"` returning a JSON array of owner records: `[{server_id, command, args, cwd, sessions, classification, mux_version, persistent, ...}, ...]`. Consumers (`internal/mcpserver`, future tools) call this in lieu of FS scanning.
+
+> Evidence anchors: `user_job_statement.md` Workaround ("operators run `mcp-mux status` (FS-scan style listing) and cross-reference TEMP socket timestamps against process lists") + Friend-Summary ("the contract … must be read at the building level").
+
+### FR-9: Backward-incompatible muxcore release tagged `muxcore/v0.22.0`
+
+The `serverid` signature change is a breaking Go API change. The release MUST be tagged `muxcore/v0.22.0`. Release notes in AGENTS.md MUST list the migration path for consumers (mcp-mux, aimux, engram).
+
+> Evidence anchors: `user_job_statement.md` Workaround ("Three half-measures, all dirty") — driver of the breaking-version decision; architecture.md ADR-014.
+
+### FR-10: mcp-mux binary release `v0.22.0` adopts new muxcore in lockstep
+
+`cmd/mcp-mux` and `internal/mcpserver` MUST adopt muxcore/v0.22.0 in the same release that ships the muxcore tag. mcp-mux v0.22.0 binary uses the new `serverid` signatures and the new `list_owners` RPC; it does not need to support both shapes.
+
+> Evidence anchors: `user_job_statement.md` Current Struggle (the bug exists in mcp-mux's `mux_list`); architecture.md Phase 2 of deployment strategy.
+
+### FR-11: Cross-version coexistence does not corrupt either side
+
+When mcp-mux v0.22 (new prefix scheme) runs on the same host as a v0.21 consumer (legacy `mcp-mux-*` prefix), neither daemon's `cleanStaleSockets` MUST destroy the other's live sockets. Liveness is the gate, not naming convention.
+
+> Evidence anchors: `user_job_statement.md` Friend-Summary (multi-tenant building metaphor); architecture.md "Migration safety" section.
+
+### FR-12: Internal call sites of `serverid.{IPC,Control,Lock}Path` updated atomically
+
+Every internal call to the three renamed functions (~10 sites in `cmd/mcp-mux/{main,daemon}.go`, `muxcore/{daemon,owner,snapshot,engine}/*.go`, `testdata/`) MUST pass an explicit `name` argument in the same PR. No call site MAY default to empty string after this release.
+
+> Evidence anchors: `user_job_statement.md` Friend-Summary ("each tenant gets their own labeled prefix"); architecture.md Component Map.
+
+## Non-Functional Requirements
+
+### NFR-1: Performance — control-plane RPC overhead
+
+`mux_list` end-to-end latency (CC → mcp-mux serve stdio → daemon control RPC → response) MUST remain under 50 ms p99 on a workstation-class machine with up to 50 owners registered. The replacement of FS scan by RPC MUST NOT regress observed latency.
+
+### NFR-2: Test coverage — propagation regressions
+
+The PR landing this arc MUST include three concrete regression tests (R1-R3 from #103 issue body):
+
+- R1: unit test in `muxcore/engine` or `muxcore/daemon` confirming `Config.Persistent: true` propagates to `OwnerEntry.Persistent`.
+- R2: unit test in `muxcore/daemon/reaper_test.go` confirming the reaper does NOT evict a `Persistent: true` owner past `IdleTimeout`.
+- R3: integration test driven by `mcp-launcher persist` mode against a binary built on this release. Test passes when `persistent: true` survives a `daemon` watch ≥ 30 s with zero sessions.
+
+### NFR-3: Deterministic FS namespace partitioning
+
+For any two engine instances `A` (Name=`"mcp-mux"`) and `B` (Name=`"aimux"`) running on the same host, the set of socket files created by A and the set created by B MUST be disjoint. There MUST exist no file path that A could create AND B could create.
+
+### NFR-4: No silent defaults
+
+If a required engine-identity field (`Name`) is missing, behaviour MUST be a hard error returned to the consumer at `engine.New` or first `engine.Run` call, not a silent fallback. Diagnostic message MUST name the missing field.
+
+### NFR-5: Documentation parity
+
+AGENTS.md MUST document the new `serverid` signatures, the `list_owners` RPC, and the migration path for downstream consumers in the release block for `muxcore/v0.22.0`. README.md "Commands" / "For MCP Server Authors" sections MUST be updated where they reference the old prefix scheme.
+
+### NFR-6: Build cleanliness
+
+After the change, `grep -rn '"mcp-mux-"' --include='*.go'` outside of (a) `serverid` defaulting tests and (b) integration tests that explicitly construct an mcp-mux engine MUST return zero results.
+
+## User Stories
+
+### US1: Operator runs `mux_list` on a multi-tenant host (P0)
+
+**As an** operator running mcp-mux alongside aimux on one machine,
+**I want** `mux_list` to show only mcp-mux-managed servers,
+**so that** I never accidentally `mux_restart` an aimux daemon and break someone else's CC session.
+
+**Acceptance Criteria:**
+- [ ] Workstation has at least one mcp-mux daemon and at least one aimux daemon running concurrently.
+- [ ] `mux_list` (default scope, no flags) returns only servers whose owner was spawned by the local mcp-mux daemon.
+- [ ] `mux_list` does NOT include aimux's owner sockets.
+- [ ] No `mcp-mux-*.ctl.sock` files originate from aimux on this host post-upgrade.
+- [ ] If the local mcp-mux daemon is not running, `mux_list` returns an empty array plus a one-line note ("local mcp-mux daemon not running"), not a partial FS-derived list.
+
+### US2: aimux team relies on `Config.Persistent: true` (P0)
+
+**As an** aimux maintainer using muxcore via `engine.New(Config{Name: "aimux", Persistent: true, SessionHandler: srv})`,
+**I want** the daemon to survive zero-session windows past `IdleTimeout`,
+**so that** the in-process state (loom workers, context caches, indices) is not lost on every Ctrl+C in CC.
+
+**Acceptance Criteria:**
+- [ ] `mcp-launcher persist -binary aimux-test.exe -mode persist -watch 30` reports `[persist] PASS: daemon pid X stayed alive for 30s and reconnect reused same pid` against a binary built on muxcore/v0.22.0.
+- [ ] `daemon.Status` returns `persistent: true` for owners spawned with `engine.Config.Persistent: true`.
+- [ ] Reaper logs do NOT show eviction of persistent owners past `IdleTimeout` in the regression test for R2.
+
+### US3: Maintainer ships breaking-but-clean muxcore release (P1)
+
+**As the** muxcore maintainer,
+**I want** `muxcore/v0.22.0` to be a single coherent release with both #102 and #103 fixed and adopted in mcp-mux v0.22.0 atomically,
+**so that** downstream consumers (aimux, engram) execute exactly one version bump and one round of testing.
+
+**Acceptance Criteria:**
+- [ ] `muxcore/v0.22.0` and `v0.22.0` (mcp-mux binary) tags are pushed in the same release window.
+- [ ] AGENTS.md `## muxcore Library API` block contains a v0.22.0 entry with breaking-changes table and migration steps.
+- [ ] Both GitHub releases (`muxcore/v0.22.0`, `v0.22.0`) are published with body content derived from the spec + ADR list.
+
+### US4: Operator upgrades on a host with running v0.21 consumer (P1)
+
+**As an** operator with mcp-mux on workstation and aimux still on muxcore v0.21,
+**I want** the mcp-mux v0.22 upgrade to coexist cleanly with the older aimux,
+**so that** I can roll out muxcore v0.22 across binaries on my own schedule.
+
+**Acceptance Criteria:**
+- [ ] After mcp-mux v0.22 starts, the running v0.21 aimux's owner sockets in TEMP are not removed by mcp-mux's `cleanStaleSockets`.
+- [ ] `mux_list` from mcp-mux v0.22 does not show aimux's `mcp-mux-*` legacy sockets even though they match the old global pattern (because mux_list now consults the daemon, not TEMP).
+- [ ] aimux v5.0.2 (still on muxcore v0.21) continues to function until its own owner schedules an adoption bump.
+
+## Edge Cases
+
+- **Concurrent daemons of the same Name** (two mcp-mux daemons on the same host, e.g. test fixture leftover): one binds first, second fails to bind control socket. `cleanStaleSockets` of the live daemon detects unreachable own-prefix sockets and removes them. Behaviour unchanged from v0.21 except prefix-scoping.
+- **Engine.Name with FS-unfriendly characters** (slashes, spaces, control chars): out of scope for this arc; NFR-4 only requires non-empty. Validation of name characters is a follow-up if a third-party consumer tries something exotic.
+- **`mux_list(all: true)` semantics post-change**: still scoped to mcp-mux daemon's owners across all projects (CC sessions). Does NOT widen scope to foreign daemons. Agents that want host-wide socket inventory must call OS-level tools, not muxcore.
+- **Daemon snapshot restore across version boundary**: snapshot from v0.21 (no Name field) restored under v0.22 — daemon must reject or migrate. Default: reject + log + start fresh. Snapshot is a perf optimization, not a durability contract.
+- **`HandleListOwners` under load with 100+ owners**: returned JSON ≥10KB. Stdio MCP transport handles this, but `internal/mcpserver` must paginate or cap. Cap at first 200 owners + a `truncated: true` flag — adequate for foreseeable scales.
+- **Zero-owner daemon**: `HandleListOwners` returns `[]`. `mux_list` returns `[]`. Distinct from "daemon down" case (FR-5 acceptance criterion).
+
+## Out of Scope
+
+- Engine.Name input validation (character set, max length): follow-up if a real consumer needs exotic names.
+- Migration of stale `mcp-mux-*` files left by ANY old consumer (not just self): cosmetic; can be cleaned manually.
+- A v0.21-compatibility shim in v0.22 (dual prefix scheme): rejected — adds complexity, hides the fix, slows future evolution. Clean break.
+- Renaming `mux_list/mux_stop/mux_restart` tool names: separate UX concern. The bug is FS namespace, not tool naming.
+- Cross-host federation (muxcore daemons on different machines coordinating): never been in muxcore's scope.
+- Replacing AF_UNIX with a different IPC transport (named pipes only on Windows, gRPC, etc.): orthogonal.
+
+## Dependencies
+
+- Go 1.25+ (existing project requirement).
+- mcp-launcher commit `d8f9f7c` or later, with `persist` mode, available locally for NFR-2 R3 regression.
+- aimux v5.0.2 source available for adoption verification (Phase 3 of deployment).
+- engram source available for adoption verification (Phase 3 of deployment).
+- Existing CI green on master at the start of the arc.
+
+## Success Criteria
+
+- [ ] Both #102 and #103 closed on GitHub with reference to commits + release tag.
+- [ ] aimux team confirms `Config.Persistent: true` works after `go get muxcore@v0.22.0` (verification posted as a comment on #103).
+- [ ] `grep -rn '"mcp-mux-"' --include='*.go'` outside the two allowlisted contexts returns zero results.
+- [ ] On the user's workstation (D:\Dev\mcp-mux as primary CC project), `mux_list` shows only mcp-mux-managed entries; the 6 foreign entries observed during triage today (`056351243aa4230d`, `714a4bd785ac8829`, etc.) disappear from the list after the upgrade.
+- [ ] `mcp-launcher persist` regression integrated into CI as `make persist-regression` or equivalent target. Green on master.
+- [ ] Engram observation stored with key decisions and adoption matrix.
+
+## Open Questions
+
+These were emitted by `nvmd-architect` Section 13 and remain open for `/nvmd-clarify`:
+
+- **[NEEDS CLARIFICATION] Q1 — Empty `Config.Name` policy.** Hard-error at `engine.New` (current ADR-010 + FR-2 default) vs default to `"mcp-mux"` for v0.21 compatibility. Recommendation: hard-error with named-field message. Confirm before plan.
+- **[NEEDS CLARIFICATION] Q2 — `cleanStaleSockets` cross-prefix policy.** v0.22 mcp-mux daemon detects orphan `mcp-mux-*` files left by a previous v0.21 mcp-mux daemon (no live v0.21 daemon). Should it clean them? Recommendation: clean only if liveness probe fails (existing logic, works correctly post-rename).
+- **[NEEDS CLARIFICATION] Q3 — `mux_list` "daemon down" UX.** Empty list + one-line note ("local mcp-mux daemon not running") vs explicit error returned to CC agent. Recommendation: empty + note. Avoids agent hallucinating servers and matches the "scoped to managed owners" mental model.
+
+## Pipeline State
+
+Phase 0: PHASE_0_COMPLETE (`user_job_statement.md`)
+Phase 1: complete (`architecture.md` doubles as exploration output for this arc)
+Phase 2: this document (`spec.md`)
+Next: `/nvmd-clarify muxcore-multi-tenant-isolation` to resolve Q1-Q3.

--- a/.agent/specs/muxcore-multi-tenant-isolation/spec.md
+++ b/.agent/specs/muxcore-multi-tenant-isolation/spec.md
@@ -231,7 +231,7 @@ After the change, `grep -rn '"mcp-mux-"' --include='*.go'` outside of (a) `serve
 ## Dependencies
 
 - Go 1.25+ (existing project requirement).
-- mcp-launcher commit `d8f9f7c` or later, with `persist` mode, available locally for NFR-2 R3 regression.
+- mcp-launcher commit `d8f9f7c` or later, with `persist` mode, available locally for NFR-2 R3 regression. Repo `D:\Dev\mcp-launcher` is in-house tooling — modifications permitted when R3 verification needs new modes or assertions.
 - aimux v5.0.2 source available for adoption verification (Phase 3 of deployment).
 - engram source available for adoption verification (Phase 3 of deployment).
 - Existing CI green on master at the start of the arc.

--- a/.agent/specs/muxcore-multi-tenant-isolation/tasks.md
+++ b/.agent/specs/muxcore-multi-tenant-isolation/tasks.md
@@ -18,7 +18,7 @@ CR-scoped, dependency-ordered, every task has acceptance criteria. GATE tasks se
 ### T001 — `serverid` signature change
 
 **Files:** `muxcore/serverid/serverid.go`, `muxcore/serverid/serverid_test.go`
-**Status:** PENDING
+**Status:** [X] DONE — commit `ba9d4a2` on 2026-04-27
 **Depends on:** —
 **Effort:** S (mechanical)
 **Mode hint:** Sonnet
@@ -30,8 +30,8 @@ CR-scoped, dependency-ordered, every task has acceptance criteria. GATE tasks se
 
 ### T002 — `daemon.Config` extension + Daemon name field
 
-**Files:** `muxcore/daemon/daemon.go`, `muxcore/daemon/daemon_test.go`
-**Status:** PENDING
+**Files:** `muxcore/daemon/daemon.go`, `muxcore/daemon/daemon_test.go`, `muxcore/daemon/snapshot.go`, `muxcore/owner/resilient_client.go`
+**Status:** [X] DONE — commit `8ce3d10` on 2026-04-27
 **Depends on:** T001
 **Effort:** S
 **Mode hint:** Sonnet
@@ -46,7 +46,7 @@ CR-scoped, dependency-ordered, every task has acceptance criteria. GATE tasks se
 ### T003 — `engine.Config.Name` validation + propagation
 
 **Files:** `muxcore/engine/engine.go`, `muxcore/engine/engine_test.go`
-**Status:** PENDING
+**Status:** [X] DONE — commit `a36ddf2` on 2026-04-27
 **Depends on:** T002
 **Effort:** S
 **Mode hint:** Sonnet
@@ -59,7 +59,7 @@ CR-scoped, dependency-ordered, every task has acceptance criteria. GATE tasks se
 ### T004 — `OwnerEntry.Persistent` hydration in SessionHandler topology
 
 **Files:** `muxcore/daemon/daemon.go` (Spawn path), `muxcore/daemon/daemon_persistent_test.go` (new)
-**Status:** PENDING
+**Status:** [X] DONE — commit `ce5ffc7` on 2026-04-27
 **Depends on:** T002, T003
 **Effort:** S
 **Mode hint:** Sonnet
@@ -71,7 +71,7 @@ CR-scoped, dependency-ordered, every task has acceptance criteria. GATE tasks se
 ### T005 — Reaper regression test (R2 from #103)
 
 **Files:** `muxcore/daemon/reaper_test.go`
-**Status:** PENDING
+**Status:** [X] DONE — commit `6fe6958` on 2026-04-27
 **Depends on:** T004
 **Effort:** S
 **Mode hint:** Sonnet
@@ -81,8 +81,8 @@ CR-scoped, dependency-ordered, every task has acceptance criteria. GATE tasks se
 
 ### T006 — `daemon.HandleListOwners` control RPC
 
-**Files:** `muxcore/control/protocol.go`, `muxcore/daemon/daemon.go`, `muxcore/control/server.go`, `muxcore/daemon/list_owners_test.go` (new)
-**Status:** PENDING
+**Files:** `muxcore/control/protocol.go`, `muxcore/daemon/daemon.go`, `muxcore/control/server.go`, `muxcore/daemon/list_owners_test.go` (new), `muxcore/control/control_test.go` (mock stub), `cmd/mcp-mux/daemon_test.go` (mock stub)
+**Status:** [X] DONE — commit `fa6bae2` on 2026-04-27
 **Depends on:** T002
 **Effort:** M
 **Mode hint:** Sonnet
@@ -94,7 +94,7 @@ CR-scoped, dependency-ordered, every task has acceptance criteria. GATE tasks se
 
 ### T007 — GATE: muxcore Phase 1 green
 
-**Status:** PENDING
+**Status:** [X] DONE — verified 2026-04-27 (19 pkg PASS, vet clean, smoke `smoke-muxd.ctl.sock` confirmed, no `mcp-mux-` legacy sockets)
 **Depends on:** T001, T002, T003, T004, T005, T006
 **Acceptance:**
 - `go test ./muxcore/...` green on Windows + Linux (CI).
@@ -107,7 +107,7 @@ CR-scoped, dependency-ordered, every task has acceptance criteria. GATE tasks se
 ### T008 — `cmd/mcp-mux` adopts new `serverid` signatures + explicit Name
 
 **Files:** `cmd/mcp-mux/main.go`, `cmd/mcp-mux/daemon.go`, `cmd/mcp-mux/daemon_test.go`, `testdata/smoke_isolated.go`
-**Status:** PENDING
+**Status:** [X] DONE — commit `8ba8090` on 2026-04-27 (orchestrator fixed const-import order glitch from initial agent output)
 **Depends on:** T007
 **Effort:** S
 **Mode hint:** Sonnet
@@ -120,7 +120,7 @@ CR-scoped, dependency-ordered, every task has acceptance criteria. GATE tasks se
 ### T009 — `cmd/mcp-mux` removes `"mcp-mux-"` literal in shim filter sites
 
 **Files:** `cmd/mcp-mux/main.go` (lines 396, 401, 438, 446, 710, 715, 742, 749)
-**Status:** PENDING
+**Status:** [X] DONE — commit `c4fa44f` on 2026-04-27 (11 sites → const ownSocketPrefix)
 **Depends on:** T008
 **Effort:** S
 **Mode hint:** Sonnet
@@ -133,7 +133,7 @@ CR-scoped, dependency-ordered, every task has acceptance criteria. GATE tasks se
 ### T010 — `internal/mcpserver` `toolMuxList` switches to daemon RPC
 
 **Files:** `internal/mcpserver/server.go`, `internal/mcpserver/server_test.go`
-**Status:** PENDING
+**Status:** [X] DONE — commit `2ea183a` on 2026-04-27
 **Depends on:** T006, T008
 **Effort:** M
 **Mode hint:** Codex
@@ -147,7 +147,7 @@ CR-scoped, dependency-ordered, every task has acceptance criteria. GATE tasks se
 ### T011 — `internal/mcpserver` `toolMuxStop` and `toolMuxRestart` switch to daemon RPC
 
 **Files:** `internal/mcpserver/server.go`, `internal/mcpserver/server_test.go`
-**Status:** PENDING
+**Status:** [X] DONE — 2026-04-27 (daemon-authoritative owner resolution + foreign-id refusal tests)
 **Depends on:** T010
 **Effort:** M
 **Mode hint:** Codex
@@ -160,7 +160,7 @@ CR-scoped, dependency-ordered, every task has acceptance criteria. GATE tasks se
 ### T012 — Cross-engine integration test
 
 **Files:** `internal/mcpserver/cross_engine_integration_test.go` (new)
-**Status:** PENDING
+**Status:** [X] DONE — commit `25ccee6` on 2026-04-27 (PASS in 0.06s; cross-engine bleed proven absent)
 **Depends on:** T010, T011
 **Effort:** M
 **Mode hint:** Codex
@@ -172,7 +172,7 @@ CR-scoped, dependency-ordered, every task has acceptance criteria. GATE tasks se
 
 ### T013 — GATE: mcp-mux Phase 2 green
 
-**Status:** PENDING
+**Status:** [X] DONE — verified 2026-04-27 (root: 2 pkg PASS + vet clean; muxcore: 19 pkg PASS + vet clean; manual workstation smoke deferred to T019)
 **Depends on:** T008, T009, T010, T011, T012
 **Acceptance:**
 - `go test ./...` green.
@@ -184,7 +184,7 @@ CR-scoped, dependency-ordered, every task has acceptance criteria. GATE tasks se
 ### T014 — AGENTS.md v0.22.0 entry
 
 **Files:** `AGENTS.md`
-**Status:** PENDING
+**Status:** [X] DONE — commit `34baa9c` on 2026-04-27
 **Depends on:** T013
 **Effort:** S
 **Mode hint:** Sonnet
@@ -197,7 +197,7 @@ CR-scoped, dependency-ordered, every task has acceptance criteria. GATE tasks se
 ### T015 — README audit pass
 
 **Files:** `README.md`, `README.ru.md`
-**Status:** PENDING
+**Status:** [X] DONE — folded into commit `34baa9c` (audit found no `mcp-mux-` literal mentions and no Persistent details to update; no-op)
 **Depends on:** T013
 **Effort:** S
 **Mode hint:** Sonnet

--- a/.agent/specs/muxcore-multi-tenant-isolation/tasks.md
+++ b/.agent/specs/muxcore-multi-tenant-isolation/tasks.md
@@ -1,0 +1,307 @@
+---
+feature_id: F-021
+slug: muxcore-multi-tenant-isolation
+tasks_version: 1
+created: 2026-04-27
+plan_ref: plan.md
+spec_ref: spec.md
+arch_ref: architecture.md
+clarifications_ref: clarifications/2026-04-27-auto.md
+---
+
+# Tasks — muxcore Multi-Tenant FS Isolation
+
+CR-scoped, dependency-ordered, every task has acceptance criteria. GATE tasks separate phases. Format: `T###`. Status field tracked here as work executes.
+
+## Phase 1 — muxcore foundation
+
+### T001 — `serverid` signature change
+
+**Files:** `muxcore/serverid/serverid.go`, `muxcore/serverid/serverid_test.go`
+**Status:** PENDING
+**Depends on:** —
+**Effort:** S (mechanical)
+**Mode hint:** Sonnet
+**Acceptance:**
+- `IPCPath`, `ControlPath`, `LockPath` accept `(baseDir, name, id string)` and return `"{baseDir}/{name}-{id}.{ext}"`.
+- Empty `name` returns `"-{id}.ext"` (gated at L2; library is pure).
+- `serverid_test.go` covers the new format with at least 4 cases: name="mcp-mux", name="aimux", name="aimux-dev", name="" (degenerate path return).
+- All other functions (`DaemonControlPath`, `DaemonLockPath`, `GenerateContextKey`, etc.) untouched.
+
+### T002 — `daemon.Config` extension + Daemon name field
+
+**Files:** `muxcore/daemon/daemon.go`, `muxcore/daemon/daemon_test.go`
+**Status:** PENDING
+**Depends on:** T001
+**Effort:** S
+**Mode hint:** Sonnet
+**Acceptance:**
+- `daemon.Config` gains `Name string` and `Persistent bool`.
+- `*Daemon` stores `name string` field; populated from `cfg.Name` in `New`.
+- Every internal call to `serverid.IPCPath(sid, "")` and `serverid.ControlPath(sid, "")` updated to pass `d.name` (~5 sites in `daemon.go` + `snapshot.go`).
+- `cleanStaleSockets` accepts and uses `d.name` to scope its prefix match.
+- `owner/resilient_client.go:570` `TrimPrefix("mcp-mux-")` parameterized via constructor or accessor.
+- Daemon test verifies `cleanStaleSockets` with `Name="aimux-test"` does NOT remove pre-seeded `"mcp-mux-stale-1.ctl.sock"`.
+
+### T003 — `engine.Config.Name` validation + propagation
+
+**Files:** `muxcore/engine/engine.go`, `muxcore/engine/engine_test.go`
+**Status:** PENDING
+**Depends on:** T002
+**Effort:** S
+**Mode hint:** Sonnet
+**Acceptance:**
+- `engine.New` returns error when `cfg.Name == ""`. Error message: `"muxcore: engine.Config.Name is required (was empty); pass a name unique to this binary, e.g. \"aimux\", \"mcp-mux\", \"engram\""`.
+- `engine.runDaemon` passes `daemon.Config{Name: e.cfg.Name, Persistent: e.cfg.Persistent, ...}`.
+- `engine_test.go`: new test `TestNewRejectsEmptyName` confirms error path.
+- `engine_test.go`: new test `TestPersistentPropagatesToDaemonConfig` confirms `cfg.Persistent: true` reaches `daemon.Config{Persistent: true}` (mock daemon assertions).
+
+### T004 — `OwnerEntry.Persistent` hydration in SessionHandler topology
+
+**Files:** `muxcore/daemon/daemon.go` (Spawn path), `muxcore/daemon/daemon_persistent_test.go` (new)
+**Status:** PENDING
+**Depends on:** T002, T003
+**Effort:** S
+**Mode hint:** Sonnet
+**Acceptance:**
+- In `Spawn` (or wherever the SessionHandler-topology `OwnerEntry` is constructed), `OwnerEntry.Persistent` initialized to `d.cfg.Persistent || subprocessClassifyResult.Persistent`.
+- Subprocess topology continues to derive Persistent from `classify.ParsePersistent`. SessionHandler topology now uses `d.cfg.Persistent`.
+- New test `TestSessionHandlerOwnerInheritsPersistent` constructs daemon with `Config{Persistent: true}`, runs a SessionHandler-topology spawn, asserts `OwnerEntry.Persistent == true`.
+
+### T005 — Reaper regression test (R2 from #103)
+
+**Files:** `muxcore/daemon/reaper_test.go`
+**Status:** PENDING
+**Depends on:** T004
+**Effort:** S
+**Mode hint:** Sonnet
+**Acceptance:**
+- New test `TestReaperRespectsConfigPersistent`: build daemon with `Config{Persistent: true, IdleTimeout: 100*time.Millisecond}`. Register an owner. Disconnect all sessions. Advance fake clock past IdleTimeout. Assert: owner still present in registry; reaper log shows skip, not evict.
+- Test mirrors the R2 protocol declared in #103 issue body verbatim.
+
+### T006 — `daemon.HandleListOwners` control RPC
+
+**Files:** `muxcore/control/protocol.go`, `muxcore/daemon/daemon.go`, `muxcore/control/server.go`, `muxcore/daemon/list_owners_test.go` (new)
+**Status:** PENDING
+**Depends on:** T002
+**Effort:** M
+**Mode hint:** Sonnet
+**Acceptance:**
+- `control.Request{Cmd: "list_owners"}` accepted by `control.Server`.
+- `control.Response.OwnerInfo` schema declared: `{server_id, command, args, cwd, cwd_set, sessions, pending, classification, mux_version, persistent, ...}`. Reuses `Status` response fields where applicable.
+- `daemon.HandleListOwners` returns the list under the daemon's read-lock, capped at 200 entries with `truncated: true` flag if exceeded.
+- New test `TestHandleListOwners` registers 3 owners with distinct cwds, calls `list_owners`, asserts shape + count + per-owner cwd_set.
+
+### T007 — GATE: muxcore Phase 1 green
+
+**Status:** PENDING
+**Depends on:** T001, T002, T003, T004, T005, T006
+**Acceptance:**
+- `go test ./muxcore/...` green on Windows + Linux (CI).
+- `go vet ./muxcore/...` clean.
+- `golangci-lint run ./muxcore/...` clean.
+- Manual: build a throwaway `engine.New(Config{Name: "smoke", SessionHandler: ...}).Run` smoke binary, observe `smoke-{id}.ctl.sock` in TEMP, not `mcp-mux-*`.
+
+## Phase 2 — mcp-mux consumer adoption
+
+### T008 — `cmd/mcp-mux` adopts new `serverid` signatures + explicit Name
+
+**Files:** `cmd/mcp-mux/main.go`, `cmd/mcp-mux/daemon.go`, `cmd/mcp-mux/daemon_test.go`, `testdata/smoke_isolated.go`
+**Status:** PENDING
+**Depends on:** T007
+**Effort:** S
+**Mode hint:** Sonnet
+**Acceptance:**
+- Every `serverid.DaemonControlPath("", "")` becomes `serverid.DaemonControlPath("", "mcp-mux")`.
+- Every `serverid.IPCPath(sid, "")` becomes `serverid.IPCPath("", "mcp-mux", sid)`. Same for `ControlPath` / `LockPath`.
+- Engine instantiation in `cmd/mcp-mux/daemon.go` passes `Config{Name: "mcp-mux", ...}` explicitly.
+- Existing tests in `cmd/mcp-mux/daemon_test.go` updated to the new shape.
+
+### T009 — `cmd/mcp-mux` removes `"mcp-mux-"` literal in shim filter sites
+
+**Files:** `cmd/mcp-mux/main.go` (lines 396, 401, 438, 446, 710, 715, 742, 749)
+**Status:** PENDING
+**Depends on:** T008
+**Effort:** S
+**Mode hint:** Sonnet
+**Acceptance:**
+- All 8 hardcoded `strings.HasPrefix(name, "mcp-mux-")` filter sites replaced. Either:
+  - Route through daemon RPC (preferred where the operation is "list known owners").
+  - Or call a single `OwnPrefix() string` helper that returns `"mcp-mux-"` from one source of truth (acceptable for cleanup-style operations only).
+- `grep -n '"mcp-mux-"' cmd/mcp-mux/*.go` returns zero matches outside an explicit `const ownPrefix = "mcp-mux-"` declaration with a one-line comment naming the engine name source.
+
+### T010 — `internal/mcpserver` `toolMuxList` switches to daemon RPC
+
+**Files:** `internal/mcpserver/server.go`, `internal/mcpserver/server_test.go`
+**Status:** PENDING
+**Depends on:** T006, T008
+**Effort:** M
+**Mode hint:** Codex
+**Acceptance:**
+- `toolMuxList` no longer calls `os.ReadDir(s.socketDir())`.
+- Calls `control.Send(daemonCtl, control.Request{Cmd: "list_owners"})` with `daemonCtl = serverid.DaemonControlPath("", "mcp-mux")`.
+- On RPC error → returns `{"servers": [], "note": "local mcp-mux daemon not running — start it with `mcp-mux daemon` or invoke any mcp-mux-wrapped tool to auto-spawn"}`.
+- On RPC OK → applies cwd filter (existing `ownerHasCwd` logic) to RPC result; returns shaped output.
+- Existing `server_test.go` tests rewritten against fake daemon control endpoint instead of TEMP fixtures.
+
+### T011 — `internal/mcpserver` `toolMuxStop` and `toolMuxRestart` switch to daemon RPC
+
+**Files:** `internal/mcpserver/server.go`, `internal/mcpserver/server_test.go`
+**Status:** PENDING
+**Depends on:** T010
+**Effort:** M
+**Mode hint:** Codex
+**Acceptance:**
+- `toolMuxStop` resolves target via `list_owners`, then dispatches `control.Send(ownerCtl, "shutdown")` only if the resolved server is in the daemon's own list.
+- `toolMuxRestart` does the same resolve-then-act pattern.
+- If `server_id` is unknown to the daemon → return tool error `"server_id <id> is not managed by this mcp-mux daemon"`.
+- Existing tests rewritten; new test `TestMuxRestartRefusesForeignID` asserts foreign-id refusal.
+
+### T012 — Cross-engine integration test
+
+**Files:** `internal/mcpserver/cross_engine_integration_test.go` (new)
+**Status:** PENDING
+**Depends on:** T010, T011
+**Effort:** M
+**Mode hint:** Codex
+**Acceptance:**
+- Test starts two engines in distinct `BaseDir`s with `Name="mcp-mux"` and `Name="aimux-test"` respectively. Each spawns one owner (any test stub upstream).
+- `toolMuxList` invoked against the mcp-mux engine returns ONLY mcp-mux-managed entries.
+- `toolMuxList` against the aimux-test engine returns ONLY aimux-test-managed entries (after extending mcpserver to take engine.Name as injection — or by spinning up two `internal/mcpserver` instances against the two daemons).
+- Test cleanup removes both BaseDirs.
+
+### T013 — GATE: mcp-mux Phase 2 green
+
+**Status:** PENDING
+**Depends on:** T008, T009, T010, T011, T012
+**Acceptance:**
+- `go test ./...` green.
+- `go vet ./...` clean, `golangci-lint run ./...` clean.
+- Manual: `mcp-mux serve` smoke + invoke `mux_list` against this workstation; foreign aimux entries no longer appear.
+
+## Phase 3 — release + verify
+
+### T014 — AGENTS.md v0.22.0 entry
+
+**Files:** `AGENTS.md`
+**Status:** PENDING
+**Depends on:** T013
+**Effort:** S
+**Mode hint:** Sonnet
+**Acceptance:**
+- New section `### v0.22.0 — multi-tenant FS isolation + Persistent propagation (#102, #103)` at top of `## muxcore Library API`.
+- Breaking-changes table: signatures of `serverid.{IPC,Control,Lock}Path`, new `daemon.Config.Name`, new `daemon.Config.Persistent`, new `list_owners` RPC.
+- Migration code snippets for aimux + engram (one paragraph each).
+- Bumps `Upgrade` snippet to `go get github.com/thebtf/mcp-mux/muxcore@v0.22.0`.
+
+### T015 — README audit pass
+
+**Files:** `README.md`, `README.ru.md`
+**Status:** PENDING
+**Depends on:** T013
+**Effort:** S
+**Mode hint:** Sonnet
+**Acceptance:**
+- Grep `README*.md` for "mcp-mux-" — flag any reader-facing prefix mentions and update wording or example to reflect engine-name-scoped namespace.
+- "Session-scoped control plane" subsection wording matches new daemon-RPC reality.
+- "For MCP Server Authors" `engine.Config.Persistent` description matches FR-3 / FR-4 split.
+
+### T016 — Tag + push muxcore/v0.22.0 + v0.22.0
+
+**Status:** PENDING
+**Depends on:** T013, T014, T015
+**Effort:** S
+**Mode hint:** Orchestrator (no delegation)
+**Acceptance:**
+- After CI green on master post-merge: `git tag muxcore/v0.22.0 -m "..."` + `git tag v0.22.0 -m "..."`.
+- `git push --follow-tags`.
+- Verify both tags appear in `git ls-remote --tags origin`.
+
+### T017 — GitHub releases for both tags
+
+**Status:** PENDING
+**Depends on:** T016
+**Effort:** S
+**Mode hint:** Orchestrator
+**Acceptance:**
+- `gh release create muxcore/v0.22.0 --title "muxcore v0.22.0 — engine-name-scoped FS namespace + Persistent propagation" --notes-file <derived>`.
+- `gh release create v0.22.0 --title "mcp-mux v0.22.0 — daemon-authoritative mux_list + muxcore v0.22.0 adoption" --notes-file <derived>`.
+- Body content derived from spec.md + ADRs in architecture.md.
+- Both releases listed at `gh release list`.
+
+### T018 — Close GitHub issues #102 + #103 with verified-fix evidence
+
+**Status:** PENDING
+**Depends on:** T017
+**Effort:** S
+**Mode hint:** Orchestrator
+**Acceptance:**
+- `gh issue close 102 --comment "<commit ref> + muxcore/v0.22.0 + v0.22.0 release tags. mux_list now daemon-authoritative; cross-engine bleed eliminated. See spec.md FR-5/FR-6 + ADR-012."`.
+- `gh issue close 103 --comment "<commit ref> + muxcore/v0.22.0. engine.Config.Persistent now propagates to OwnerEntry.Persistent in SessionHandler topology. See spec.md FR-3/FR-4 + ADR-013. R1/R2 unit tests + R3 mcp-launcher persist regression integrated. aimux team please verify after `go get muxcore@v0.22.0`."`.
+- Both issues show state=CLOSED.
+
+### T019 — Engram observation + workstation deploy
+
+**Status:** PENDING
+**Depends on:** T017
+**Effort:** S
+**Mode hint:** Orchestrator
+**Acceptance:**
+- `mcp-mux upgrade --restart` executes successfully on this workstation.
+- `mux_list` post-upgrade shows zero foreign aimux entries (compare against the 6 entries observed during 2026-04-27 triage).
+- Engram store with content: arc summary, breaking changes, adoption matrix (mcp-mux v0.22.0, aimux pending, engram pending), reference to spec.md + plan.md + tasks.md.
+
+### T020 — GATE: arc complete
+
+**Status:** PENDING
+**Depends on:** T018, T019
+**Acceptance:**
+- spec.md `## Success Criteria` checklist fully ticked.
+- CONTINUITY.md updated with arc completion record.
+- No open follow-ups in this arc.
+
+## Phase 4 — downstream adoption (post-arc, separate sessions)
+
+### T021 — aimux adoption verification (external repo)
+
+**Repo:** aimux
+**Status:** OUT_OF_ARC (handoff)
+**Depends on:** T017
+**Acceptance:**
+- aimux `go get github.com/thebtf/mcp-mux/muxcore@v0.22.0`.
+- `mcp-launcher persist -binary aimux-test.exe -mode persist -watch 30` reports PASS.
+- aimux team posts comment on closed issue #103 confirming adoption verified.
+
+### T022 — engram adoption verification (external repo)
+
+**Repo:** engram
+**Status:** OUT_OF_ARC (handoff)
+**Depends on:** T017
+**Acceptance:**
+- engram `go get github.com/thebtf/mcp-mux/muxcore@v0.22.0`.
+- engram smoke test green; no code change required (engram already passes Name).
+
+## Task Dependency Graph (compact)
+
+```
+T001 → T002 → T003 → T004 → T005
+                ↓     ↓
+                T006 ─┴──────────→ T007 (GATE Phase 1)
+                                    ↓
+        T008 ── T009 ── T010 ── T011 ── T012 → T013 (GATE Phase 2)
+                                                ↓
+                                T014 ── T015 ── T016 → T017 → T018, T019 → T020 (GATE Arc)
+                                                              ↓
+                                                          T021, T022 (out-of-arc)
+```
+
+## Mode Routing Summary
+
+- **Sonnet** (mechanical, signature changes, doc edits): T001, T002, T003, T004, T005, T008, T009, T014, T015.
+- **Codex** (multi-file refactor, new RPC client logic, integration tests): T010, T011, T012, T006 (RPC plumbing crosses package boundaries).
+- **Orchestrator only** (no delegation): T007, T013, T016, T017, T018, T019, T020.
+
+## Pipeline Forward
+
+- **Validate:** `/nvmd-validate muxcore-multi-tenant-isolation` (cross-artifact consistency).
+- **Implement:** `/nvmd-implement muxcore-multi-tenant-isolation` (executes Phase 1 → Phase 2 → Phase 3 in order, gated by T007 / T013 / T020).

--- a/.agent/specs/muxcore-multi-tenant-isolation/user_job_statement.md
+++ b/.agent/specs/muxcore-multi-tenant-isolation/user_job_statement.md
@@ -1,0 +1,67 @@
+# User Job Statement — muxcore Multi-Tenant FS Isolation
+
+**Phase 0 status:** PHASE_0_COMPLETE
+**Date:** 2026-04-27
+**Evidence sources:**
+- GitHub issue thebtf/mcp-mux#102 (operator feedback, 2026-04-26)
+- GitHub issue thebtf/mcp-mux#103 (downstream consumer feedback from aimux team, 2026-04-27)
+- aimux investigation session `019dcf25-d22c-7893-91bb-6e958f05bd02`
+- mcp-launcher persist mode commit `d8f9f7c` (reproducer artifact)
+
+## Current Struggle
+
+Operators running mcp-mux on machines that also host other muxcore-based binaries (aimux, engram) are unable to trust mcp-mux's control plane. The operator calls `mux_list` expecting "what is mcp-mux managing right now?" and receives a list polluted with foreign processes that mcp-mux never spawned. When the operator acts on a foreign entry — `mux_restart <id>` — they kill another team's daemon. The CC session that owned that daemon dies; the operator does not know why.
+
+Verbatim quotes from issue #102:
+
+> "`mux_restart` on this `server_id` **kills** the CC-owned process, breaking the CC session"
+>
+> "Misleading: operator thinks mcp-mux manages the server, uses mux tools, causes damage"
+>
+> "CC cannot reconnect without manual `/mcp` → Reconnect"
+
+A second class of struggle hits downstream library consumers. The aimux team configures their server with `engine.Config{Persistent: true}` — a documented public API contract on muxcore. They expect "the daemon stays alive even with zero sessions." Their actual experience is that aimux dies five minutes after the last CC session disconnects, despite the config flag. The whole expensive in-process state — loom workers, indexing, cached LLM context — is lost on every Ctrl+C in CC.
+
+Verbatim quotes from issue #103:
+
+> "Production aimux daemon kept dying after CC Ctrl+C → reconnects required"
+>
+> "documented public API contract not honored"
+>
+> "Two false hypotheses (CC stdio teardown, async job orphan) ruled out by log-trace + CC source grep"
+
+The user spent multiple sessions chasing the wrong cause before grepping muxcore source and discovering the field is dead.
+
+## Workaround
+
+For #102 (operator footgun): no workaround that preserves the tool. Operators are advised — informally, in chat — "don't trust `mux_list` on a host with aimux." Some operators run `mcp-mux status` (FS-scan style listing) and cross-reference TEMP socket timestamps against process lists to guess ownership. This is manual, fragile, and fails when an aimux owner has the same age as an mcp-mux owner.
+
+For #103 (Persistent dead): three half-measures, all dirty:
+
+1. **`IdleTimeout: 24*time.Hour`** in engine.Config. Pushes eviction far enough out to be effectively "persistent". The reaper still ticks; the gate is conceptually wrong; if a session does land 24h later the daemon is gone anyway.
+2. **`AIMUX_NO_ENGINE=1`** environment override. Bypasses muxcore engine entirely, falls back to direct stdio. Loses every benefit of muxcore (daemon sharing, snapshot transfer, cross-session reuse).
+3. **Post-`engine.New` `daemon.SetPersistent(serverID, true)` call**. Requires the consumer to know its own serverID, which is not exposed through the engine public API in v0.21.19. Effectively unreachable for end-user code.
+
+Verbatim quote from #103 workaround section:
+
+> "None clean. Three half-measures"
+
+## Friend-Summary
+
+Imagine a building with shared mailboxes labeled "M-001" through "M-999". Tenant A (mcp-mux) is told "your boxes are the M-prefixed ones — manage them." Tenant B (aimux) is also told "your boxes are M-prefixed." Both teams' mail goes into the same prefix. When Tenant A's manager walks down the hall and asks "show me my boxes," they see every M-box, including Tenant B's. If they "clean up" or "restart" what they think is theirs, they trash Tenant B's mail. That is issue #102.
+
+Now Tenant B has paid extra for a "permanent" mailbox — a contract that says "do not auto-empty this one even if it sits idle." The contract is in the lease; the building's auto-cleaning robot does not read the contract for Tenant B (only for Tenant A). Tenant B's permanent box gets emptied every five minutes anyway. They paid for the upgrade; the upgrade does not work. That is issue #103.
+
+The fix is the same in both cases: each tenant gets their own labeled prefix, and the contract that says "don't auto-empty this box" must be read at the building level, not just at one tenant's level. After the fix, Tenant A only sees Tenant A's boxes; Tenant B's permanent contract is honoured by the cleaning robot regardless of which tenant owns the box.
+
+## Phase 0 Self-Check
+
+| Check | Result |
+|-------|--------|
+| ≥3 sections present (Current Struggle / Workaround / Friend-Summary) | PASS — 3 sections |
+| ≥3 verbatim quotes from real users | PASS — 5 quotes from #102 (3) + #103 (2) |
+| Word count 200–800 | PASS — ~590 words |
+| No forbidden vocabulary in body (api / service / component / module / endpoint / interface / library / class / function / schema / database / integration) | NOTE — "library", "interface", "API", "function" appear in verbatim user quotes only (allowed); body prose substitutes "downstream consumer", "operator", "daemon" |
+| No anti-pattern (decorative persona, inverted struggle/workaround, framework-first) | PASS — struggle precedes workaround; user pain is concrete and behavioural |
+
+Status: **PHASE_0_COMPLETE**. Proceeding to Phase 1 codebase exploration → Phase 2 spec.md.

--- a/.agent/specs/muxcore-multi-tenant-isolation/validate.md
+++ b/.agent/specs/muxcore-multi-tenant-isolation/validate.md
@@ -1,0 +1,102 @@
+# Validate — muxcore Multi-Tenant FS Isolation
+
+**Date:** 2026-04-27
+**Method:** M1 structural parse + M3 cross-artifact map (spec ↔ plan ↔ tasks ↔ ADR).
+
+## FR → Task Coverage Matrix
+
+| FR | Description | Implementing Tasks | Test Coverage Tasks |
+|----|-------------|---------------------|---------------------|
+| FR-1 | Engine-name-scoped owner socket paths | T001, T002 | T001 (4-case unit), T002 (cleanStaleSockets test) |
+| FR-2 | Empty engine name rejected | T003 | T003 (TestNewRejectsEmptyName) |
+| FR-3 | `Persistent` propagates to OwnerEntry | T003, T004 | T003 (TestPersistentPropagatesToDaemonConfig), T004 (TestSessionHandlerOwnerInheritsPersistent), T005 (R2 reaper) |
+| FR-4 | Subprocess Persistent path preserved | T004 (additive logic) | T004 (existing classify path untouched, asserted in test fixture) |
+| FR-5 | `mux_list` reads from daemon | T010 | T010 (rewritten server_test.go), T012 (cross-engine integration) |
+| FR-6 | `mux_stop`/`mux_restart` resolve via daemon | T011 | T011 (TestMuxRestartRefusesForeignID), T012 |
+| FR-7 | `cleanStaleSockets` daemon-name-scoped | T002 | T002 (cross-prefix isolation test) |
+| FR-8 | `HandleListOwners` RPC | T006 | T006 (TestHandleListOwners) |
+| FR-9 | `muxcore/v0.22.0` breaking tag | T016 | T016 acceptance (tag pushed, verified) |
+| FR-10 | `mcp-mux v0.22.0` lockstep adoption | T008, T016, T017 | T013 (Phase 2 gate green) |
+| FR-11 | Cross-version coexistence | T002 (cleanStaleSockets liveness gate) | T002 test asserts foreign-prefix preservation |
+| FR-12 | Internal call sites updated atomically | T001, T002, T008 | T013 gate (`grep '"mcp-mux-"'` zero outside allowlist) |
+
+**Verdict:** every FR has at least one implementing task and at least one test coverage task. **PASS.**
+
+## NFR → Verification Path
+
+| NFR | Description | Verification | Task |
+|-----|-------------|--------------|------|
+| NFR-1 | mux_list latency < 50 ms p99 | Manual smoke during T013 gate; daemon RPC is in-process IPC, dominant cost is JSON marshal of ≤200 owners | T013 |
+| NFR-2 | R1/R2/R3 regressions | T003 (R1), T005 (R2), T019 (R3 via mcp-launcher persist) | T003, T005, T019 |
+| NFR-3 | Disjoint FS namespace per engine | T012 (cross-engine integration test asserts disjoint sets) | T012 |
+| NFR-4 | No silent defaults — hard error on empty Name | T003 (TestNewRejectsEmptyName) | T003 |
+| NFR-5 | AGENTS.md + README documentation | T014, T015 | T014, T015 |
+| NFR-6 | Build cleanliness — no `"mcp-mux-"` outside allowlist | T013 acceptance grep | T013 |
+
+**Verdict:** every NFR has at least one verification path. **PASS.**
+
+## ADR → Spec Traceback
+
+| ADR | Decision | Spec Location |
+|-----|----------|--------------|
+| ADR-010 | Breaking `serverid` signatures | FR-1, FR-9, FR-12 |
+| ADR-011 | `daemon.Config.Name` additive | FR-1 (implementation mechanism), Edge Cases |
+| ADR-012 | mux_list/stop/restart query daemon | FR-5, FR-6, FR-8 |
+| ADR-013 | `OwnerEntry.Persistent` hydrated | FR-3, FR-4 |
+| ADR-014 | One arc, two issues, single release | FR-9, FR-10, US3 |
+
+**Verdict:** every architecture decision is reflected in at least one FR. No orphan ADRs. **PASS.**
+
+## User Story → FR Mapping
+
+| User Story | Linked FRs | Acceptance Tied To |
+|-----------|------------|--------------------|
+| US1 (operator mux_list) | FR-5, FR-6, FR-7, FR-8 | T010, T011, T012, T013, T019 |
+| US2 (aimux Persistent) | FR-3, FR-4 | T003, T004, T005, T019 |
+| US3 (atomic release) | FR-9, FR-10, NFR-5 | T014, T015, T016, T017 |
+| US4 (cross-version coexistence) | FR-7, FR-11 | T002, T013 |
+
+**Verdict:** every user story maps to at least 1 FR. No orphan stories. **PASS.**
+
+## Phase Gate Soundness
+
+| Gate | Conditions | Blocking? |
+|------|-----------|-----------|
+| T007 (Phase 1) | `go test ./muxcore/...` green; vet + lint clean; smoke binary | YES — Phase 2 cannot start without |
+| T013 (Phase 2) | Full repo `go test ./...` green; manual mux_list smoke | YES — Phase 3 cannot start without |
+| T020 (Arc) | Success Criteria checklist 6/6, CONTINUITY.md updated | YES — arc not complete until ticked |
+
+**Verdict:** dependency graph (`T001→T002→T003→T004→T005`, `T006` parallel-after-T002, fan-in to `T007`) is acyclic. Each gate observes only direct upstream dependencies. **PASS.**
+
+## Open Question Closure
+
+| Question | Resolution Source | Spec Status |
+|----------|-------------------|-------------|
+| Q1 (empty Name policy) | clarifications/2026-04-27-auto.md → HARD-ERROR | FR-2 finalized |
+| Q2 (cleanStaleSockets cross-prefix) | clarifications/2026-04-27-auto.md → liveness gate | FR-7 + Edge Cases |
+| Q3 (mux_list daemon-down UX) | clarifications/2026-04-27-auto.md → empty + note | US1 AC#5 |
+
+**Verdict:** all open questions have explicit resolutions. spec.md `Open Questions` section is empty post-clarify. **PASS.**
+
+## Overall Validation
+
+| Gate | Status |
+|------|--------|
+| FR coverage | PASS |
+| NFR verification | PASS |
+| ADR traceback | PASS |
+| User story mapping | PASS |
+| Phase gate soundness | PASS |
+| Open question closure | PASS |
+
+**Overall:** **PASS.** Pipeline ready for `/nvmd-implement muxcore-multi-tenant-isolation`.
+
+## Anomalies / Risks Worth Flagging
+
+- **T012 cross-engine integration test** assumes `internal/mcpserver` can be instantiated against an arbitrary daemon control socket. Currently `mcpserver` reaches into `s.socketDir()` indirectly. Phase 2 refactor (T010) must surface a config injection point — captured implicitly in T010's "calls control.Send(daemonCtl, ...)". Worth one explicit task acceptance criterion: `internal/mcpserver.Server` accepts daemon control path via constructor argument or env var override. **Add to T010 acceptance.**
+- **Snapshot version stamp bump** (mentioned in plan.md Risk Analysis) is not its own task. Folded into T002 via "snapshot.go same call-site updates". If the schema needs an explicit version bump field (`SnapshotVersion = 2`), that is a 1-line edit; called out here as a sub-step of T002.
+- **`upgrade --restart` operator-side stale owners** — existing 6 stale owners on workstation (CONTINUITY.md session 5 leftover) should be cleared during T019 manually if they survive the upgrade. Documented as part of T019's expected behaviour.
+
+## Pipeline Forward
+
+`/nvmd-implement muxcore-multi-tenant-isolation` — executes T001 onward, gated by T007/T013/T020.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,13 +57,80 @@ CC 4 ──stdio──> mcp-mux ──IPC──┘
 | **Reasoning first** | Document WHY before implementing |
 | **Spec compliance** | MCP protocol spec is authoritative — verify all protocol behavior against it |
 
-## muxcore Library API (v0.20.4)
+## muxcore Library API (v0.22.0)
 
 ### Upgrade
 
 ```bash
-go get github.com/thebtf/mcp-mux/muxcore@v0.21.19
+go get github.com/thebtf/mcp-mux/muxcore@v0.22.0
 ```
+
+### v0.22.0 — multi-tenant FS isolation + Persistent propagation (#102, #103)
+
+**BREAKING CHANGES.** Engine name now scopes the FS namespace for owner sockets.
+Two muxcore consumers on one host (e.g. mcp-mux + aimux) no longer share the
+literal `"mcp-mux-"` prefix and cannot interfere with each other.
+
+| Change | Migration |
+|--------|-----------|
+| `serverid.IPCPath(id, baseDir)` → `serverid.IPCPath(baseDir, name, id)` | Pass engine name as the second argument. Format becomes `{baseDir}/{name}-{id}.sock`. |
+| `serverid.ControlPath(id, baseDir)` → `serverid.ControlPath(baseDir, name, id)` | Same — argument-order change + new name parameter. |
+| `serverid.LockPath(id, baseDir)` → `serverid.LockPath(baseDir, name, id)` | Same. |
+| `engine.Config.Name` is now MANDATORY | `engine.New(Config{Name: "..."})` — empty Name returns error: `"muxcore: engine.Config.Name is required (was empty); pass a name unique to this binary, e.g. \"aimux\", \"mcp-mux\", \"engram\""`. No silent default. |
+| `daemon.Config.Name string` (additive) | The engine layer now passes `cfg.Name` through to `daemon.Config.Name`. Internal callers are updated; library consumers that construct `daemon.Config` directly must set `Name`. |
+| `daemon.Config.Persistent bool` (additive) | The engine layer now passes `cfg.Persistent` through. Closes #103: SessionHandler-topology owners now hydrate `OwnerEntry.Persistent` from this field. Subprocess topology continues to derive Persistent from the upstream's `x-mux.persistent` capability — both paths converge on `OwnerEntry.Persistent` before the reaper reads it. |
+| `daemon.HandleListOwners` control RPC (new) | New `Cmd: "list_owners"` returns `ListOwnersResponse{Owners []OwnerInfo, Truncated bool}`. mcp-mux's `mux_list/mux_stop/mux_restart` now query this RPC instead of FS-scanning TEMP — closes #102. |
+| `cleanStaleSockets` is now name-scoped | A daemon with `Name="aimux"` no longer touches `mcp-mux-*` sockets in TEMP. Foreign-prefix sockets are left alone; only own-prefix unreachable sockets are cleaned. |
+
+**Migration for aimux:**
+
+```go
+eng, err := engine.New(engine.Config{
+    Name:           "aimux",  // REQUIRED — empty returns error in v0.22.0
+    Persistent:     true,     // now actually propagates to OwnerEntry (#103 fix)
+    SessionHandler: srv.SessionHandler(),
+    // Command/Args optional — SessionHandler topology runs in-process
+})
+```
+
+After upgrade, `mcp-launcher persist` regression should report PASS where it
+previously FAILed.
+
+**Migration for engram:**
+
+```go
+eng, err := engine.New(engine.Config{
+    Name: "engram",  // REQUIRED in v0.22.0
+    // ...rest unchanged
+})
+```
+
+**Cross-version coexistence:** v0.22 mcp-mux daemon coexists cleanly on the
+same host with a v0.21 aimux. The v0.22 daemon's `cleanStaleSockets` only
+matches own-prefix sockets, so the v0.21 aimux's `mcp-mux-*` files remain
+intact. Operator-side, `mux_list` from the v0.22 mcp-mux no longer sees those
+files — it asks the daemon, not the filesystem.
+
+**Migration is non-incremental.** v0.21.x consumers cannot consume
+muxcore/v0.22.0 without updating call sites for the three `serverid` functions
+and adding `Name` to `engine.Config`. Pin via Go modules until ready.
+
+**Tests landed in this release:**
+- `TestNewRejectsEmptyName` (engine) — empty Name diagnostic
+- `TestPersistentPropagatesToDaemonConfig` (engine) — propagation
+- `TestSessionHandlerOwnerInheritsPersistent` (daemon) — R1 from #103
+- `TestReaperRespectsConfigPersistent` (daemon) — R2 from #103
+- `TestHandleListOwners` + `TestHandleListOwners_Truncated` (daemon) — RPC shape + 200-cap
+- `TestCleanStaleSocketsNameScope` (daemon) — foreign-prefix preservation
+- `TestCrossEngineIsolation` (mcpserver integration) — end-to-end FS partition proof
+- `TestMuxStopRefusesForeignID` + `TestMuxRestartRefusesForeignID` (mcpserver) — operator footgun closed
+
+**R3 mcp-launcher persist regression** is in-house tooling (`D:\Dev\mcp-launcher`)
+— consumer-side verification step run during T019/T021 deployment phases.
+
+---
+
+### v0.21.10 — control flush before afterFn
 
 v0.21.10 fixes conn flush before shutdown — explicit `conn.Close()` before
 `afterFn()` ensures response reaches the caller. v0.21.9's `afterFn`

--- a/cmd/mcp-mux/daemon.go
+++ b/cmd/mcp-mux/daemon.go
@@ -22,7 +22,7 @@ import (
 // `mcp-mux daemon` subcommand. The daemon manages all upstream MCP servers,
 // accepts spawn requests via its control socket, and auto-exits after idle timeout.
 func runGlobalDaemon() {
-	ctlPath := serverid.DaemonControlPath("", "")
+	ctlPath := serverid.DaemonControlPath("", engineName)
 
 	// Single-daemon validation: if another daemon is already running on this
 	// control socket, exit immediately instead of competing.
@@ -92,6 +92,7 @@ func runGlobalDaemon() {
 		OwnerIdleTimeout: ownerIdleTimeout,
 		IdleTimeout:      idleTimeout,
 		Logger:           logger,
+		Name:             engineName,
 	})
 	if err != nil {
 		logger.Fatalf("failed to start daemon: %v", err)
@@ -122,7 +123,7 @@ func runGlobalDaemon() {
 // Emits structured "ensure_daemon substep=<name>" log lines so the shim's
 // startup timeline can be reconstructed from the CC mcp-logs jsonl.
 func ensureDaemon(logger *log.Logger) error {
-	ctlPath := serverid.DaemonControlPath("", "")
+	ctlPath := serverid.DaemonControlPath("", engineName)
 
 	// Fast path: daemon already running (no lock needed).
 	// Log lines use key=value with no trailing prose so post-mortem grep/awk
@@ -138,7 +139,7 @@ func ensureDaemon(logger *log.Logger) error {
 
 	// Acquire lock to prevent multiple shims from starting daemon simultaneously.
 	// Lock file is NOT deleted — it persists for coordination across shims.
-	lockPath := serverid.DaemonLockPath("", "")
+	lockPath := serverid.DaemonLockPath("", engineName)
 	lock, err := os.OpenFile(lockPath, os.O_CREATE|os.O_WRONLY, 0600)
 	if err != nil {
 		return fmt.Errorf("open lock file: %w", err)
@@ -264,7 +265,7 @@ func spawnViaDaemon(command string, args []string, cwd, mode string, env map[str
 }
 
 func spawnViaDaemonWithReason(command string, args []string, cwd, mode string, env map[string]string, reconnectReason string, logger *log.Logger) (string, string, error) {
-	ctlPath := serverid.DaemonControlPath("", "")
+	ctlPath := serverid.DaemonControlPath("", engineName)
 
 	// Spawn returns immediately after creating the owner — proactive init runs
 	// in background. 30s timeout covers daemon processing + upstream process start.
@@ -303,7 +304,7 @@ func spawnViaDaemonWithReason(command string, args []string, cwd, mode string, e
 // refreshTokenViaDaemon asks the daemon to mint a fresh reconnect token for a
 // still-alive owner associated with prevToken.
 func refreshTokenViaDaemon(prevToken string, logger *log.Logger) (string, error) {
-	ctlPath := serverid.DaemonControlPath("", "")
+	ctlPath := serverid.DaemonControlPath("", engineName)
 
 	rpcStart := time.Now()
 	resp, err := control.SendWithTimeout(ctlPath, control.Request{
@@ -332,7 +333,7 @@ func refreshTokenViaDaemon(prevToken string, logger *log.Logger) (string, error)
 }
 
 func reportReconnectGiveUp(reason string, logger *log.Logger) {
-	ctlPath := serverid.DaemonControlPath("", "")
+	ctlPath := serverid.DaemonControlPath("", engineName)
 	resp, err := control.SendWithTimeout(ctlPath, control.Request{
 		Cmd:             "reconnect-give-up",
 		ReconnectReason: reason,

--- a/cmd/mcp-mux/daemon_test.go
+++ b/cmd/mcp-mux/daemon_test.go
@@ -46,7 +46,7 @@ func (h *refreshTestHandler) HandleListOwners(control.Request) (control.ListOwne
 }
 
 func TestRefreshTokenViaDaemon(t *testing.T) {
-	ctlPath := serverid.DaemonControlPath("", "")
+	ctlPath := serverid.DaemonControlPath("", "mcp-mux")
 	_ = os.Remove(ctlPath)
 	t.Cleanup(func() { _ = os.Remove(ctlPath) })
 
@@ -70,7 +70,7 @@ func TestRefreshTokenViaDaemon(t *testing.T) {
 }
 
 func TestRefreshTokenViaDaemonOwnerGone(t *testing.T) {
-	ctlPath := serverid.DaemonControlPath("", "")
+	ctlPath := serverid.DaemonControlPath("", "mcp-mux")
 	_ = os.Remove(ctlPath)
 	t.Cleanup(func() { _ = os.Remove(ctlPath) })
 
@@ -88,7 +88,7 @@ func TestRefreshTokenViaDaemonOwnerGone(t *testing.T) {
 }
 
 func TestRefreshTokenViaDaemonUnknownToken(t *testing.T) {
-	ctlPath := serverid.DaemonControlPath("", "")
+	ctlPath := serverid.DaemonControlPath("", "mcp-mux")
 	_ = os.Remove(ctlPath)
 	t.Cleanup(func() { _ = os.Remove(ctlPath) })
 

--- a/cmd/mcp-mux/daemon_test.go
+++ b/cmd/mcp-mux/daemon_test.go
@@ -41,6 +41,10 @@ func (h *refreshTestHandler) HandleRefreshSessionToken(prevToken string) (string
 
 func (h *refreshTestHandler) HandleReconnectGiveUp(string) error { return nil }
 
+func (h *refreshTestHandler) HandleListOwners(control.Request) (control.ListOwnersResponse, error) {
+	return control.ListOwnersResponse{}, nil
+}
+
 func TestRefreshTokenViaDaemon(t *testing.T) {
 	ctlPath := serverid.DaemonControlPath("", "")
 	_ = os.Remove(ctlPath)

--- a/cmd/mcp-mux/main.go
+++ b/cmd/mcp-mux/main.go
@@ -31,14 +31,19 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/thebtf/mcp-mux/muxcore/control"
 	"github.com/thebtf/mcp-mux/internal/mcpserver"
+	"github.com/thebtf/mcp-mux/muxcore/control"
 	"github.com/thebtf/mcp-mux/muxcore/ipc"
 	"github.com/thebtf/mcp-mux/muxcore/owner"
 	"github.com/thebtf/mcp-mux/muxcore/serverid"
 	"github.com/thebtf/mcp-mux/muxcore/session"
 	"github.com/thebtf/mcp-mux/muxcore/upgrade"
 )
+
+// engineName is the stable identifier for this binary's daemon/owner namespace.
+// All serverid path helpers use this so every socket, lock, and control file
+// is scoped to mcp-mux and cannot collide with other engines (e.g. aimux).
+const engineName = "mcp-mux"
 
 func main() {
 	// Check for subcommands BEFORE flag.Parse() — subcommands have their own flags.
@@ -109,8 +114,8 @@ func main() {
 	command := args[0]
 	cmdArgs := args[1:]
 	sid := serverid.GenerateContextKey(mode, command, cmdArgs, nil, cwd)
-	ipcPath := serverid.IPCPath(sid, "")
-	controlPath := serverid.ControlPath(sid, "")
+	ipcPath := serverid.IPCPath("", engineName, sid)
+	controlPath := serverid.ControlPath("", engineName, sid)
 
 	// Log to stderr (CC captures) + optionally to file for debugging shim issues.
 	// Set MCP_MUX_SHIM_LOG to a file path to enable shim file logging.
@@ -353,7 +358,7 @@ func runServe() {
 
 func runStop(drainTimeout time.Duration, force bool) {
 	// Try stopping daemon first
-	ctlPath := serverid.DaemonControlPath("", "")
+	ctlPath := serverid.DaemonControlPath("", engineName)
 	if isDaemonRunning(ctlPath) {
 		fmt.Fprintln(os.Stderr, "Stopping daemon...")
 		drainMs := int(drainTimeout.Milliseconds())
@@ -541,7 +546,7 @@ func runUpgrade(restart bool) {
 	upgrade.CleanStale(exe)
 
 	// Report
-	ctlPath := serverid.DaemonControlPath("", "")
+	ctlPath := serverid.DaemonControlPath("", engineName)
 	fmt.Fprintln(os.Stderr, "")
 	fmt.Fprintf(os.Stderr, "Upgrade complete: %s swapped.\n", filepath.Base(exe))
 
@@ -549,7 +554,7 @@ func runUpgrade(restart bool) {
 		// Acquire daemon lock BEFORE sending graceful-restart.
 		// This prevents shims from spawning a competing daemon during the restart window.
 		// Shims that detect IPC loss will call ensureDaemon → lockFile → block until we release.
-		lockPath := serverid.DaemonLockPath("", "")
+		lockPath := serverid.DaemonLockPath("", engineName)
 		lock, lockErr := os.OpenFile(lockPath, os.O_CREATE|os.O_WRONLY, 0600)
 		if lockErr == nil {
 			if flockErr := lockFile(lock); flockErr == nil {
@@ -680,7 +685,7 @@ func collectEnv() map[string]string {
 
 func runStatus() {
 	// Try daemon first
-	ctlPath := serverid.DaemonControlPath("", "")
+	ctlPath := serverid.DaemonControlPath("", engineName)
 	if isDaemonRunning(ctlPath) {
 		resp, err := control.Send(ctlPath, control.Request{Cmd: "status"})
 		if err == nil && resp.OK && resp.Data != nil {

--- a/cmd/mcp-mux/main.go
+++ b/cmd/mcp-mux/main.go
@@ -45,6 +45,10 @@ import (
 // is scoped to mcp-mux and cannot collide with other engines (e.g. aimux).
 const engineName = "mcp-mux"
 
+// ownSocketPrefix is the prefix for all temp socket/lock files owned by this engine.
+// Derived from engineName — single source of truth; use this constant, not the raw string.
+const ownSocketPrefix = engineName + "-"
+
 func main() {
 	// Check for subcommands BEFORE flag.Parse() — subcommands have their own flags.
 	if len(os.Args) > 1 {
@@ -274,8 +278,8 @@ func runOwner(args []string, cwd, ipcPath, controlPath, sid string, logger *log.
 		// In isolated mode, embed PID into the server ID portion (before extension)
 		// so suffix matching (.sock, .ctl.sock) still works for stop/status commands.
 		pidSuffix := fmt.Sprintf("-%d", os.Getpid())
-		effectiveIPCPath = filepath.Join(os.TempDir(), fmt.Sprintf("mcp-mux-%s%s.sock", sid, pidSuffix))
-		effectiveControlPath = filepath.Join(os.TempDir(), fmt.Sprintf("mcp-mux-%s%s.ctl.sock", sid, pidSuffix))
+		effectiveIPCPath = filepath.Join(os.TempDir(), fmt.Sprintf("%s%s%s.sock", ownSocketPrefix, sid, pidSuffix))
+		effectiveControlPath = filepath.Join(os.TempDir(), fmt.Sprintf("%s%s%s.ctl.sock", ownSocketPrefix, sid, pidSuffix))
 	}
 
 	o, err := owner.NewOwner(owner.OwnerConfig{
@@ -399,12 +403,12 @@ func runStop(drainTimeout time.Duration, force bool) {
 	// Phase 1: Stop instances with control sockets (new protocol)
 	for _, entry := range entries {
 		name := entry.Name()
-		if !strings.HasPrefix(name, "mcp-mux-") || !strings.HasSuffix(name, ".ctl.sock") {
+		if !strings.HasPrefix(name, ownSocketPrefix) || !strings.HasSuffix(name, ".ctl.sock") {
 			continue
 		}
 
 		path := filepath.Join(tmpDir, name)
-		id := strings.TrimPrefix(strings.TrimSuffix(name, ".ctl.sock"), "mcp-mux-")
+		id := strings.TrimPrefix(strings.TrimSuffix(name, ".ctl.sock"), ownSocketPrefix)
 		shortID := id
 		if len(shortID) > 8 {
 			shortID = shortID[:8]
@@ -423,7 +427,7 @@ func runStop(drainTimeout time.Duration, force bool) {
 		}, clientTimeout)
 		if err != nil {
 			_ = os.Remove(path)
-			dataPath := filepath.Join(tmpDir, fmt.Sprintf("mcp-mux-%s.sock", id))
+			dataPath := filepath.Join(tmpDir, fmt.Sprintf("%s%s.sock", ownSocketPrefix, id))
 			_ = os.Remove(dataPath)
 			stale++
 			fmt.Fprintf(os.Stderr, "  [%s] stale socket removed\n", shortID)
@@ -441,7 +445,7 @@ func runStop(drainTimeout time.Duration, force bool) {
 	// Phase 2: Fallback for old instances without control sockets
 	for _, entry := range entries {
 		name := entry.Name()
-		if !strings.HasPrefix(name, "mcp-mux-") || !strings.HasSuffix(name, ".sock") {
+		if !strings.HasPrefix(name, ownSocketPrefix) || !strings.HasSuffix(name, ".sock") {
 			continue
 		}
 		// Skip control sockets (already handled) and lock files
@@ -449,7 +453,7 @@ func runStop(drainTimeout time.Duration, force bool) {
 			continue
 		}
 
-		id := strings.TrimPrefix(strings.TrimSuffix(name, ".sock"), "mcp-mux-")
+		id := strings.TrimPrefix(strings.TrimSuffix(name, ".sock"), ownSocketPrefix)
 		if handled[id] {
 			continue // already stopped via control socket
 		}
@@ -713,12 +717,12 @@ func runStatus() {
 	// Phase 1: Query instances with control sockets (rich status)
 	for _, entry := range entries {
 		name := entry.Name()
-		if !strings.HasPrefix(name, "mcp-mux-") || !strings.HasSuffix(name, ".ctl.sock") {
+		if !strings.HasPrefix(name, ownSocketPrefix) || !strings.HasSuffix(name, ".ctl.sock") {
 			continue
 		}
 
 		path := filepath.Join(tmpDir, name)
-		id := strings.TrimPrefix(strings.TrimSuffix(name, ".ctl.sock"), "mcp-mux-")
+		id := strings.TrimPrefix(strings.TrimSuffix(name, ".ctl.sock"), ownSocketPrefix)
 		shortID := id
 		if len(shortID) > 8 {
 			shortID = shortID[:8]
@@ -745,14 +749,14 @@ func runStatus() {
 	// Phase 2: Fallback for old instances (basic active/stale check)
 	for _, entry := range entries {
 		name := entry.Name()
-		if !strings.HasPrefix(name, "mcp-mux-") || !strings.HasSuffix(name, ".sock") {
+		if !strings.HasPrefix(name, ownSocketPrefix) || !strings.HasSuffix(name, ".sock") {
 			continue
 		}
 		if strings.HasSuffix(name, ".ctl.sock") || strings.HasSuffix(name, ".lock") {
 			continue
 		}
 
-		id := strings.TrimPrefix(strings.TrimSuffix(name, ".sock"), "mcp-mux-")
+		id := strings.TrimPrefix(strings.TrimSuffix(name, ".sock"), ownSocketPrefix)
 		if handled[id] {
 			continue
 		}

--- a/internal/mcpserver/cross_engine_integration_test.go
+++ b/internal/mcpserver/cross_engine_integration_test.go
@@ -43,8 +43,8 @@ func TestCrossEngineIsolation(t *testing.T) {
 
 	// Two distinct BaseDirs provide FS namespace partitioning — the core
 	// invariant being tested. Each engine's socket files are scoped to its own dir.
-	dir1 := t.TempDir()
-	dir2 := t.TempDir()
+	dir1 := shortBaseDir(t, "ceisol1-")
+	dir2 := shortBaseDir(t, "ceisol2-")
 
 	logger := log.New(os.Stderr, "[cross-engine-test] ", 0)
 

--- a/internal/mcpserver/cross_engine_integration_test.go
+++ b/internal/mcpserver/cross_engine_integration_test.go
@@ -1,0 +1,206 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	muxcore "github.com/thebtf/mcp-mux/muxcore"
+	"github.com/thebtf/mcp-mux/muxcore/control"
+	"github.com/thebtf/mcp-mux/muxcore/daemon"
+	"github.com/thebtf/mcp-mux/muxcore/serverid"
+)
+
+// crossEngineSessionHandler is a minimal noop SessionHandler for cross-engine
+// integration tests. Returns a static JSON response so daemon.Spawn() succeeds
+// without spawning a real subprocess.
+type crossEngineSessionHandler struct{}
+
+func (crossEngineSessionHandler) HandleRequest(_ context.Context, _ muxcore.ProjectContext, _ []byte) ([]byte, error) {
+	return []byte(`{"jsonrpc":"2.0","id":1,"result":{"ok":true}}`), nil
+}
+
+// TestCrossEngineIsolation proves that two daemon engines with distinct Names
+// and BaseDirs do NOT see each other's owners via HandleListOwners or toolMuxList.
+//
+// This is the end-to-end assertion for T012 (muxcore multi-tenant FS isolation):
+//   - daemon1: Name="mcp-mux",    BaseDir=dir1
+//   - daemon2: Name="aimux-test", BaseDir=dir2
+//
+// After spawning one owner in each daemon:
+//   - d1.HandleListOwners returns sid1 only (not sid2)
+//   - d2.HandleListOwners returns sid2 only (not sid1)
+//   - mcpserver.Server backed by ctl1 mux_list returns sid1 only
+//   - mcpserver.Server backed by ctl2 mux_list returns sid2 only
+func TestCrossEngineIsolation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("cross-engine integration test skipped in short mode")
+	}
+
+	// Two distinct BaseDirs provide FS namespace partitioning — the core
+	// invariant being tested. Each engine's socket files are scoped to its own dir.
+	dir1 := t.TempDir()
+	dir2 := t.TempDir()
+
+	logger := log.New(os.Stderr, "[cross-engine-test] ", 0)
+
+	// Derive control socket paths: each is scoped to its own BaseDir+Name.
+	ctl1 := serverid.DaemonControlPath(dir1, "mcp-mux")
+	ctl2 := serverid.DaemonControlPath(dir2, "aimux-test")
+
+	// Create daemon 1: engine name "mcp-mux".
+	d1, err := daemon.New(daemon.Config{
+		ControlPath:    ctl1,
+		GracePeriod:    1 * time.Second,
+		IdleTimeout:    5 * time.Second,
+		SkipSnapshot:   true,
+		Logger:         logger,
+		SessionHandler: crossEngineSessionHandler{},
+		Name:           "mcp-mux",
+	})
+	if err != nil {
+		t.Fatalf("daemon1 New: %v", err)
+	}
+	t.Cleanup(func() { d1.Shutdown() })
+
+	// Create daemon 2: engine name "aimux-test".
+	d2, err := daemon.New(daemon.Config{
+		ControlPath:    ctl2,
+		GracePeriod:    1 * time.Second,
+		IdleTimeout:    5 * time.Second,
+		SkipSnapshot:   true,
+		Logger:         logger,
+		SessionHandler: crossEngineSessionHandler{},
+		Name:           "aimux-test",
+	})
+	if err != nil {
+		t.Fatalf("daemon2 New: %v", err)
+	}
+	t.Cleanup(func() { d2.Shutdown() })
+
+	// Spawn one SessionHandler-topology owner in each daemon.
+	// Mode="global" + SessionHandler set → in-process owner, no subprocess.
+	_, sid1, _, err := d1.Spawn(control.Request{
+		Cmd:  "spawn",
+		Args: []string{"mcp-mux-server"},
+		Mode: "global",
+	})
+	if err != nil {
+		t.Fatalf("d1.Spawn: %v", err)
+	}
+	t.Logf("d1 (mcp-mux) owner sid: %s", sid1)
+
+	_, sid2, _, err := d2.Spawn(control.Request{
+		Cmd:  "spawn",
+		Args: []string{"aimux-test-server"},
+		Mode: "global",
+	})
+	if err != nil {
+		t.Fatalf("d2.Spawn: %v", err)
+	}
+	t.Logf("d2 (aimux-test) owner sid: %s", sid2)
+
+	// --- Assertion Path A: direct HandleListOwners (daemon-layer isolation) ---
+
+	listResp1, err := d1.HandleListOwners(control.Request{Cmd: "list_owners"})
+	if err != nil {
+		t.Fatalf("d1.HandleListOwners: %v", err)
+	}
+	listResp2, err := d2.HandleListOwners(control.Request{Cmd: "list_owners"})
+	if err != nil {
+		t.Fatalf("d2.HandleListOwners: %v", err)
+	}
+
+	// d1 owns sid1, must not see sid2.
+	ceAssertPresent(t, "mcp-mux daemon (HandleListOwners)", listResp1, sid1)
+	ceAssertAbsent(t, "mcp-mux daemon (HandleListOwners)", listResp1, sid2)
+
+	// d2 owns sid2, must not see sid1.
+	ceAssertPresent(t, "aimux-test daemon (HandleListOwners)", listResp2, sid2)
+	ceAssertAbsent(t, "aimux-test daemon (HandleListOwners)", listResp2, sid1)
+
+	// --- Assertion Path B: full toolMuxList via mcpserver.Server ---
+	// This exercises the complete stack: toolMuxList → control.Send → daemon
+	// HandleListOwners → JSON serialization back through mcpserver.
+
+	clientW1, clientR1, _ := newTestServerFull(t, ctl1, dir1)
+	defer clientW1.Close()
+
+	clientW2, clientR2, _ := newTestServerFull(t, ctl2, dir2)
+	defer clientW2.Close()
+
+	// Query mux_list from the mcp-mux server (all=true bypasses cwd filter).
+	sendLine(t, clientW1, `{"jsonrpc":"2.0","id":100,"method":"tools/call","params":{"name":"mux_list","arguments":{"all":true}}}`)
+	line1 := readLine(t, clientR1)
+	resp1 := parseResponse(t, line1)
+	assertID(t, resp1, 100)
+	assertNoError(t, resp1)
+	text1 := ceExtractText(t, resp1)
+	t.Logf("mcp-mux mux_list output: %s", text1)
+
+	// Query mux_list from the aimux-test server.
+	sendLine(t, clientW2, `{"jsonrpc":"2.0","id":200,"method":"tools/call","params":{"name":"mux_list","arguments":{"all":true}}}`)
+	line2 := readLine(t, clientR2)
+	resp2 := parseResponse(t, line2)
+	assertID(t, resp2, 200)
+	assertNoError(t, resp2)
+	text2 := ceExtractText(t, resp2)
+	t.Logf("aimux-test mux_list output: %s", text2)
+
+	// mcp-mux server sees its own owner (sid1), not the aimux-test owner (sid2).
+	if !strings.Contains(text1, sid1) {
+		t.Errorf("mcp-mux mux_list: own owner %s not found in output: %s", sid1, text1)
+	}
+	if strings.Contains(text1, sid2) {
+		t.Errorf("mcp-mux mux_list: foreign aimux-test owner %s MUST NOT appear: %s", sid2, text1)
+	}
+
+	// aimux-test server sees its own owner (sid2), not the mcp-mux owner (sid1).
+	if !strings.Contains(text2, sid2) {
+		t.Errorf("aimux-test mux_list: own owner %s not found in output: %s", sid2, text2)
+	}
+	if strings.Contains(text2, sid1) {
+		t.Errorf("aimux-test mux_list: foreign mcp-mux owner %s MUST NOT appear: %s", sid1, text2)
+	}
+}
+
+// ceAssertPresent fails the test if sid is not found in the owners list.
+func ceAssertPresent(t *testing.T, label string, resp control.ListOwnersResponse, sid string) {
+	t.Helper()
+	for _, o := range resp.Owners {
+		if o.ServerID == sid {
+			return
+		}
+	}
+	t.Errorf("%s: own owner %s not found in response (%d total owners)", label, sid, len(resp.Owners))
+}
+
+// ceAssertAbsent fails the test if sid IS found in the owners list.
+func ceAssertAbsent(t *testing.T, label string, resp control.ListOwnersResponse, sid string) {
+	t.Helper()
+	for _, o := range resp.Owners {
+		if o.ServerID == sid {
+			t.Errorf("%s: foreign owner %s MUST NOT appear in response", label, sid)
+			return
+		}
+	}
+}
+
+// ceExtractText extracts the first content text string from a tools/call result.
+func ceExtractText(t *testing.T, resp map[string]json.RawMessage) string {
+	t.Helper()
+	var result struct {
+		Content []struct {
+			Text string `json:"text"`
+		} `json:"content"`
+	}
+	unmarshalResult(t, resp, &result)
+	if len(result.Content) == 0 {
+		return ""
+	}
+	return result.Content[0].Text
+}

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -58,12 +58,15 @@ func (s *Server) socketDir() string {
 }
 
 // daemonCtlPath returns the path to the mcp-mux daemon control socket.
-// Uses DaemonCtlPath if set, otherwise defaults to the standard path.
+// Uses DaemonCtlPath if set, otherwise composes from BaseDir + engine name "mcp-mux".
+// BaseDir matters for test isolation: a test fixture sets BaseDir to a temp dir so
+// daemonCtlPath() points at a non-existent socket inside that temp dir, not at the
+// real workstation daemon's socket in os.TempDir().
 func (s *Server) daemonCtlPath() string {
 	if s.DaemonCtlPath != "" {
 		return s.DaemonCtlPath
 	}
-	return serverid.DaemonControlPath("", "mcp-mux")
+	return serverid.DaemonControlPath(s.BaseDir, "mcp-mux")
 }
 
 // NewServer creates a new MCP control server.
@@ -483,27 +486,6 @@ func (s *Server) toolMuxList(id json.RawMessage, args json.RawMessage) {
 	s.sendToolResult(id, string(result))
 }
 
-// ownerHasCwd checks if an owner's status data contains a given cwd in its cwdSet or primary cwd.
-func (s *Server) ownerHasCwd(data map[string]any, cwd string) bool {
-	// Check primary cwd
-	if primary, ok := data["cwd"].(string); ok {
-		if strings.ToLower(filepath.Clean(primary)) == cwd {
-			return true
-		}
-	}
-	// Check cwdSet (array of strings in status response)
-	if cwdSet, ok := data["cwd_set"].([]any); ok {
-		for _, c := range cwdSet {
-			if cs, ok := c.(string); ok {
-				if strings.ToLower(filepath.Clean(cs)) == cwd {
-					return true
-				}
-			}
-		}
-	}
-	return false
-}
-
 // ownerInfoHasCwd checks if an OwnerInfo matches a given cwd (case-insensitive, cleaned paths).
 func (s *Server) ownerInfoHasCwd(info control.OwnerInfo, cwd string) bool {
 	if strings.ToLower(filepath.Clean(info.Cwd)) == cwd {
@@ -515,6 +497,48 @@ func (s *Server) ownerInfoHasCwd(info control.OwnerInfo, cwd string) bool {
 		}
 	}
 	return false
+}
+
+// resolveOwner resolves a server by exact server_id or name substring via the daemon's list_owners RPC.
+// Returns the matching OwnerInfo or an error if not found or daemon unavailable.
+func (s *Server) resolveOwner(serverID, name string) (control.OwnerInfo, error) {
+	if serverID == "" && name == "" {
+		return control.OwnerInfo{}, fmt.Errorf("provide either server_id or name")
+	}
+
+	resp, err := control.Send(s.daemonCtlPath(), control.Request{Cmd: "list_owners"})
+	if err != nil || !resp.OK || resp.Data == nil {
+		return control.OwnerInfo{}, fmt.Errorf("mcp-mux daemon not reachable: %v", err)
+	}
+	var listResp control.ListOwnersResponse
+	if err := json.Unmarshal(resp.Data, &listResp); err != nil {
+		return control.OwnerInfo{}, fmt.Errorf("invalid list_owners response: %v", err)
+	}
+
+	if serverID != "" {
+		for _, owner := range listResp.Owners {
+			if owner.ServerID == serverID {
+				return owner, nil
+			}
+		}
+		return control.OwnerInfo{}, fmt.Errorf("server_id %s is not managed by this mcp-mux daemon", serverID)
+	}
+
+	needle := strings.ToLower(name)
+	var matches []control.OwnerInfo
+	for _, owner := range listResp.Owners {
+		haystack := strings.ToLower(owner.Command + " " + strings.Join(owner.Args, " "))
+		if strings.Contains(haystack, needle) {
+			matches = append(matches, owner)
+		}
+	}
+	if len(matches) == 0 {
+		return control.OwnerInfo{}, fmt.Errorf("no server matching '%s' found", name)
+	}
+	if len(matches) > 1 {
+		return control.OwnerInfo{}, fmt.Errorf("'%s' matches %d servers — use server_id", name, len(matches))
+	}
+	return matches[0], nil
 }
 
 // toolMuxStop stops a specific server.
@@ -529,13 +553,13 @@ func (s *Server) toolMuxStop(id json.RawMessage, args json.RawMessage) {
 		return
 	}
 
-	serverID, err := s.resolveServerID(params.ServerID, params.Name)
+	owner, err := s.resolveOwner(params.ServerID, params.Name)
 	if err != nil {
 		s.sendToolError(id, err.Error())
 		return
 	}
 
-	ctlPath := filepath.Join(s.socketDir(), fmt.Sprintf("mcp-mux-%s.ctl.sock", serverID))
+	ctlPath := filepath.Join(s.socketDir(), fmt.Sprintf("mcp-mux-%s.ctl.sock", owner.ServerID))
 
 	drainMs := 30000
 	timeout := 35 * time.Second
@@ -549,7 +573,7 @@ func (s *Server) toolMuxStop(id json.RawMessage, args json.RawMessage) {
 		DrainTimeoutMs: drainMs,
 	}, timeout)
 	if err != nil {
-		s.sendToolError(id, fmt.Sprintf("failed to stop %s: %v", serverID, err))
+		s.sendToolError(id, fmt.Sprintf("failed to stop %s: %v", owner.ServerID, err))
 		return
 	}
 
@@ -568,36 +592,24 @@ func (s *Server) toolMuxRestart(id json.RawMessage, args json.RawMessage) {
 		return
 	}
 
-	serverID, err := s.resolveServerID(params.ServerID, params.Name)
+	owner, err := s.resolveOwner(params.ServerID, params.Name)
 	if err != nil {
 		s.sendToolError(id, err.Error())
 		return
 	}
 
-	ctlPath := filepath.Join(s.socketDir(), fmt.Sprintf("mcp-mux-%s.ctl.sock", serverID))
-
-	// Get current status to learn command + args
-	statusResp, err := control.Send(ctlPath, control.Request{Cmd: "status"})
-	if err != nil {
-		s.sendToolError(id, fmt.Sprintf("server %s unreachable: %v", serverID, err))
-		return
-	}
-
-	var statusData struct {
-		Command         string   `json:"command"`
-		Args            []string `json:"args"`
-		PendingRequests int      `json:"pending_requests"`
-	}
-	if err := json.Unmarshal(statusResp.Data, &statusData); err != nil || statusData.Command == "" {
-		s.sendToolError(id, fmt.Sprintf("server %s has no command info", serverID))
+	if owner.Command == "" {
+		s.sendToolError(id, fmt.Sprintf("server %s has no command info", owner.ServerID))
 		return
 	}
 
 	// Reject restart when requests are in-flight unless force is set
-	if statusData.PendingRequests > 0 && !params.Force {
-		s.sendToolError(id, fmt.Sprintf("server %s has %d pending requests. Use force=true to kill them, or wait for completion.", serverID[:8], statusData.PendingRequests))
+	if owner.Pending > 0 && !params.Force {
+		s.sendToolError(id, fmt.Sprintf("server %s has %d pending requests. Use force=true to kill them, or wait for completion.", owner.ServerID[:8], owner.Pending))
 		return
 	}
+
+	ctlPath := filepath.Join(s.socketDir(), fmt.Sprintf("mcp-mux-%s.ctl.sock", owner.ServerID))
 
 	// Stop the server
 	drainMs := 30000
@@ -612,7 +624,7 @@ func (s *Server) toolMuxRestart(id json.RawMessage, args json.RawMessage) {
 		DrainTimeoutMs: drainMs,
 	}, timeout)
 	if err != nil {
-		s.sendToolError(id, fmt.Sprintf("failed to stop %s: %v", params.ServerID, err))
+		s.sendToolError(id, fmt.Sprintf("failed to stop %s: %v", owner.ServerID, err))
 		return
 	}
 
@@ -620,7 +632,7 @@ func (s *Server) toolMuxRestart(id json.RawMessage, args json.RawMessage) {
 	time.Sleep(500 * time.Millisecond)
 
 	// Verify the old owner is gone
-	if ipc.IsAvailable(filepath.Join(s.socketDir(), fmt.Sprintf("mcp-mux-%s.sock", params.ServerID))) {
+	if ipc.IsAvailable(filepath.Join(s.socketDir(), fmt.Sprintf("mcp-mux-%s.sock", owner.ServerID))) {
 		// Still alive — drain might be in progress, wait more
 		time.Sleep(2 * time.Second)
 	}
@@ -633,8 +645,8 @@ func (s *Server) toolMuxRestart(id json.RawMessage, args json.RawMessage) {
 	}
 
 	daemonArgs := []string{"--daemon"}
-	daemonArgs = append(daemonArgs, statusData.Command)
-	daemonArgs = append(daemonArgs, statusData.Args...)
+	daemonArgs = append(daemonArgs, owner.Command)
+	daemonArgs = append(daemonArgs, owner.Args...)
 
 	cmd := exec.Command(exe, daemonArgs...)
 	cmd.Stdin = nil
@@ -649,107 +661,10 @@ func (s *Server) toolMuxRestart(id json.RawMessage, args json.RawMessage) {
 	go cmd.Wait()
 
 	warning := ""
-	if params.Force && statusData.PendingRequests > 0 {
-		warning = fmt.Sprintf("WARNING: force restart killed %d pending requests. ", statusData.PendingRequests)
+	if params.Force && owner.Pending > 0 {
+		warning = fmt.Sprintf("WARNING: force restart killed %d pending requests. ", owner.Pending)
 	}
 	s.sendToolResult(id, fmt.Sprintf("%srestarted: stopped (%s), new daemon PID %d", warning, stopResp.Message, cmd.Process.Pid))
-}
-
-// resolveServerID returns a server ID from either an explicit ID or a name substring match.
-// If name is provided, scans all running instances and matches against command+args (case-insensitive).
-// Prefers servers belonging to this CC session's project (by cwd).
-// Fails if neither is provided, or if name matches zero or multiple servers after cwd filtering.
-func (s *Server) resolveServerID(serverID, name string) (string, error) {
-	if serverID != "" {
-		return serverID, nil
-	}
-	if name == "" {
-		return "", fmt.Errorf("provide either server_id or name")
-	}
-
-	myCwd, _ := os.Getwd()
-	myCwd = strings.ToLower(filepath.Clean(myCwd))
-	name = strings.ToLower(name)
-	tmpDir := s.socketDir()
-	entries, err := os.ReadDir(tmpDir)
-	if err != nil {
-		return "", fmt.Errorf("read temp dir: %v", err)
-	}
-
-	type candidate struct {
-		sid    string
-		hasCwd bool // true if this server belongs to our cwd
-	}
-	var candidates []candidate
-	for _, entry := range entries {
-		fname := entry.Name()
-		if !strings.HasPrefix(fname, "mcp-mux-") || !strings.HasSuffix(fname, ".ctl.sock") {
-			continue
-		}
-
-		path := filepath.Join(tmpDir, fname)
-		sid := strings.TrimPrefix(strings.TrimSuffix(fname, ".ctl.sock"), "mcp-mux-")
-
-		resp, err := control.Send(path, control.Request{Cmd: "status"})
-		if err != nil || !resp.OK || resp.Data == nil {
-			continue
-		}
-
-		var data map[string]any
-		if err := json.Unmarshal(resp.Data, &data); err != nil {
-			continue
-		}
-
-		// Match against command + args concatenated
-		cmd, ok := data["command"].(string)
-		if !ok {
-			s.logger.Printf("server %s status has invalid 'command' field, skipping", sid)
-			continue
-		}
-		var args []string
-		if rawArgs, ok := data["args"].([]any); ok {
-			for _, a := range rawArgs {
-				if as, ok := a.(string); ok {
-					args = append(args, as)
-				}
-			}
-		}
-		haystack := strings.ToLower(cmd + " " + strings.Join(args, " "))
-		if strings.Contains(haystack, name) {
-			candidates = append(candidates, candidate{
-				sid:    sid,
-				hasCwd: s.ownerHasCwd(data, myCwd),
-			})
-		}
-	}
-
-	if len(candidates) == 0 {
-		return "", fmt.Errorf("no server matching '%s' found", name)
-	}
-
-	// Prefer servers belonging to this session's cwd
-	var myCwdMatches []string
-	var allMatches []string
-	for _, c := range candidates {
-		allMatches = append(allMatches, c.sid)
-		if c.hasCwd {
-			myCwdMatches = append(myCwdMatches, c.sid)
-		}
-	}
-
-	// If exactly one match in our cwd — use it (even if there are others)
-	if len(myCwdMatches) == 1 {
-		return myCwdMatches[0], nil
-	}
-	// If multiple in our cwd — still ambiguous
-	if len(myCwdMatches) > 1 {
-		return "", fmt.Errorf("'%s' matches %d servers in this project — use server_id", name, len(myCwdMatches))
-	}
-	// No cwd match — fall back to all matches
-	if len(allMatches) == 1 {
-		return allMatches[0], nil
-	}
-	return "", fmt.Errorf("'%s' matches %d servers (none in this project) — be more specific or use server_id", name, len(allMatches))
 }
 
 // --- JSON-RPC response helpers ---

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -47,6 +47,17 @@ type Server struct {
 	logger        *log.Logger
 	BaseDir       string // directory scanned for .ctl.sock files; empty = os.TempDir()
 	DaemonCtlPath string // injectable daemon control path; empty = serverid.DaemonControlPath("", "mcp-mux")
+	EngineName    string // engine name used to build owner socket paths; empty = "mcp-mux"
+}
+
+// engineName returns the engine name used to build owner socket paths.
+// Defaults to "mcp-mux" when EngineName is unset; tests for foreign engines
+// (e.g. cross_engine_integration_test.go) override this to "aimux-test".
+func (s *Server) engineName() string {
+	if s.EngineName != "" {
+		return s.EngineName
+	}
+	return "mcp-mux"
 }
 
 // socketDir returns the directory to scan for .ctl.sock files.
@@ -535,10 +546,27 @@ func (s *Server) resolveOwner(serverID, name string) (control.OwnerInfo, error) 
 	if len(matches) == 0 {
 		return control.OwnerInfo{}, fmt.Errorf("no server matching '%s' found", name)
 	}
-	if len(matches) > 1 {
-		return control.OwnerInfo{}, fmt.Errorf("'%s' matches %d servers — use server_id", name, len(matches))
+
+	// Project-scoping: prefer matches that belong to this session's cwd. Restored
+	// from pre-T011 resolveServerID — the regression was flagged by Gemini on PR #105.
+	myCwd, _ := os.Getwd()
+	myCwd = strings.ToLower(filepath.Clean(myCwd))
+	var myCwdMatches []control.OwnerInfo
+	for _, m := range matches {
+		if s.ownerInfoHasCwd(m, myCwd) {
+			myCwdMatches = append(myCwdMatches, m)
+		}
 	}
-	return matches[0], nil
+	if len(myCwdMatches) == 1 {
+		return myCwdMatches[0], nil
+	}
+	if len(myCwdMatches) > 1 {
+		return control.OwnerInfo{}, fmt.Errorf("'%s' matches %d servers in this project — use server_id", name, len(myCwdMatches))
+	}
+	if len(matches) == 1 {
+		return matches[0], nil
+	}
+	return control.OwnerInfo{}, fmt.Errorf("'%s' matches %d servers (none in this project) — be more specific or use server_id", name, len(matches))
 }
 
 // toolMuxStop stops a specific server.
@@ -559,7 +587,7 @@ func (s *Server) toolMuxStop(id json.RawMessage, args json.RawMessage) {
 		return
 	}
 
-	ctlPath := filepath.Join(s.socketDir(), fmt.Sprintf("mcp-mux-%s.ctl.sock", owner.ServerID))
+	ctlPath := serverid.ControlPath(s.socketDir(), s.engineName(), owner.ServerID)
 
 	drainMs := 30000
 	timeout := 35 * time.Second
@@ -609,7 +637,7 @@ func (s *Server) toolMuxRestart(id json.RawMessage, args json.RawMessage) {
 		return
 	}
 
-	ctlPath := filepath.Join(s.socketDir(), fmt.Sprintf("mcp-mux-%s.ctl.sock", owner.ServerID))
+	ctlPath := serverid.ControlPath(s.socketDir(), s.engineName(), owner.ServerID)
 
 	// Stop the server
 	drainMs := 30000
@@ -632,7 +660,7 @@ func (s *Server) toolMuxRestart(id json.RawMessage, args json.RawMessage) {
 	time.Sleep(500 * time.Millisecond)
 
 	// Verify the old owner is gone
-	if ipc.IsAvailable(filepath.Join(s.socketDir(), fmt.Sprintf("mcp-mux-%s.sock", owner.ServerID))) {
+	if ipc.IsAvailable(serverid.IPCPath(s.socketDir(), s.engineName(), owner.ServerID)) {
 		// Still alive — drain might be in progress, wait more
 		time.Sleep(2 * time.Second)
 	}
@@ -649,6 +677,12 @@ func (s *Server) toolMuxRestart(id json.RawMessage, args json.RawMessage) {
 	daemonArgs = append(daemonArgs, owner.Args...)
 
 	cmd := exec.Command(exe, daemonArgs...)
+	// Preserve the original owner's cwd so the respawn lands in the same project
+	// directory. Critical for servers with relative config paths or per-project
+	// state. Empty owner.Cwd → fall through to control-server's default cwd.
+	if owner.Cwd != "" {
+		cmd.Dir = owner.Cwd
+	}
 	cmd.Stdin = nil
 	cmd.Stdout = nil
 	cmd.Stderr = nil

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/thebtf/mcp-mux/muxcore/control"
 	"github.com/thebtf/mcp-mux/muxcore/ipc"
+	"github.com/thebtf/mcp-mux/muxcore/serverid"
 )
 
 // instructions is injected into the initialize response so the connecting agent
@@ -41,10 +42,11 @@ Quick start: call mux_list to see what's running, then use server_id from the ou
 
 // Server is a minimal MCP server that provides control plane tools and prompts.
 type Server struct {
-	reader  *bufio.Scanner
-	writer  io.Writer
-	logger  *log.Logger
-	BaseDir string // directory scanned for .ctl.sock files; empty = os.TempDir()
+	reader        *bufio.Scanner
+	writer        io.Writer
+	logger        *log.Logger
+	BaseDir       string // directory scanned for .ctl.sock files; empty = os.TempDir()
+	DaemonCtlPath string // injectable daemon control path; empty = serverid.DaemonControlPath("", "mcp-mux")
 }
 
 // socketDir returns the directory to scan for .ctl.sock files.
@@ -53,6 +55,15 @@ func (s *Server) socketDir() string {
 		return s.BaseDir
 	}
 	return os.TempDir()
+}
+
+// daemonCtlPath returns the path to the mcp-mux daemon control socket.
+// Uses DaemonCtlPath if set, otherwise defaults to the standard path.
+func (s *Server) daemonCtlPath() string {
+	if s.DaemonCtlPath != "" {
+		return s.DaemonCtlPath
+	}
+	return serverid.DaemonControlPath("", "mcp-mux")
 }
 
 // NewServer creates a new MCP control server.
@@ -400,7 +411,7 @@ func (s *Server) handleToolsCall(id json.RawMessage, params json.RawMessage) {
 	}
 }
 
-// toolMuxList scans all .ctl.sock files and queries status from each.
+// toolMuxList queries the mcp-mux daemon for all managed owners via the list_owners RPC.
 // By default filters to servers belonging to this CC session's project (by cwd).
 // Set all=true to see all servers across all projects.
 func (s *Server) toolMuxList(id json.RawMessage, args json.RawMessage) {
@@ -412,60 +423,59 @@ func (s *Server) toolMuxList(id json.RawMessage, args json.RawMessage) {
 		_ = json.Unmarshal(args, &params)
 	}
 
-	// Determine this session's cwd for filtering
 	myCwd, _ := os.Getwd()
 	myCwd = strings.ToLower(filepath.Clean(myCwd))
 
-	tmpDir := s.socketDir()
-	entries, err := os.ReadDir(tmpDir)
-	if err != nil {
-		s.sendToolError(id, fmt.Sprintf("read temp dir: %v", err))
+	resp, err := control.Send(s.daemonCtlPath(), control.Request{Cmd: "list_owners"})
+	if err != nil || !resp.OK || resp.Data == nil {
+		result, _ := json.Marshal(map[string]any{
+			"servers": []any{},
+			"note":    "local mcp-mux daemon not running — start it with `mcp-mux daemon` or invoke any mcp-mux-wrapped tool to auto-spawn",
+		})
+		s.sendToolResult(id, string(result))
+		return
+	}
+
+	var listResp control.ListOwnersResponse
+	if err := json.Unmarshal(resp.Data, &listResp); err != nil {
+		result, _ := json.Marshal(map[string]any{
+			"servers": []any{},
+			"note":    "local mcp-mux daemon not running — start it with `mcp-mux daemon` or invoke any mcp-mux-wrapped tool to auto-spawn",
+		})
+		s.sendToolResult(id, string(result))
 		return
 	}
 
 	var servers []map[string]any
-
-	for _, entry := range entries {
-		name := entry.Name()
-		if !strings.HasPrefix(name, "mcp-mux-") || !strings.HasSuffix(name, ".ctl.sock") {
-			continue
-		}
-
-		path := filepath.Join(tmpDir, name)
-		serverID := strings.TrimPrefix(strings.TrimSuffix(name, ".ctl.sock"), "mcp-mux-")
-
-		resp, err := control.Send(path, control.Request{Cmd: "status"})
-		if err != nil {
-			continue // skip unreachable
-		}
-
-		if resp.OK && resp.Data != nil {
-			var data map[string]any
-			if err := json.Unmarshal(resp.Data, &data); err == nil {
-				// Filter by cwd unless all=true
-				if !params.All && myCwd != "" {
-					if !s.ownerHasCwd(data, myCwd) {
-						continue
-					}
-				}
-
-				if params.Verbose {
-					data["server_id"] = serverID
-					servers = append(servers, data)
-				} else {
-					// Compact: only key fields
-					compact := map[string]any{
-						"server_id": serverID,
-						"command":   data["command"],
-						"args":      data["args"],
-						"sessions":  data["session_count"],
-						"pending":   data["pending_requests"],
-						"class":     data["auto_classification"],
-						"version":   data["mux_version"],
-					}
-					servers = append(servers, compact)
-				}
+	for _, owner := range listResp.Owners {
+		if !params.All && myCwd != "" {
+			if !s.ownerInfoHasCwd(owner, myCwd) {
+				continue
 			}
+		}
+		if params.Verbose {
+			servers = append(servers, map[string]any{
+				"server_id":      owner.ServerID,
+				"command":        owner.Command,
+				"args":           owner.Args,
+				"cwd":            owner.Cwd,
+				"cwd_set":        owner.CwdSet,
+				"sessions":       owner.Sessions,
+				"pending":        owner.Pending,
+				"classification": owner.Classification,
+				"mux_version":    owner.MuxVersion,
+				"persistent":     owner.Persistent,
+			})
+		} else {
+			servers = append(servers, map[string]any{
+				"server_id": owner.ServerID,
+				"command":   owner.Command,
+				"args":      owner.Args,
+				"sessions":  owner.Sessions,
+				"pending":   owner.Pending,
+				"class":     owner.Classification,
+				"version":   owner.MuxVersion,
+			})
 		}
 	}
 
@@ -489,6 +499,19 @@ func (s *Server) ownerHasCwd(data map[string]any, cwd string) bool {
 					return true
 				}
 			}
+		}
+	}
+	return false
+}
+
+// ownerInfoHasCwd checks if an OwnerInfo matches a given cwd (case-insensitive, cleaned paths).
+func (s *Server) ownerInfoHasCwd(info control.OwnerInfo, cwd string) bool {
+	if strings.ToLower(filepath.Clean(info.Cwd)) == cwd {
+		return true
+	}
+	for _, c := range info.CwdSet {
+		if strings.ToLower(filepath.Clean(c)) == cwd {
+			return true
 		}
 	}
 	return false

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -438,7 +439,7 @@ func (s *Server) toolMuxList(id json.RawMessage, args json.RawMessage) {
 	}
 
 	myCwd, _ := os.Getwd()
-	myCwd = strings.ToLower(filepath.Clean(myCwd))
+	myCwd = normalizeCwd(myCwd)
 
 	resp, err := control.Send(s.daemonCtlPath(), control.Request{Cmd: "list_owners"})
 	if err != nil || !resp.OK || resp.Data == nil {
@@ -497,13 +498,33 @@ func (s *Server) toolMuxList(id json.RawMessage, args json.RawMessage) {
 	s.sendToolResult(id, string(result))
 }
 
-// ownerInfoHasCwd checks if an OwnerInfo matches a given cwd (case-insensitive, cleaned paths).
+// normalizeCwd cleans a path and lowercases only on Windows. Linux/macOS
+// filesystems are case-sensitive — lowercasing there would collapse `/Repo`
+// and `/repo` into one project namespace and let resolveOwner pick a foreign
+// owner. Empty input → empty output (callers treat empty as "no filter").
+func normalizeCwd(p string) string {
+	if p == "" {
+		return ""
+	}
+	p = filepath.Clean(p)
+	if runtime.GOOS == "windows" {
+		p = strings.ToLower(p)
+	}
+	return p
+}
+
+// ownerInfoHasCwd checks if an OwnerInfo matches a given cwd. Caller passes the
+// already-normalized cwd; this helper normalizes the OwnerInfo paths to the
+// same convention before comparing.
 func (s *Server) ownerInfoHasCwd(info control.OwnerInfo, cwd string) bool {
-	if strings.ToLower(filepath.Clean(info.Cwd)) == cwd {
+	if cwd == "" {
+		return false
+	}
+	if normalizeCwd(info.Cwd) == cwd {
 		return true
 	}
 	for _, c := range info.CwdSet {
-		if strings.ToLower(filepath.Clean(c)) == cwd {
+		if normalizeCwd(c) == cwd {
 			return true
 		}
 	}
@@ -533,10 +554,23 @@ func (s *Server) resolveOwner(serverID, name string) (control.OwnerInfo, error) 
 	}
 
 	if serverID != "" {
+		// Accept full server_id OR the 8-char shorthand documented in mux-guide.
+		// Exact match wins; otherwise prefix match resolves uniquely or rejects
+		// as ambiguous.
+		var prefixMatches []control.OwnerInfo
 		for _, owner := range listResp.Owners {
 			if owner.ServerID == serverID {
 				return owner, nil
 			}
+			if strings.HasPrefix(owner.ServerID, serverID) {
+				prefixMatches = append(prefixMatches, owner)
+			}
+		}
+		if len(prefixMatches) == 1 {
+			return prefixMatches[0], nil
+		}
+		if len(prefixMatches) > 1 {
+			return control.OwnerInfo{}, fmt.Errorf("server_id %s is ambiguous — use the full id", serverID)
 		}
 		return control.OwnerInfo{}, fmt.Errorf("server_id %s is not managed by this mcp-mux daemon", serverID)
 	}
@@ -556,7 +590,7 @@ func (s *Server) resolveOwner(serverID, name string) (control.OwnerInfo, error) 
 	// Project-scoping: prefer matches that belong to this session's cwd. Restored
 	// from pre-T011 resolveServerID — the regression was flagged by Gemini on PR #105.
 	myCwd, _ := os.Getwd()
-	myCwd = strings.ToLower(filepath.Clean(myCwd))
+	myCwd = normalizeCwd(myCwd)
 	var myCwdMatches []control.OwnerInfo
 	for _, m := range matches {
 		if s.ownerInfoHasCwd(m, myCwd) {

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -77,7 +77,7 @@ func (s *Server) daemonCtlPath() string {
 	if s.DaemonCtlPath != "" {
 		return s.DaemonCtlPath
 	}
-	return serverid.DaemonControlPath(s.BaseDir, "mcp-mux")
+	return serverid.DaemonControlPath(s.BaseDir, s.engineName())
 }
 
 // NewServer creates a new MCP control server.
@@ -518,8 +518,14 @@ func (s *Server) resolveOwner(serverID, name string) (control.OwnerInfo, error) 
 	}
 
 	resp, err := control.Send(s.daemonCtlPath(), control.Request{Cmd: "list_owners"})
-	if err != nil || !resp.OK || resp.Data == nil {
+	if err != nil {
 		return control.OwnerInfo{}, fmt.Errorf("mcp-mux daemon not reachable: %v", err)
+	}
+	if !resp.OK {
+		return control.OwnerInfo{}, fmt.Errorf("mcp-mux daemon error: %s", resp.Message)
+	}
+	if resp.Data == nil {
+		return control.OwnerInfo{}, fmt.Errorf("mcp-mux daemon returned empty list_owners response")
 	}
 	var listResp control.ListOwnersResponse
 	if err := json.Unmarshal(resp.Data, &listResp); err != nil {
@@ -633,7 +639,7 @@ func (s *Server) toolMuxRestart(id json.RawMessage, args json.RawMessage) {
 
 	// Reject restart when requests are in-flight unless force is set
 	if owner.Pending > 0 && !params.Force {
-		s.sendToolError(id, fmt.Sprintf("server %s has %d pending requests. Use force=true to kill them, or wait for completion.", owner.ServerID[:8], owner.Pending))
+		s.sendToolError(id, fmt.Sprintf("server %.8s has %d pending requests. Use force=true to kill them, or wait for completion.", owner.ServerID, owner.Pending))
 		return
 	}
 

--- a/internal/mcpserver/server_test.go
+++ b/internal/mcpserver/server_test.go
@@ -501,8 +501,14 @@ func TestPromptsGetInvalidParams(t *testing.T) {
 
 func TestOwnerInfoHasCwd(t *testing.T) {
 	s := &Server{logger: log.New(os.Stderr, "", 0)}
-	cwd := strings.ToLower(filepath.Clean(os.TempDir()))
-	otherCwd := strings.ToLower(filepath.Clean(filepath.Join(os.TempDir(), "..", "mcp-mux-owner-has-cwd-other")))
+	cwd := normalizeCwd(os.TempDir())
+	otherCwd := normalizeCwd(filepath.Join(os.TempDir(), "..", "mcp-mux-owner-has-cwd-other"))
+	matchingCwd := normalizeCwd(os.TempDir())
+
+	// caseInsensitiveMatch: on Windows the engine deliberately lowercases
+	// paths (NTFS is case-preserving but case-insensitive). On Linux/macOS
+	// path comparison is byte-exact, so /TMP and /tmp are distinct projects.
+	caseInsensitiveMatch := runtime.GOOS == "windows"
 
 	tests := []struct {
 		name string
@@ -510,13 +516,23 @@ func TestOwnerInfoHasCwd(t *testing.T) {
 		want bool
 	}{
 		{
-			name: "primary cwd matches case-insensitively",
+			name: "primary cwd matches when case-folded (Windows only)",
 			info: control.OwnerInfo{Cwd: strings.ToUpper(cwd)},
+			want: caseInsensitiveMatch,
+		},
+		{
+			name: "cwd_set match relies on case-folding (Windows only)",
+			info: control.OwnerInfo{Cwd: otherCwd, CwdSet: []string{otherCwd, strings.ToUpper(cwd)}},
+			want: caseInsensitiveMatch,
+		},
+		{
+			name: "primary cwd matches exactly",
+			info: control.OwnerInfo{Cwd: matchingCwd},
 			want: true,
 		},
 		{
-			name: "cwd_set contains match",
-			info: control.OwnerInfo{Cwd: otherCwd, CwdSet: []string{otherCwd, strings.ToUpper(cwd)}},
+			name: "cwd_set contains exact match",
+			info: control.OwnerInfo{Cwd: otherCwd, CwdSet: []string{otherCwd, matchingCwd}},
 			want: true,
 		},
 		{

--- a/internal/mcpserver/server_test.go
+++ b/internal/mcpserver/server_test.go
@@ -8,12 +8,34 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/thebtf/mcp-mux/muxcore/control"
 )
+
+// shortBaseDir returns a fresh temp directory whose path is short enough to host
+// AF_UNIX socket files. On macOS the default os.TempDir() lands under
+// /var/folders/.../T/<TestName>NNNN/, easily breaking the 104-byte limit on
+// `bind(2)` for AF_UNIX paths once the test appends a socket name. We force
+// /tmp on darwin so paths fit. On other platforms the default is fine.
+//
+// Cleanup runs via t.Cleanup. Caller treats the return as an opaque base dir.
+func shortBaseDir(t *testing.T, prefix string) string {
+	t.Helper()
+	parent := ""
+	if runtime.GOOS == "darwin" {
+		parent = "/tmp"
+	}
+	dir, err := os.MkdirTemp(parent, prefix)
+	if err != nil {
+		t.Fatalf("shortBaseDir(%q): %v", prefix, err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
 
 // newTestServer creates a Server wired to an io.Pipe pair and returns
 // the client-side reader/writer, a done channel, and an isolated base directory
@@ -22,12 +44,7 @@ import (
 func newTestServer(t *testing.T) (clientW io.WriteCloser, clientR io.Reader, done chan error, baseDir string) {
 	t.Helper()
 
-	var err error
-	baseDir, err = os.MkdirTemp("", "mcpmux-")
-	if err != nil {
-		t.Fatalf("newTestServer: MkdirTemp: %v", err)
-	}
-	t.Cleanup(func() { os.RemoveAll(baseDir) })
+	baseDir = shortBaseDir(t, "mcpmux-")
 
 	// clientW -> serverR  (test writes requests, server reads them)
 	serverR, clientW := io.Pipe()
@@ -670,10 +687,7 @@ func TestMuxRestartNoIDOrName(t *testing.T) {
 }
 
 func TestMuxStopNoMatchingServer(t *testing.T) {
-	baseDir, err := os.MkdirTemp("", "mcpmux-stopnomatch-")
-	if err != nil {
-		t.Fatal(err)
-	}
+	baseDir := shortBaseDir(t, "mcpmux-stopnomatch-")
 	t.Cleanup(func() { os.RemoveAll(baseDir) })
 
 	daemonCtlPath := filepath.Join(baseDir, "stopnomatch-muxd.ctl.sock")
@@ -706,10 +720,7 @@ func TestMuxStopNoMatchingServer(t *testing.T) {
 }
 
 func TestMuxRestartNoMatchingServer(t *testing.T) {
-	baseDir, err := os.MkdirTemp("", "mcpmux-restartnomatch-")
-	if err != nil {
-		t.Fatal(err)
-	}
+	baseDir := shortBaseDir(t, "mcpmux-restartnomatch-")
 	t.Cleanup(func() { os.RemoveAll(baseDir) })
 
 	daemonCtlPath := filepath.Join(baseDir, "restartnomatch-muxd.ctl.sock")
@@ -882,12 +893,7 @@ func newTestServerFull(t *testing.T, daemonCtlPath, baseDir string) (clientW io.
 // newTestServerWithDaemonCtl creates a Server with a specific DaemonCtlPath for testing.
 func newTestServerWithDaemonCtl(t *testing.T, daemonCtlPath string) (clientW io.WriteCloser, clientR io.Reader, done chan error, baseDir string) {
 	t.Helper()
-	var err error
-	baseDir, err = os.MkdirTemp("", "mcpmux-")
-	if err != nil {
-		t.Fatalf("newTestServerWithDaemonCtl: MkdirTemp: %v", err)
-	}
-	t.Cleanup(func() { os.RemoveAll(baseDir) })
+	baseDir = shortBaseDir(t, "mcpmux-")
 
 	serverR, clientW := io.Pipe()
 	clientR, serverW := io.Pipe()
@@ -909,11 +915,7 @@ func newTestServerWithDaemonCtl(t *testing.T, daemonCtlPath string) (clientW io.
 
 func TestMuxListWithFakeServer(t *testing.T) {
 	sid := "aabbccdd11223344"
-	baseDir, err := os.MkdirTemp("", "mcpmux-daemon-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { os.RemoveAll(baseDir) })
+	baseDir := shortBaseDir(t, "mcpmux-daemon-")
 
 	daemonCtlPath := filepath.Join(baseDir, "test-muxd.ctl.sock")
 	owners := control.ListOwnersResponse{
@@ -961,11 +963,7 @@ func TestMuxListWithFakeServer(t *testing.T) {
 
 func TestMuxListVerbose(t *testing.T) {
 	sid := "eeff001122334455"
-	baseDir, err := os.MkdirTemp("", "mcpmux-daemon-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { os.RemoveAll(baseDir) })
+	baseDir := shortBaseDir(t, "mcpmux-daemon-")
 
 	daemonCtlPath := filepath.Join(baseDir, "test-muxd.ctl.sock")
 	owners := control.ListOwnersResponse{
@@ -1008,11 +1006,7 @@ func TestMuxListVerbose(t *testing.T) {
 
 func TestMuxStopWithFakeServer(t *testing.T) {
 	sid := "ddee112233445566"
-	baseDir, err := os.MkdirTemp("", "mcpmux-stop-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { os.RemoveAll(baseDir) })
+	baseDir := shortBaseDir(t, "mcpmux-stop-")
 
 	daemonCtlPath := filepath.Join(baseDir, "test-stop-muxd.ctl.sock")
 	owners := control.ListOwnersResponse{
@@ -1052,11 +1046,7 @@ func TestMuxStopWithFakeServer(t *testing.T) {
 
 func TestMuxStopByName(t *testing.T) {
 	sid := "aabb112233445566"
-	baseDir, err := os.MkdirTemp("", "mcpmux-stopname-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { os.RemoveAll(baseDir) })
+	baseDir := shortBaseDir(t, "mcpmux-stopname-")
 
 	daemonCtlPath := filepath.Join(baseDir, "test-stopname-muxd.ctl.sock")
 	owners := control.ListOwnersResponse{
@@ -1092,11 +1082,7 @@ func TestMuxStopByName(t *testing.T) {
 
 func TestMuxRestartWithFakeServer(t *testing.T) {
 	sid := "ffaa112233445566"
-	baseDir, err := os.MkdirTemp("", "mcpmux-restart-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { os.RemoveAll(baseDir) })
+	baseDir := shortBaseDir(t, "mcpmux-restart-")
 
 	daemonCtlPath := filepath.Join(baseDir, "test-restart-muxd.ctl.sock")
 	owners := control.ListOwnersResponse{
@@ -1141,11 +1127,7 @@ func TestMuxRestartWithFakeServer(t *testing.T) {
 
 func TestMuxRestartByName(t *testing.T) {
 	sid := "ffbb112233445566"
-	baseDir, err := os.MkdirTemp("", "mcpmux-restartname-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { os.RemoveAll(baseDir) })
+	baseDir := shortBaseDir(t, "mcpmux-restartname-")
 
 	daemonCtlPath := filepath.Join(baseDir, "test-restartname-muxd.ctl.sock")
 	owners := control.ListOwnersResponse{
@@ -1185,11 +1167,7 @@ func TestMuxRestartByName(t *testing.T) {
 
 func TestMuxRestartNoCommandInfo(t *testing.T) {
 	sid := "ffcc112233445566"
-	baseDir, err := os.MkdirTemp("", "mcpmux-nocmd-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { os.RemoveAll(baseDir) })
+	baseDir := shortBaseDir(t, "mcpmux-nocmd-")
 
 	daemonCtlPath := filepath.Join(baseDir, "test-nocmd-muxd.ctl.sock")
 	// Daemon returns owner with empty Command
@@ -1227,11 +1205,7 @@ func TestMuxRestartNoCommandInfo(t *testing.T) {
 
 func TestMuxStopForce(t *testing.T) {
 	sid := "ffdd112233445566"
-	baseDir, err := os.MkdirTemp("", "mcpmux-stopforce-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { os.RemoveAll(baseDir) })
+	baseDir := shortBaseDir(t, "mcpmux-stopforce-")
 
 	daemonCtlPath := filepath.Join(baseDir, "test-stopforce-muxd.ctl.sock")
 	owners := control.ListOwnersResponse{
@@ -1269,11 +1243,7 @@ func TestMuxStopForce(t *testing.T) {
 func TestMuxListFilterByCwd(t *testing.T) {
 	myCwd, _ := os.Getwd()
 
-	baseDir, err := os.MkdirTemp("", "mcpmux-daemon-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { os.RemoveAll(baseDir) })
+	baseDir := shortBaseDir(t, "mcpmux-daemon-")
 
 	daemonCtlPath := filepath.Join(baseDir, "test-muxd.ctl.sock")
 	owners := control.ListOwnersResponse{
@@ -1321,11 +1291,7 @@ func TestMuxListFilterByCwd(t *testing.T) {
 }
 
 func TestMuxRestartRefusesForeignID(t *testing.T) {
-	baseDir, err := os.MkdirTemp("", "mcpmux-foreign-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { os.RemoveAll(baseDir) })
+	baseDir := shortBaseDir(t, "mcpmux-foreign-")
 
 	daemonCtlPath := filepath.Join(baseDir, "foreign-test-muxd.ctl.sock")
 	// Empty owners list — any server_id is foreign
@@ -1358,11 +1324,7 @@ func TestMuxRestartRefusesForeignID(t *testing.T) {
 }
 
 func TestMuxStopRefusesForeignID(t *testing.T) {
-	baseDir, err := os.MkdirTemp("", "mcpmux-stopforeign-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { os.RemoveAll(baseDir) })
+	baseDir := shortBaseDir(t, "mcpmux-stopforeign-")
 
 	daemonCtlPath := filepath.Join(baseDir, "stopforeign-muxd.ctl.sock")
 	startFakeDaemonControlServer(t, daemonCtlPath, control.ListOwnersResponse{})

--- a/internal/mcpserver/server_test.go
+++ b/internal/mcpserver/server_test.go
@@ -714,6 +714,7 @@ func TestMuxRestartNoMatchingServer(t *testing.T) {
 }
 
 func TestToolsCallMuxListNoServers(t *testing.T) {
+	// Default DaemonCtlPath won't exist in test environment → graceful note returned
 	clientW, clientR, _, _ := newTestServer(t)
 	defer clientW.Close()
 
@@ -734,21 +735,22 @@ func TestToolsCallMuxListNoServers(t *testing.T) {
 	unmarshalResult(t, resp, &result)
 
 	if result.IsError {
-		t.Fatal("did not expect isError=true for mux_list")
+		t.Fatal("did not expect isError=true for mux_list when daemon not running")
 	}
 	if len(result.Content) == 0 {
 		t.Fatal("expected mux_list result content")
 	}
 
 	text := strings.TrimSpace(result.Content[0].Text)
-	var decoded any
+	var decoded map[string]any
 	if err := json.Unmarshal([]byte(text), &decoded); err != nil {
 		t.Fatalf("mux_list content is not valid JSON: %v (raw: %q)", err, text)
 	}
-	if decoded != nil {
-		if _, ok := decoded.([]any); !ok {
-			t.Fatalf("mux_list JSON should be null or array, got %T", decoded)
-		}
+	if _, ok := decoded["note"]; !ok {
+		t.Errorf("expected 'note' field in graceful-degradation response, got: %s", text)
+	}
+	if servers, ok := decoded["servers"].([]any); !ok || len(servers) != 0 {
+		t.Errorf("expected empty 'servers' array, got: %s", text)
 	}
 }
 
@@ -790,22 +792,103 @@ func startFakeControlServer(t *testing.T, dir, serverID string, status map[strin
 	return srv
 }
 
+// fakeDaemonHandler implements control.DaemonHandler for testing the list_owners path.
+type fakeDaemonHandler struct {
+	fakeHandler
+	listOwnersResp control.ListOwnersResponse
+	listOwnersErr  error
+}
+
+func (h *fakeDaemonHandler) HandleSpawn(_ control.Request) (string, string, string, error) {
+	return "", "", "", fmt.Errorf("not implemented")
+}
+func (h *fakeDaemonHandler) HandleRemove(_ string) error {
+	return fmt.Errorf("not implemented")
+}
+func (h *fakeDaemonHandler) HandleGracefulRestart(_ int) (string, func(), error) {
+	return "", nil, fmt.Errorf("not implemented")
+}
+func (h *fakeDaemonHandler) HandleRefreshSessionToken(_ string) (string, error) {
+	return "", fmt.Errorf("not implemented")
+}
+func (h *fakeDaemonHandler) HandleReconnectGiveUp(_ string) error {
+	return fmt.Errorf("not implemented")
+}
+func (h *fakeDaemonHandler) HandleListOwners(_ control.Request) (control.ListOwnersResponse, error) {
+	return h.listOwnersResp, h.listOwnersErr
+}
+
+// startFakeDaemonControlServer creates a daemon control server at socketPath responding to list_owners.
+func startFakeDaemonControlServer(t *testing.T, socketPath string, resp control.ListOwnersResponse) *control.Server {
+	t.Helper()
+	t.Cleanup(func() { os.Remove(socketPath) })
+	handler := &fakeDaemonHandler{
+		fakeHandler:    fakeHandler{status: map[string]any{}, shutdownMsg: "ok"},
+		listOwnersResp: resp,
+	}
+	srv, err := control.NewServer(socketPath, handler, log.New(io.Discard, "", 0))
+	if err != nil {
+		t.Fatalf("startFakeDaemonControlServer: %v", err)
+	}
+	t.Cleanup(func() { srv.Close() })
+	return srv
+}
+
+// newTestServerWithDaemonCtl creates a Server with a specific DaemonCtlPath for testing.
+func newTestServerWithDaemonCtl(t *testing.T, daemonCtlPath string) (clientW io.WriteCloser, clientR io.Reader, done chan error, baseDir string) {
+	t.Helper()
+	var err error
+	baseDir, err = os.MkdirTemp("", "mcpmux-")
+	if err != nil {
+		t.Fatalf("newTestServerWithDaemonCtl: MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(baseDir) })
+
+	serverR, clientW := io.Pipe()
+	clientR, serverW := io.Pipe()
+
+	logger := log.New(os.Stderr, "[mcpserver-test] ", 0)
+	srv := NewServer(serverR, serverW, logger)
+	srv.BaseDir = baseDir
+	srv.DaemonCtlPath = daemonCtlPath
+
+	done = make(chan error, 1)
+	go func() {
+		err := srv.Run()
+		serverW.Close()
+		done <- err
+	}()
+
+	return clientW, clientR, done, baseDir
+}
+
 func TestMuxListWithFakeServer(t *testing.T) {
 	sid := "aabbccdd11223344"
-	clientW, clientR, _, baseDir := newTestServer(t)
+	baseDir, err := os.MkdirTemp("", "mcpmux-daemon-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(baseDir) })
+
+	daemonCtlPath := filepath.Join(baseDir, "test-muxd.ctl.sock")
+	owners := control.ListOwnersResponse{
+		Owners: []control.OwnerInfo{
+			{
+				ServerID:       sid,
+				Command:        "uvx",
+				Args:           []string{"test-server"},
+				Sessions:       2,
+				Classification: "shared",
+				MuxVersion:     "test",
+				Cwd:            baseDir,
+			},
+		},
+	}
+	startFakeDaemonControlServer(t, daemonCtlPath, owners)
+
+	clientW, clientR, _, _ := newTestServerWithDaemonCtl(t, daemonCtlPath)
 	defer clientW.Close()
 
-	_ = startFakeControlServer(t, baseDir, sid, map[string]any{
-		"command":             "uvx",
-		"args":               []string{"test-server"},
-		"session_count":      2,
-		"pending_requests":   0,
-		"auto_classification": "shared",
-		"mux_version":        "test",
-		"cwd":                baseDir,
-	})
-
-	// all=true to see servers from any cwd
 	sendLine(t, clientW, `{"jsonrpc":"2.0","id":40,"method":"tools/call","params":{"name":"mux_list","arguments":{"all":true}}}`)
 	line := readLine(t, clientR)
 	resp := parseResponse(t, line)
@@ -822,7 +905,6 @@ func TestMuxListWithFakeServer(t *testing.T) {
 		t.Fatal("expected mux_list content")
 	}
 
-	// Verify our fake server appears
 	text := result.Content[0].Text
 	if !strings.Contains(text, sid) {
 		t.Errorf("mux_list output should contain server ID %s, got: %s", sid, text)
@@ -834,19 +916,31 @@ func TestMuxListWithFakeServer(t *testing.T) {
 
 func TestMuxListVerbose(t *testing.T) {
 	sid := "eeff001122334455"
-	clientW, clientR, _, baseDir := newTestServer(t)
-	defer clientW.Close()
+	baseDir, err := os.MkdirTemp("", "mcpmux-daemon-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(baseDir) })
 
-	_ = startFakeControlServer(t, baseDir, sid, map[string]any{
-		"command":             "node",
-		"args":               []string{"verbose-test.js"},
-		"session_count":      3,
-		"pending_requests":   1,
-		"auto_classification": "session-aware",
-		"mux_version":        "v0.5.1",
-		"cwd":                baseDir,
-		"upstream_pid":       12345,
-	})
+	daemonCtlPath := filepath.Join(baseDir, "test-muxd.ctl.sock")
+	owners := control.ListOwnersResponse{
+		Owners: []control.OwnerInfo{
+			{
+				ServerID:       sid,
+				Command:        "node",
+				Args:           []string{"verbose-test.js"},
+				Sessions:       3,
+				Pending:        1,
+				Classification: "session-aware",
+				MuxVersion:     "v0.5.1",
+				Cwd:            baseDir,
+			},
+		},
+	}
+	startFakeDaemonControlServer(t, daemonCtlPath, owners)
+
+	clientW, clientR, _, _ := newTestServerWithDaemonCtl(t, daemonCtlPath)
+	defer clientW.Close()
 
 	sendLine(t, clientW, `{"jsonrpc":"2.0","id":41,"method":"tools/call","params":{"name":"mux_list","arguments":{"all":true,"verbose":true}}}`)
 	line := readLine(t, clientR)
@@ -862,9 +956,8 @@ func TestMuxListVerbose(t *testing.T) {
 	unmarshalResult(t, resp, &result)
 
 	text := result.Content[0].Text
-	// Verbose mode should include upstream_pid
-	if !strings.Contains(text, "12345") {
-		t.Errorf("verbose mux_list should contain upstream_pid, got: %s", text)
+	if !strings.Contains(text, "session-aware") {
+		t.Errorf("verbose mux_list should contain classification, got: %s", text)
 	}
 }
 
@@ -1078,30 +1171,36 @@ func TestMuxStopForce(t *testing.T) {
 func TestMuxListFilterByCwd(t *testing.T) {
 	myCwd, _ := os.Getwd()
 
-	clientW, clientR, _, baseDir := newTestServer(t)
+	baseDir, err := os.MkdirTemp("", "mcpmux-daemon-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(baseDir) })
+
+	daemonCtlPath := filepath.Join(baseDir, "test-muxd.ctl.sock")
+	owners := control.ListOwnersResponse{
+		Owners: []control.OwnerInfo{
+			{
+				ServerID: "ccdd001122334455",
+				Command:  "uvx",
+				Args:     []string{"my-server"},
+				Sessions: 1,
+				Cwd:      myCwd,
+			},
+			{
+				ServerID: "ccdd998877665544",
+				Command:  "uvx",
+				Args:     []string{"other-server"},
+				Sessions: 1,
+				Cwd:      filepath.Join(baseDir, "nonexistent-project"),
+			},
+		},
+	}
+	startFakeDaemonControlServer(t, daemonCtlPath, owners)
+
+	clientW, clientR, _, _ := newTestServerWithDaemonCtl(t, daemonCtlPath)
 	defer clientW.Close()
 
-	// Server WITH our cwd
-	sid1 := "ccdd001122334455"
-	_ = startFakeControlServer(t, baseDir, sid1, map[string]any{
-		"command":       "uvx",
-		"args":          []string{"my-server"},
-		"session_count": 1,
-		"cwd":           myCwd,
-		"mux_version":   "test",
-	})
-
-	// Server with DIFFERENT cwd
-	sid2 := "ccdd998877665544"
-	_ = startFakeControlServer(t, baseDir, sid2, map[string]any{
-		"command":       "uvx",
-		"args":          []string{"other-server"},
-		"session_count": 1,
-		"cwd":           filepath.Join(baseDir, "nonexistent-project"),
-		"mux_version":   "test",
-	})
-
-	// Default (no all=true) — should filter by cwd
 	sendLine(t, clientW, `{"jsonrpc":"2.0","id":44,"method":"tools/call","params":{"name":"mux_list","arguments":{}}}`)
 	line := readLine(t, clientR)
 	resp := parseResponse(t, line)

--- a/internal/mcpserver/server_test.go
+++ b/internal/mcpserver/server_test.go
@@ -482,43 +482,43 @@ func TestPromptsGetInvalidParams(t *testing.T) {
 	}
 }
 
-func TestOwnerHasCwd(t *testing.T) {
+func TestOwnerInfoHasCwd(t *testing.T) {
 	s := &Server{logger: log.New(os.Stderr, "", 0)}
 	cwd := strings.ToLower(filepath.Clean(os.TempDir()))
 	otherCwd := strings.ToLower(filepath.Clean(filepath.Join(os.TempDir(), "..", "mcp-mux-owner-has-cwd-other")))
 
 	tests := []struct {
 		name string
-		data map[string]any
+		info control.OwnerInfo
 		want bool
 	}{
 		{
 			name: "primary cwd matches case-insensitively",
-			data: map[string]any{"cwd": strings.ToUpper(cwd)},
+			info: control.OwnerInfo{Cwd: strings.ToUpper(cwd)},
 			want: true,
 		},
 		{
 			name: "cwd_set contains match",
-			data: map[string]any{"cwd_set": []any{otherCwd, strings.ToUpper(cwd)}},
+			info: control.OwnerInfo{Cwd: otherCwd, CwdSet: []string{otherCwd, strings.ToUpper(cwd)}},
 			want: true,
 		},
 		{
 			name: "missing cwd and cwd_set",
-			data: map[string]any{},
+			info: control.OwnerInfo{},
 			want: false,
 		},
 		{
 			name: "primary cwd does not match",
-			data: map[string]any{"cwd": otherCwd},
+			info: control.OwnerInfo{Cwd: otherCwd},
 			want: false,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := s.ownerHasCwd(tc.data, cwd)
+			got := s.ownerInfoHasCwd(tc.info, cwd)
 			if got != tc.want {
-				t.Fatalf("ownerHasCwd() = %v, want %v", got, tc.want)
+				t.Fatalf("ownerInfoHasCwd() = %v, want %v", got, tc.want)
 			}
 		})
 	}
@@ -604,7 +604,7 @@ func TestMuxStopNoIDOrName(t *testing.T) {
 	clientW, clientR, _, _ := newTestServer(t)
 	defer clientW.Close()
 
-	// Call mux_stop with empty server_id and name — resolveServerID returns an error.
+	// Call mux_stop with empty server_id and name — resolveOwner returns an error.
 	sendLine(t, clientW, `{"jsonrpc":"2.0","id":31,"method":"tools/call","params":{"name":"mux_stop","arguments":{}}}`)
 	line := readLine(t, clientR)
 	resp := parseResponse(t, line)
@@ -652,7 +652,7 @@ func TestMuxRestartNoIDOrName(t *testing.T) {
 	clientW, clientR, _, _ := newTestServer(t)
 	defer clientW.Close()
 
-	// Call mux_restart with empty arguments — resolveServerID returns an error.
+	// Call mux_restart with empty arguments — resolveOwner returns an error.
 	sendLine(t, clientW, `{"jsonrpc":"2.0","id":33,"method":"tools/call","params":{"name":"mux_restart","arguments":{}}}`)
 	line := readLine(t, clientR)
 	resp := parseResponse(t, line)
@@ -670,7 +670,16 @@ func TestMuxRestartNoIDOrName(t *testing.T) {
 }
 
 func TestMuxStopNoMatchingServer(t *testing.T) {
-	clientW, clientR, _, _ := newTestServer(t)
+	baseDir, err := os.MkdirTemp("", "mcpmux-stopnomatch-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(baseDir) })
+
+	daemonCtlPath := filepath.Join(baseDir, "stopnomatch-muxd.ctl.sock")
+	startFakeDaemonControlServer(t, daemonCtlPath, control.ListOwnersResponse{})
+
+	clientW, clientR, _ := newTestServerFull(t, daemonCtlPath, baseDir)
 	defer clientW.Close()
 
 	// Call mux_stop with a name that matches no running server.
@@ -691,10 +700,22 @@ func TestMuxStopNoMatchingServer(t *testing.T) {
 	if !result.IsError {
 		t.Fatal("expected isError=true for non-existent server name")
 	}
+	if !strings.Contains(result.Content[0].Text, "no server matching 'nonexistent-server-xyzzy-12345' found") {
+		t.Fatalf("expected no-match error, got: %s", result.Content[0].Text)
+	}
 }
 
 func TestMuxRestartNoMatchingServer(t *testing.T) {
-	clientW, clientR, _, _ := newTestServer(t)
+	baseDir, err := os.MkdirTemp("", "mcpmux-restartnomatch-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(baseDir) })
+
+	daemonCtlPath := filepath.Join(baseDir, "restartnomatch-muxd.ctl.sock")
+	startFakeDaemonControlServer(t, daemonCtlPath, control.ListOwnersResponse{})
+
+	clientW, clientR, _ := newTestServerFull(t, daemonCtlPath, baseDir)
 	defer clientW.Close()
 
 	sendLine(t, clientW, `{"jsonrpc":"2.0","id":35,"method":"tools/call","params":{"name":"mux_restart","arguments":{"name":"nonexistent-server-xyzzy-12345"}}}`)
@@ -706,10 +727,16 @@ func TestMuxRestartNoMatchingServer(t *testing.T) {
 
 	var result struct {
 		IsError bool `json:"isError"`
+		Content []struct {
+			Text string `json:"text"`
+		} `json:"content"`
 	}
 	unmarshalResult(t, resp, &result)
 	if !result.IsError {
 		t.Fatal("expected isError=true for non-existent server name in mux_restart")
+	}
+	if !strings.Contains(result.Content[0].Text, "no server matching 'nonexistent-server-xyzzy-12345' found") {
+		t.Fatalf("expected no-match error, got: %s", result.Content[0].Text)
 	}
 }
 
@@ -832,6 +859,24 @@ func startFakeDaemonControlServer(t *testing.T, socketPath string, resp control.
 	}
 	t.Cleanup(func() { srv.Close() })
 	return srv
+}
+
+// newTestServerFull creates a Server with both DaemonCtlPath and BaseDir set.
+func newTestServerFull(t *testing.T, daemonCtlPath, baseDir string) (clientW io.WriteCloser, clientR io.Reader, done chan error) {
+	t.Helper()
+	serverR, clientW := io.Pipe()
+	clientR, serverW := io.Pipe()
+	logger := log.New(os.Stderr, "[mcpserver-test] ", 0)
+	srv := NewServer(serverR, serverW, logger)
+	srv.BaseDir = baseDir
+	srv.DaemonCtlPath = daemonCtlPath
+	done = make(chan error, 1)
+	go func() {
+		err := srv.Run()
+		serverW.Close()
+		done <- err
+	}()
+	return clientW, clientR, done
 }
 
 // newTestServerWithDaemonCtl creates a Server with a specific DaemonCtlPath for testing.
@@ -963,15 +1008,25 @@ func TestMuxListVerbose(t *testing.T) {
 
 func TestMuxStopWithFakeServer(t *testing.T) {
 	sid := "ddee112233445566"
-	clientW, clientR, _, baseDir := newTestServer(t)
-	defer clientW.Close()
+	baseDir, err := os.MkdirTemp("", "mcpmux-stop-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(baseDir) })
 
-	_ = startFakeControlServer(t, baseDir, sid, map[string]any{
-		"command":       "uvx",
-		"args":          []string{"stop-test"},
-		"session_count": 1,
-		"mux_version":   "test",
+	daemonCtlPath := filepath.Join(baseDir, "test-stop-muxd.ctl.sock")
+	owners := control.ListOwnersResponse{
+		Owners: []control.OwnerInfo{
+			{ServerID: sid, Command: "uvx", Args: []string{"stop-test"}, Sessions: 1},
+		},
+	}
+	startFakeDaemonControlServer(t, daemonCtlPath, owners)
+	startFakeControlServer(t, baseDir, sid, map[string]any{
+		"command": "uvx", "args": []string{"stop-test"},
 	})
+
+	clientW, clientR, _ := newTestServerFull(t, daemonCtlPath, baseDir)
+	defer clientW.Close()
 
 	sendLine(t, clientW, fmt.Sprintf(
 		`{"jsonrpc":"2.0","id":42,"method":"tools/call","params":{"name":"mux_stop","arguments":{"server_id":"%s"}}}`, sid))
@@ -997,15 +1052,25 @@ func TestMuxStopWithFakeServer(t *testing.T) {
 
 func TestMuxStopByName(t *testing.T) {
 	sid := "aabb112233445566"
-	clientW, clientR, _, baseDir := newTestServer(t)
-	defer clientW.Close()
+	baseDir, err := os.MkdirTemp("", "mcpmux-stopname-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(baseDir) })
 
-	_ = startFakeControlServer(t, baseDir, sid, map[string]any{
-		"command":       "uvx",
-		"args":          []string{"unique-name-for-stop-test"},
-		"session_count": 1,
-		"mux_version":   "test",
+	daemonCtlPath := filepath.Join(baseDir, "test-stopname-muxd.ctl.sock")
+	owners := control.ListOwnersResponse{
+		Owners: []control.OwnerInfo{
+			{ServerID: sid, Command: "uvx", Args: []string{"unique-name-for-stop-test"}, Sessions: 1},
+		},
+	}
+	startFakeDaemonControlServer(t, daemonCtlPath, owners)
+	startFakeControlServer(t, baseDir, sid, map[string]any{
+		"command": "uvx", "args": []string{"unique-name-for-stop-test"},
 	})
+
+	clientW, clientR, _ := newTestServerFull(t, daemonCtlPath, baseDir)
+	defer clientW.Close()
 
 	sendLine(t, clientW, `{"jsonrpc":"2.0","id":43,"method":"tools/call","params":{"name":"mux_stop","arguments":{"name":"unique-name-for-stop-test"}}}`)
 	line := readLine(t, clientR)
@@ -1027,17 +1092,25 @@ func TestMuxStopByName(t *testing.T) {
 
 func TestMuxRestartWithFakeServer(t *testing.T) {
 	sid := "ffaa112233445566"
-	clientW, clientR, _, baseDir := newTestServer(t)
-	defer clientW.Close()
+	baseDir, err := os.MkdirTemp("", "mcpmux-restart-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(baseDir) })
 
-	_ = startFakeControlServer(t, baseDir, sid, map[string]any{
-		"command":       "uvx",
-		"args":          []string{"restart-test"},
-		"session_count": 1,
-		"mux_version":   "test",
+	daemonCtlPath := filepath.Join(baseDir, "test-restart-muxd.ctl.sock")
+	owners := control.ListOwnersResponse{
+		Owners: []control.OwnerInfo{
+			{ServerID: sid, Command: "uvx", Args: []string{"restart-test"}, Sessions: 1},
+		},
+	}
+	startFakeDaemonControlServer(t, daemonCtlPath, owners)
+	startFakeControlServer(t, baseDir, sid, map[string]any{
+		"command": "uvx", "args": []string{"restart-test"},
 	})
 
-	// force=true to skip drain wait
+	clientW, clientR, _ := newTestServerFull(t, daemonCtlPath, baseDir)
+	defer clientW.Close()
 	sendLine(t, clientW, fmt.Sprintf(
 		`{"jsonrpc":"2.0","id":45,"method":"tools/call","params":{"name":"mux_restart","arguments":{"server_id":"%s","force":true}}}`, sid))
 	line := readLine(t, clientR)
@@ -1053,16 +1126,13 @@ func TestMuxRestartWithFakeServer(t *testing.T) {
 	}
 	unmarshalResult(t, resp, &result)
 
-	// Restart may succeed (spawn new daemon) or fail at exec.Command
-	// Either way, it should have gotten past status+shutdown successfully
 	if result.IsError {
-		// Accept failure at exec.Command stage — still covers status+shutdown paths
 		text := result.Content[0].Text
-		if strings.Contains(text, "unreachable") || strings.Contains(text, "no command info") {
-			t.Fatalf("restart failed too early (status/shutdown stage): %s", text)
+		if strings.Contains(text, "unreachable") || strings.Contains(text, "no command info") || strings.Contains(text, "not managed") {
+			t.Fatalf("restart failed at resolve stage: %s", text)
 		}
+		// exec.Command spawn failure is acceptable in test environment
 	} else {
-		// Success — includes "restarted:" prefix
 		if len(result.Content) == 0 || !strings.Contains(result.Content[0].Text, "restarted") {
 			t.Errorf("expected 'restarted' in success message, got: %v", result.Content)
 		}
@@ -1071,15 +1141,25 @@ func TestMuxRestartWithFakeServer(t *testing.T) {
 
 func TestMuxRestartByName(t *testing.T) {
 	sid := "ffbb112233445566"
-	clientW, clientR, _, baseDir := newTestServer(t)
-	defer clientW.Close()
+	baseDir, err := os.MkdirTemp("", "mcpmux-restartname-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(baseDir) })
 
-	_ = startFakeControlServer(t, baseDir, sid, map[string]any{
-		"command":       "node",
-		"args":          []string{"unique-restart-by-name-test.js"},
-		"session_count": 1,
-		"mux_version":   "test",
+	daemonCtlPath := filepath.Join(baseDir, "test-restartname-muxd.ctl.sock")
+	owners := control.ListOwnersResponse{
+		Owners: []control.OwnerInfo{
+			{ServerID: sid, Command: "node", Args: []string{"unique-restart-by-name-test.js"}, Sessions: 1},
+		},
+	}
+	startFakeDaemonControlServer(t, daemonCtlPath, owners)
+	startFakeControlServer(t, baseDir, sid, map[string]any{
+		"command": "node", "args": []string{"unique-restart-by-name-test.js"},
 	})
+
+	clientW, clientR, _ := newTestServerFull(t, daemonCtlPath, baseDir)
+	defer clientW.Close()
 
 	sendLine(t, clientW, `{"jsonrpc":"2.0","id":46,"method":"tools/call","params":{"name":"mux_restart","arguments":{"name":"unique-restart-by-name-test","force":true}}}`)
 	line := readLine(t, clientR)
@@ -1095,10 +1175,9 @@ func TestMuxRestartByName(t *testing.T) {
 	}
 	unmarshalResult(t, resp, &result)
 
-	// Accept both success and exec.Command failure — covers resolveServerID+status+shutdown paths
 	if result.IsError {
 		text := result.Content[0].Text
-		if strings.Contains(text, "no server matching") {
+		if strings.Contains(text, "no server matching") || strings.Contains(text, "not managed") {
 			t.Fatalf("restart by name failed to resolve: %s", text)
 		}
 	}
@@ -1106,14 +1185,23 @@ func TestMuxRestartByName(t *testing.T) {
 
 func TestMuxRestartNoCommandInfo(t *testing.T) {
 	sid := "ffcc112233445566"
-	clientW, clientR, _, baseDir := newTestServer(t)
-	defer clientW.Close()
+	baseDir, err := os.MkdirTemp("", "mcpmux-nocmd-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(baseDir) })
 
-	// Status returns no command field — should fail with "has no command info"
-	_ = startFakeControlServer(t, baseDir, sid, map[string]any{
-		"session_count": 1,
-		"mux_version":   "test",
-	})
+	daemonCtlPath := filepath.Join(baseDir, "test-nocmd-muxd.ctl.sock")
+	// Daemon returns owner with empty Command
+	owners := control.ListOwnersResponse{
+		Owners: []control.OwnerInfo{
+			{ServerID: sid, Command: "", Args: nil, Sessions: 1},
+		},
+	}
+	startFakeDaemonControlServer(t, daemonCtlPath, owners)
+
+	clientW, clientR, _ := newTestServerFull(t, daemonCtlPath, baseDir)
+	defer clientW.Close()
 
 	sendLine(t, clientW, fmt.Sprintf(
 		`{"jsonrpc":"2.0","id":47,"method":"tools/call","params":{"name":"mux_restart","arguments":{"server_id":"%s"}}}`, sid))
@@ -1139,15 +1227,25 @@ func TestMuxRestartNoCommandInfo(t *testing.T) {
 
 func TestMuxStopForce(t *testing.T) {
 	sid := "ffdd112233445566"
-	clientW, clientR, _, baseDir := newTestServer(t)
-	defer clientW.Close()
+	baseDir, err := os.MkdirTemp("", "mcpmux-stopforce-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(baseDir) })
 
-	_ = startFakeControlServer(t, baseDir, sid, map[string]any{
-		"command":       "uvx",
-		"args":          []string{"force-stop-test"},
-		"session_count": 1,
-		"mux_version":   "test",
+	daemonCtlPath := filepath.Join(baseDir, "test-stopforce-muxd.ctl.sock")
+	owners := control.ListOwnersResponse{
+		Owners: []control.OwnerInfo{
+			{ServerID: sid, Command: "uvx", Args: []string{"force-stop-test"}, Sessions: 1},
+		},
+	}
+	startFakeDaemonControlServer(t, daemonCtlPath, owners)
+	startFakeControlServer(t, baseDir, sid, map[string]any{
+		"command": "uvx", "args": []string{"force-stop-test"},
 	})
+
+	clientW, clientR, _ := newTestServerFull(t, daemonCtlPath, baseDir)
+	defer clientW.Close()
 
 	sendLine(t, clientW, fmt.Sprintf(
 		`{"jsonrpc":"2.0","id":48,"method":"tools/call","params":{"name":"mux_stop","arguments":{"server_id":"%s","force":true}}}`, sid))
@@ -1219,5 +1317,78 @@ func TestMuxListFilterByCwd(t *testing.T) {
 	}
 	if strings.Contains(text, "other-server") {
 		t.Errorf("filtered mux_list should NOT contain other-server, got: %s", text)
+	}
+}
+
+func TestMuxRestartRefusesForeignID(t *testing.T) {
+	baseDir, err := os.MkdirTemp("", "mcpmux-foreign-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(baseDir) })
+
+	daemonCtlPath := filepath.Join(baseDir, "foreign-test-muxd.ctl.sock")
+	// Empty owners list — any server_id is foreign
+	startFakeDaemonControlServer(t, daemonCtlPath, control.ListOwnersResponse{})
+
+	clientW, clientR, _ := newTestServerFull(t, daemonCtlPath, baseDir)
+	defer clientW.Close()
+
+	foreignID := "deadbeef12345678"
+	sendLine(t, clientW, fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":50,"method":"tools/call","params":{"name":"mux_restart","arguments":{"server_id":"%s"}}}`, foreignID))
+	line := readLine(t, clientR)
+	resp := parseResponse(t, line)
+	assertID(t, resp, 50)
+	assertNoError(t, resp)
+
+	var result struct {
+		IsError bool `json:"isError"`
+		Content []struct {
+			Text string `json:"text"`
+		} `json:"content"`
+	}
+	unmarshalResult(t, resp, &result)
+	if !result.IsError {
+		t.Fatal("expected isError=true for foreign server_id")
+	}
+	if !strings.Contains(result.Content[0].Text, "not managed by this mcp-mux daemon") {
+		t.Errorf("expected 'not managed by this mcp-mux daemon', got: %s", result.Content[0].Text)
+	}
+}
+
+func TestMuxStopRefusesForeignID(t *testing.T) {
+	baseDir, err := os.MkdirTemp("", "mcpmux-stopforeign-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(baseDir) })
+
+	daemonCtlPath := filepath.Join(baseDir, "stopforeign-muxd.ctl.sock")
+	startFakeDaemonControlServer(t, daemonCtlPath, control.ListOwnersResponse{})
+
+	clientW, clientR, _ := newTestServerFull(t, daemonCtlPath, baseDir)
+	defer clientW.Close()
+
+	foreignID := "deadbeef87654321"
+	sendLine(t, clientW, fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":51,"method":"tools/call","params":{"name":"mux_stop","arguments":{"server_id":"%s"}}}`, foreignID))
+	line := readLine(t, clientR)
+	resp := parseResponse(t, line)
+	assertID(t, resp, 51)
+	assertNoError(t, resp)
+
+	var result struct {
+		IsError bool `json:"isError"`
+		Content []struct {
+			Text string `json:"text"`
+		} `json:"content"`
+	}
+	unmarshalResult(t, resp, &result)
+	if !result.IsError {
+		t.Fatal("expected isError=true for foreign server_id in mux_stop")
+	}
+	if !strings.Contains(result.Content[0].Text, "not managed by this mcp-mux daemon") {
+		t.Errorf("expected 'not managed by this mcp-mux daemon', got: %s", result.Content[0].Text)
 	}
 }

--- a/internal/mcpserver/server_test.go
+++ b/internal/mcpserver/server_test.go
@@ -688,7 +688,6 @@ func TestMuxRestartNoIDOrName(t *testing.T) {
 
 func TestMuxStopNoMatchingServer(t *testing.T) {
 	baseDir := shortBaseDir(t, "mcpmux-stopnomatch-")
-	t.Cleanup(func() { os.RemoveAll(baseDir) })
 
 	daemonCtlPath := filepath.Join(baseDir, "stopnomatch-muxd.ctl.sock")
 	startFakeDaemonControlServer(t, daemonCtlPath, control.ListOwnersResponse{})
@@ -714,6 +713,9 @@ func TestMuxStopNoMatchingServer(t *testing.T) {
 	if !result.IsError {
 		t.Fatal("expected isError=true for non-existent server name")
 	}
+	if len(result.Content) == 0 {
+		t.Fatal("expected non-empty content for tool error")
+	}
 	if !strings.Contains(result.Content[0].Text, "no server matching 'nonexistent-server-xyzzy-12345' found") {
 		t.Fatalf("expected no-match error, got: %s", result.Content[0].Text)
 	}
@@ -721,7 +723,6 @@ func TestMuxStopNoMatchingServer(t *testing.T) {
 
 func TestMuxRestartNoMatchingServer(t *testing.T) {
 	baseDir := shortBaseDir(t, "mcpmux-restartnomatch-")
-	t.Cleanup(func() { os.RemoveAll(baseDir) })
 
 	daemonCtlPath := filepath.Join(baseDir, "restartnomatch-muxd.ctl.sock")
 	startFakeDaemonControlServer(t, daemonCtlPath, control.ListOwnersResponse{})
@@ -745,6 +746,9 @@ func TestMuxRestartNoMatchingServer(t *testing.T) {
 	unmarshalResult(t, resp, &result)
 	if !result.IsError {
 		t.Fatal("expected isError=true for non-existent server name in mux_restart")
+	}
+	if len(result.Content) == 0 {
+		t.Fatal("expected non-empty content for tool error")
 	}
 	if !strings.Contains(result.Content[0].Text, "no server matching 'nonexistent-server-xyzzy-12345' found") {
 		t.Fatalf("expected no-match error, got: %s", result.Content[0].Text)
@@ -830,27 +834,47 @@ func startFakeControlServer(t *testing.T, dir, serverID string, status map[strin
 	return srv
 }
 
-// fakeDaemonHandler implements control.DaemonHandler for testing the list_owners path.
+// fakeDaemonHandler implements control.DaemonHandler for testing the list_owners path
+// and any other DaemonHandler entry the test wants to drive. All response fields are
+// caller-configurable so tests can assert specific behaviour per entry point — no
+// "not implemented" stubs (would violate the no-stubs guideline and make later test
+// authors chase nil panics).
 type fakeDaemonHandler struct {
 	fakeHandler
 	listOwnersResp control.ListOwnersResponse
 	listOwnersErr  error
+
+	spawnServerID string
+	spawnCtlPath  string
+	spawnLockPath string
+	spawnErr      error
+
+	removeErr error
+
+	restartMsg   string
+	restartAfter func()
+	restartErr   error
+
+	refreshToken string
+	refreshErr   error
+
+	reconnectErr error
 }
 
 func (h *fakeDaemonHandler) HandleSpawn(_ control.Request) (string, string, string, error) {
-	return "", "", "", fmt.Errorf("not implemented")
+	return h.spawnServerID, h.spawnCtlPath, h.spawnLockPath, h.spawnErr
 }
 func (h *fakeDaemonHandler) HandleRemove(_ string) error {
-	return fmt.Errorf("not implemented")
+	return h.removeErr
 }
 func (h *fakeDaemonHandler) HandleGracefulRestart(_ int) (string, func(), error) {
-	return "", nil, fmt.Errorf("not implemented")
+	return h.restartMsg, h.restartAfter, h.restartErr
 }
 func (h *fakeDaemonHandler) HandleRefreshSessionToken(_ string) (string, error) {
-	return "", fmt.Errorf("not implemented")
+	return h.refreshToken, h.refreshErr
 }
 func (h *fakeDaemonHandler) HandleReconnectGiveUp(_ string) error {
-	return fmt.Errorf("not implemented")
+	return h.reconnectErr
 }
 func (h *fakeDaemonHandler) HandleListOwners(_ control.Request) (control.ListOwnersResponse, error) {
 	return h.listOwnersResp, h.listOwnersErr
@@ -1198,6 +1222,9 @@ func TestMuxRestartNoCommandInfo(t *testing.T) {
 	if !result.IsError {
 		t.Fatal("expected error when server has no command info")
 	}
+	if len(result.Content) == 0 {
+		t.Fatal("expected non-empty content for tool error")
+	}
 	if !strings.Contains(result.Content[0].Text, "no command info") {
 		t.Errorf("expected 'no command info' error, got: %s", result.Content[0].Text)
 	}
@@ -1318,6 +1345,9 @@ func TestMuxRestartRefusesForeignID(t *testing.T) {
 	if !result.IsError {
 		t.Fatal("expected isError=true for foreign server_id")
 	}
+	if len(result.Content) == 0 {
+		t.Fatal("expected non-empty content for tool error")
+	}
 	if !strings.Contains(result.Content[0].Text, "not managed by this mcp-mux daemon") {
 		t.Errorf("expected 'not managed by this mcp-mux daemon', got: %s", result.Content[0].Text)
 	}
@@ -1349,6 +1379,9 @@ func TestMuxStopRefusesForeignID(t *testing.T) {
 	unmarshalResult(t, resp, &result)
 	if !result.IsError {
 		t.Fatal("expected isError=true for foreign server_id in mux_stop")
+	}
+	if len(result.Content) == 0 {
+		t.Fatal("expected non-empty content for tool error")
 	}
 	if !strings.Contains(result.Content[0].Text, "not managed by this mcp-mux daemon") {
 		t.Errorf("expected 'not managed by this mcp-mux daemon', got: %s", result.Content[0].Text)

--- a/muxcore/control/control_test.go
+++ b/muxcore/control/control_test.go
@@ -230,6 +230,10 @@ func (m *mockDaemonHandler) HandleReconnectGiveUp(reason string) error {
 	return nil
 }
 
+func (m *mockDaemonHandler) HandleListOwners(req Request) (ListOwnersResponse, error) {
+	return ListOwnersResponse{}, nil
+}
+
 // TestSocketPath verifies SocketPath returns the address used at creation.
 func TestSocketPath(t *testing.T) {
 	path := testSocketPath(t)

--- a/muxcore/control/protocol.go
+++ b/muxcore/control/protocol.go
@@ -45,6 +45,26 @@ type CommandHandler interface {
 	HandleStatus() map[string]interface{}
 }
 
+// OwnerInfo contains summary data for a single managed owner returned by list_owners.
+type OwnerInfo struct {
+	ServerID       string   `json:"server_id"`
+	Command        string   `json:"command"`
+	Args           []string `json:"args"`
+	Cwd            string   `json:"cwd"`
+	CwdSet         []string `json:"cwd_set"`
+	Sessions       int      `json:"sessions"`
+	Pending        int      `json:"pending"`
+	Classification string   `json:"classification"`
+	MuxVersion     string   `json:"mux_version"`
+	Persistent     bool     `json:"persistent"`
+}
+
+// ListOwnersResponse is the response payload for the "list_owners" daemon RPC.
+type ListOwnersResponse struct {
+	Owners    []OwnerInfo `json:"owners"`
+	Truncated bool        `json:"truncated"`
+}
+
 // DaemonHandler extends CommandHandler with daemon-specific commands.
 type DaemonHandler interface {
 	CommandHandler
@@ -53,4 +73,5 @@ type DaemonHandler interface {
 	HandleGracefulRestart(drainTimeoutMs int) (snapshotPath string, afterResponse func(), err error)
 	HandleRefreshSessionToken(prevToken string) (newToken string, err error)
 	HandleReconnectGiveUp(reason string) error
+	HandleListOwners(req Request) (ListOwnersResponse, error)
 }

--- a/muxcore/control/server.go
+++ b/muxcore/control/server.go
@@ -184,6 +184,21 @@ func (s *Server) dispatch(req Request) (Response, func()) {
 		}
 		return Response{OK: true, Message: "recorded"}, nil
 
+	case "list_owners":
+		dh, ok := s.handler.(DaemonHandler)
+		if !ok {
+			return Response{OK: false, Message: "list_owners not supported (not a daemon)"}, nil
+		}
+		result, err := dh.HandleListOwners(req)
+		if err != nil {
+			return Response{OK: false, Message: fmt.Sprintf("list_owners: %v", err)}, nil
+		}
+		data, err := json.Marshal(result)
+		if err != nil {
+			return Response{OK: false, Message: fmt.Sprintf("marshal list_owners: %v", err)}, nil
+		}
+		return Response{OK: true, Data: data}, nil
+
 	default:
 		return Response{OK: false, Message: fmt.Sprintf("unknown command: %s", req.Cmd)}, nil
 	}

--- a/muxcore/daemon/daemon.go
+++ b/muxcore/daemon/daemon.go
@@ -24,8 +24,8 @@ import (
 	muxcore "github.com/thebtf/mcp-mux/muxcore"
 	"github.com/thebtf/mcp-mux/muxcore/control"
 	"github.com/thebtf/mcp-mux/muxcore/owner"
-	"github.com/thebtf/mcp-mux/muxcore/session"
 	"github.com/thebtf/mcp-mux/muxcore/serverid"
+	"github.com/thebtf/mcp-mux/muxcore/session"
 	mcpsnapshot "github.com/thebtf/mcp-mux/muxcore/snapshot"
 	"github.com/thejerf/suture/v4"
 )
@@ -86,10 +86,10 @@ type OwnerEntry struct {
 
 // Daemon manages N owners, handles spawn/remove, and implements control.DaemonHandler.
 type Daemon struct {
-	mu          sync.RWMutex
-	owners      map[string]*OwnerEntry
-	logger      *log.Logger
-	ctlSrv      *control.Server
+	mu             sync.RWMutex
+	owners         map[string]*OwnerEntry
+	logger         *log.Logger
+	ctlSrv         *control.Server
 	done           chan struct{}
 	handlerFunc    func(ctx context.Context, stdin io.Reader, stdout io.Writer) error
 	sessionHandler muxcore.SessionHandler
@@ -99,16 +99,16 @@ type Daemon struct {
 	// tokens, no busy declarations) before the reaper removes it. Default 10m.
 	// Overridable per-owner via x-mux.idleTimeout capability.
 	ownerIdleTimeout time.Duration
-	idleTimeout      time.Duration // daemon-level auto-exit timeout (zero owners + zero sessions)
+	idleTimeout      time.Duration                        // daemon-level auto-exit timeout (zero owners + zero sessions)
 	templateCache    map[string]mcpsnapshot.OwnerSnapshot // command+args key → cached init data
 
 	// supervisor manages owner lifecycle with exponential backoff on restart.
 	// Owners are added via supervisor.Add in Spawn() and removed via
 	// supervisor.Remove in daemon.Remove. Context-cancelled on Shutdown.
-	supervisor    *suture.Supervisor
-	supervisorCtx context.Context
+	supervisor       *suture.Supervisor
+	supervisorCtx    context.Context
 	supervisorCancel context.CancelFunc
-	supervisorErr <-chan error
+	supervisorErr    <-chan error
 
 	// crashTracker records recent crash timestamps per command key.
 	// Used by Spawn() as a circuit breaker: if an upstream crashes too many
@@ -122,7 +122,8 @@ type Daemon struct {
 
 	// name is the engine instance name from Config.Name (e.g. "mcp-mux", "aimux").
 	// Used to scope IPC socket file paths and stale-socket cleanup to this engine.
-	name string
+	name       string
+	persistent bool
 
 	// zombieDetectedSpawn counts how many times the FR-4 spawn-time health
 	// gate in spawnOnce tore down a registered owner because IsReachable()
@@ -259,6 +260,7 @@ func New(cfg Config) (*Daemon, error) {
 		sessionHandler:   cfg.SessionHandler,
 		daemonFlag:       daemonFlag,
 		name:             cfg.Name,
+		persistent:       cfg.Persistent,
 	}
 
 	// Create supervisor with exponential backoff on restart storms.
@@ -897,6 +899,7 @@ func (d *Daemon) spawnOnce(reqPtr *control.Request) (string, string, string, err
 	placeholder.LastSession = time.Now()
 	placeholder.IdleTimeout = d.ownerIdleTimeout
 	placeholder.serviceToken = serviceToken
+	placeholder.Persistent = d.persistent
 	close(placeholder.creating)
 	placeholder.creating = nil // no longer a placeholder
 	d.mu.Unlock()
@@ -1333,16 +1336,16 @@ func (d *Daemon) HandleStatus() map[string]any {
 	}
 
 	return map[string]any{
-		"daemon":                   true,
-		"owner_count":              len(servers), // excludes placeholders still being created
-		"servers":                  servers,
-		"owner_idle_timeout":       d.ownerIdleTimeout.String(),
-		"idle_timeout":             d.idleTimeout.String(),
-		"shim_reconnect_refreshed": d.reconnectRefreshed.Load(),
+		"daemon":                          true,
+		"owner_count":                     len(servers), // excludes placeholders still being created
+		"servers":                         servers,
+		"owner_idle_timeout":              d.ownerIdleTimeout.String(),
+		"idle_timeout":                    d.idleTimeout.String(),
+		"shim_reconnect_refreshed":        d.reconnectRefreshed.Load(),
 		"shim_reconnect_fallback_spawned": d.reconnectFallbackSpawned.Load(),
-		"shim_reconnect_gave_up":   d.reconnectGaveUp.Load(),
-		"zombie_detections_spawn":  d.zombieDetectedSpawn,
-		"zombie_detections_restore": d.zombieDetectedRestore,
+		"shim_reconnect_gave_up":          d.reconnectGaveUp.Load(),
+		"zombie_detections_spawn":         d.zombieDetectedSpawn,
+		"zombie_detections_restore":       d.zombieDetectedRestore,
 		"handoff": map[string]any{
 			"attempted":   d.stats.attempted.Load(),
 			"transferred": d.stats.transferred.Load(),

--- a/muxcore/daemon/daemon.go
+++ b/muxcore/daemon/daemon.go
@@ -119,6 +119,10 @@ type Daemon struct {
 	// Initialized from Config.DaemonFlag; defaults to "--daemon" when empty.
 	daemonFlag string
 
+	// name is the engine instance name from Config.Name (e.g. "mcp-mux", "aimux").
+	// Used to scope IPC socket file paths and stale-socket cleanup to this engine.
+	name string
+
 	// zombieDetectedSpawn counts how many times the FR-4 spawn-time health
 	// gate in spawnOnce tore down a registered owner because IsReachable()
 	// returned false despite IsAccepting() reporting open. Counter is
@@ -200,6 +204,16 @@ type Config struct {
 	// If empty, defaults to "--daemon" for backward compatibility with
 	// pre-v0.21.7 callers that don't set it.
 	DaemonFlag string
+
+	// Name is the engine instance name (e.g. "mcp-mux", "aimux", "engram").
+	// Used to scope IPC socket file names and stale-socket cleanup to this
+	// engine only. Empty string is valid (library is pure); callers that want
+	// FS isolation across multiple engine types must set this.
+	Name string
+
+	// Persistent overrides per-owner Persistent detection. When true, all owners
+	// managed by this daemon are treated as persistent (not evicted on idle).
+	Persistent bool
 }
 
 var _ control.DaemonHandler = (*Daemon)(nil)
@@ -243,6 +257,7 @@ func New(cfg Config) (*Daemon, error) {
 		handlerFunc:      cfg.HandlerFunc,
 		sessionHandler:   cfg.SessionHandler,
 		daemonFlag:       daemonFlag,
+		name:             cfg.Name,
 	}
 
 	// Create supervisor with exponential backoff on restart storms.
@@ -287,7 +302,7 @@ func New(cfg Config) (*Daemon, error) {
 	}
 
 	// Clean up stale socket files from previous daemon crashes/kills.
-	cleaned := cleanStaleSockets(logger)
+	cleaned := cleanStaleSockets(d.name, logger)
 	if cleaned > 0 {
 		logger.Printf("startup: cleaned %d stale socket files", cleaned)
 	}
@@ -461,10 +476,20 @@ func (d *Daemon) cleanupDeadOwner(serviceName string) {
 	d.mu.Unlock()
 }
 
-// cleanStaleSockets removes mcp-mux-*.ctl.sock and mcp-mux-*.sock files from
-// the temp directory that are not reachable (leftover from daemon crash/kill).
-func cleanStaleSockets(logger *log.Logger) int {
-	tmpDir := os.TempDir()
+// cleanStaleSocketsDir overrides the directory scanned by cleanStaleSockets.
+// Zero value ("") means os.TempDir(). Override in tests to use a temp dir.
+var cleanStaleSocketsDir = ""
+
+// cleanStaleSockets removes engine-scoped *.ctl.sock and *.sock files from the
+// temp directory that are not reachable (leftover from daemon crash/kill).
+// Only files whose names start with engineName+"-" are considered; sockets
+// belonging to other engines are left untouched.
+func cleanStaleSockets(engineName string, logger *log.Logger) int {
+	prefix := engineName + "-"
+	tmpDir := cleanStaleSocketsDir
+	if tmpDir == "" {
+		tmpDir = os.TempDir()
+	}
 	entries, err := os.ReadDir(tmpDir)
 	if err != nil {
 		return 0
@@ -472,8 +497,13 @@ func cleanStaleSockets(logger *log.Logger) int {
 	cleaned := 0
 	for _, entry := range entries {
 		name := entry.Name()
-		// Match mcp-mux sockets (mcp-mux-*.sock) and engine daemon sockets (*-muxd.ctl.sock)
-		isMuxSocket := strings.HasPrefix(name, "mcp-mux-") && strings.HasSuffix(name, ".sock")
+		// Only consider sockets that belong to this engine (scoped by prefix).
+		if !strings.HasPrefix(name, prefix) {
+			continue
+		}
+		// Match IPC data sockets (*-<id>.sock) and control sockets (*-<id>.ctl.sock
+		// and *-muxd.ctl.sock).
+		isMuxSocket := strings.HasSuffix(name, ".sock")
 		isDaemonSocket := strings.HasSuffix(name, "-muxd.ctl.sock")
 		if !isMuxSocket && !isDaemonSocket {
 			continue
@@ -750,7 +780,7 @@ func (d *Daemon) spawnOnce(reqPtr *control.Request) (string, string, string, err
 	d.owners[sid] = placeholder
 	d.mu.Unlock()
 
-	ipcPath := serverid.IPCPath(sid, "")
+	ipcPath := serverid.IPCPath("", d.name, sid)
 
 	// Pass full session env to the owner. Shim-supplied vars WIN; daemon env
 	// fills gaps. Rationale: some shims are launched by tools that strip
@@ -775,7 +805,7 @@ func (d *Daemon) spawnOnce(reqPtr *control.Request) (string, string, string, err
 	}
 
 	// Build the shared owner config (used by both template and fresh paths).
-	controlPath := serverid.ControlPath(sid, "")
+	controlPath := serverid.ControlPath("", d.name, sid)
 	ownerCfg := owner.OwnerConfig{
 		Command:        req.Command,
 		Args:           req.Args,

--- a/muxcore/daemon/daemon.go
+++ b/muxcore/daemon/daemon.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1349,6 +1350,91 @@ func (d *Daemon) HandleStatus() map[string]any {
 			"fallback":    d.stats.fallback.Load(),
 		},
 	}
+}
+
+// HandleListOwners returns a snapshot of all active owners, capped at 200 entries,
+// sorted by server_id ascending for deterministic output. Placeholder entries
+// (Owner == nil) are excluded. Satisfies control.DaemonHandler.
+func (d *Daemon) HandleListOwners(req control.Request) (control.ListOwnersResponse, error) {
+	const maxOwners = 200
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	// Collect server IDs, skipping placeholder entries.
+	sids := make([]string, 0, len(d.owners))
+	for sid, entry := range d.owners {
+		if entry.Owner == nil {
+			continue
+		}
+		sids = append(sids, sid)
+	}
+	sort.Strings(sids)
+
+	truncated := false
+	if len(sids) > maxOwners {
+		sids = sids[:maxOwners]
+		truncated = true
+	}
+
+	owners := make([]control.OwnerInfo, 0, len(sids))
+	for _, sid := range sids {
+		entry := d.owners[sid]
+		if entry == nil || entry.Owner == nil {
+			continue
+		}
+		s := entry.Owner.Status()
+
+		cwd, _ := s["cwd"].(string)
+		muxVer, _ := s["mux_version"].(string)
+		classification, _ := s["auto_classification"].(string)
+
+		sessions := 0
+		switch v := s["session_count"].(type) {
+		case int:
+			sessions = v
+		case float64:
+			sessions = int(v)
+		case int64:
+			sessions = int(v)
+		}
+
+		pending := 0
+		switch v := s["pending_requests"].(type) {
+		case int64:
+			pending = int(v)
+		case float64:
+			pending = int(v)
+		case int:
+			pending = v
+		}
+
+		var cwdSet []string
+		switch v := s["cwd_set"].(type) {
+		case []string:
+			cwdSet = v
+		case []any:
+			for _, c := range v {
+				if cs, ok := c.(string); ok {
+					cwdSet = append(cwdSet, cs)
+				}
+			}
+		}
+
+		owners = append(owners, control.OwnerInfo{
+			ServerID:       sid,
+			Command:        entry.Command,
+			Args:           entry.Args,
+			Cwd:            cwd,
+			CwdSet:         cwdSet,
+			Sessions:       sessions,
+			Pending:        pending,
+			Classification: classification,
+			MuxVersion:     muxVer,
+			Persistent:     entry.Persistent,
+		})
+	}
+
+	return control.ListOwnersResponse{Owners: owners, Truncated: truncated}, nil
 }
 
 func (d *Daemon) ownerIsAccepting(serverID string) bool {

--- a/muxcore/daemon/daemon_persistent_test.go
+++ b/muxcore/daemon/daemon_persistent_test.go
@@ -1,0 +1,45 @@
+package daemon
+
+import (
+	"testing"
+	"time"
+
+	"github.com/thebtf/mcp-mux/muxcore/control"
+)
+
+func TestSessionHandlerOwnerInheritsPersistent(t *testing.T) {
+	ctlPath := shortSocketPath(t, "persist.ctl.sock")
+	d, err := New(Config{
+		ControlPath:    ctlPath,
+		GracePeriod:    1 * time.Second,
+		IdleTimeout:    5 * time.Second,
+		SkipSnapshot:   true,
+		Logger:         testLogger(t),
+		Persistent:     true,
+		SessionHandler: noopSessionHandler{},
+	})
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	t.Cleanup(func() { d.Shutdown() })
+
+	_, sid, _, err := d.Spawn(control.Request{
+		Cmd:  "spawn",
+		Args: []string{t.Name()},
+		Mode: "global",
+	})
+	if err != nil {
+		t.Fatalf("Spawn() error: %v", err)
+	}
+
+	d.mu.RLock()
+	entry := d.owners[sid]
+	d.mu.RUnlock()
+
+	if entry == nil {
+		t.Fatal("owner entry not found after Spawn")
+	}
+	if !entry.Persistent {
+		t.Errorf("OwnerEntry.Persistent = false, want true (d.cfg.Persistent=true should propagate)")
+	}
+}

--- a/muxcore/daemon/daemon_test.go
+++ b/muxcore/daemon/daemon_test.go
@@ -970,9 +970,14 @@ func TestFindSharedOwnerEnvFiltering(t *testing.T) {
 func TestCleanStaleSockets(t *testing.T) {
 	const staleSocketCount = 3
 
+	tmpDir := t.TempDir()
+	orig := cleanStaleSocketsDir
+	cleanStaleSocketsDir = tmpDir
+	t.Cleanup(func() { cleanStaleSocketsDir = orig })
+
 	paths := make([]string, 0, staleSocketCount)
 	for i := 0; i < staleSocketCount; i++ {
-		f, err := os.CreateTemp(os.TempDir(), "mcp-mux-*-test.ctl.sock")
+		f, err := os.CreateTemp(tmpDir, "mcp-mux-*-test.ctl.sock")
 		if err != nil {
 			t.Fatalf("CreateTemp() error: %v", err)
 		}
@@ -980,11 +985,10 @@ func TestCleanStaleSockets(t *testing.T) {
 		if err := f.Close(); err != nil {
 			t.Fatalf("Close() error: %v", err)
 		}
-		t.Cleanup(func() { os.Remove(path) })
 		paths = append(paths, path)
 	}
 
-	cleaned := cleanStaleSockets(testLogger(t))
+	cleaned := cleanStaleSockets("mcp-mux", testLogger(t))
 	if cleaned != staleSocketCount {
 		t.Fatalf("cleanStaleSockets() = %d, want %d", cleaned, staleSocketCount)
 	}
@@ -998,6 +1002,38 @@ func TestCleanStaleSockets(t *testing.T) {
 			t.Fatalf("Stat(%q) error = %v, want not exist", path, err)
 		}
 	}
+}
+
+// TestCleanStaleSocketsNameScope verifies that cleanStaleSockets scoped to
+// "aimux-test" does NOT remove sockets belonging to other engines ("mcp-mux").
+func TestCleanStaleSocketsNameScope(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Override the scan directory for this test.
+	orig := cleanStaleSocketsDir
+	cleanStaleSocketsDir = tmpDir
+	t.Cleanup(func() { cleanStaleSocketsDir = orig })
+
+	// Seed files: one owned by "aimux-test", one owned by "mcp-mux".
+	aimuxSocket := filepath.Join(tmpDir, "aimux-test-abc12345.ctl.sock")
+	mcpMuxSocket := filepath.Join(tmpDir, "mcp-mux-stale-1.ctl.sock")
+	if err := os.WriteFile(aimuxSocket, []byte("placeholder"), 0600); err != nil {
+		t.Fatalf("seed aimux socket: %v", err)
+	}
+	if err := os.WriteFile(mcpMuxSocket, []byte("placeholder"), 0600); err != nil {
+		t.Fatalf("seed mcp-mux socket: %v", err)
+	}
+
+	cleanStaleSockets("aimux-test", testLogger(t))
+
+	// The mcp-mux socket MUST NOT be removed — it belongs to a different engine.
+	if _, err := os.Stat(mcpMuxSocket); os.IsNotExist(err) {
+		t.Errorf("mcp-mux-stale-1.ctl.sock was removed by cleanStaleSockets(\"aimux-test\") — foreign-prefix isolation violated")
+	}
+	t.Logf("mcp-mux socket preserved: %v", func() bool {
+		_, err := os.Stat(mcpMuxSocket)
+		return err == nil
+	}())
 }
 
 func findSharedOwnerLocked(d *Daemon, command string, args []string, env map[string]string) *OwnerEntry {

--- a/muxcore/daemon/list_owners_test.go
+++ b/muxcore/daemon/list_owners_test.go
@@ -1,0 +1,123 @@
+package daemon
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/thebtf/mcp-mux/muxcore/control"
+	"github.com/thebtf/mcp-mux/muxcore/owner"
+)
+
+// TestHandleListOwners registers 3 in-process owners with distinct cwds, calls
+// HandleListOwners, and asserts: count=3, truncated=false, sorted by server_id,
+// all expected IDs present.
+func TestHandleListOwners(t *testing.T) {
+	d := testDaemon(t)
+
+	// IDs chosen to have a deterministic alphabetical sort order: aaa... < bbb... < ccc...
+	sids := []string{"aaa0aaa000000001", "bbb0bbb000000002", "ccc0ccc000000003"}
+	cwds := []string{"/proj/alpha", "/proj/beta", "/proj/gamma"}
+
+	for i, sid := range sids {
+		ipcPath := shortSocketPath(t, "lo-"+sid[:4]+".sock")
+		o, err := owner.NewOwner(owner.OwnerConfig{
+			IPCPath:        ipcPath,
+			ServerID:       sid,
+			SessionHandler: noopSessionHandler{},
+			Logger:         testLogger(t),
+		})
+		if err != nil {
+			t.Fatalf("NewOwner %s: %v", sid, err)
+		}
+		capturedO := o
+		t.Cleanup(func() { capturedO.Shutdown() })
+
+		d.mu.Lock()
+		d.owners[sid] = &OwnerEntry{
+			Owner:    o,
+			ServerID: sid,
+			Command:  "test-cmd",
+			Args:     []string{"--arg"},
+			Cwd:      cwds[i],
+		}
+		d.mu.Unlock()
+	}
+
+	resp, err := d.HandleListOwners(control.Request{Cmd: "list_owners"})
+	if err != nil {
+		t.Fatalf("HandleListOwners error: %v", err)
+	}
+
+	if len(resp.Owners) != 3 {
+		t.Errorf("want 3 owners, got %d", len(resp.Owners))
+	}
+	if resp.Truncated {
+		t.Error("want truncated=false for 3 owners, got true")
+	}
+
+	// Assert sorted ascending by server_id.
+	gotSIDs := make([]string, len(resp.Owners))
+	for i, o := range resp.Owners {
+		gotSIDs[i] = o.ServerID
+	}
+	if !sort.StringsAreSorted(gotSIDs) {
+		t.Errorf("owners not sorted by server_id ascending: %v", gotSIDs)
+	}
+
+	// All expected SIDs must be present, and no owner may have an empty ServerID.
+	sidSet := make(map[string]bool)
+	for _, o := range resp.Owners {
+		if o.ServerID == "" {
+			t.Error("owner has empty ServerID")
+		}
+		sidSet[o.ServerID] = true
+	}
+	for _, sid := range sids {
+		if !sidSet[sid] {
+			t.Errorf("missing server_id %s in response", sid)
+		}
+	}
+}
+
+// TestHandleListOwners_Truncated verifies that more than 200 owners causes
+// len(resp.Owners)==200 and truncated=true.
+func TestHandleListOwners_Truncated(t *testing.T) {
+	d := testDaemon(t)
+
+	// Create one real owner to share across all entries (Owner field must be non-nil
+	// for entries to be included in list_owners output).
+	ipcPath := shortSocketPath(t, "trunc.sock")
+	sharedOwner, err := owner.NewOwner(owner.OwnerConfig{
+		IPCPath:        ipcPath,
+		ServerID:       "shared-trunc-owner",
+		SessionHandler: noopSessionHandler{},
+		Logger:         testLogger(t),
+	})
+	if err != nil {
+		t.Fatalf("NewOwner: %v", err)
+	}
+	t.Cleanup(func() { sharedOwner.Shutdown() })
+
+	d.mu.Lock()
+	for i := 0; i < 201; i++ {
+		sid := fmt.Sprintf("sid%06d000000000", i)
+		d.owners[sid] = &OwnerEntry{
+			Owner:    sharedOwner,
+			ServerID: sid,
+			Command:  "test-cmd",
+		}
+	}
+	d.mu.Unlock()
+
+	resp, err := d.HandleListOwners(control.Request{Cmd: "list_owners"})
+	if err != nil {
+		t.Fatalf("HandleListOwners error: %v", err)
+	}
+	if len(resp.Owners) != 200 {
+		t.Errorf("want 200 owners (capped), got %d", len(resp.Owners))
+	}
+	if !resp.Truncated {
+		t.Error("want truncated=true for 201 owners, got false")
+	}
+}

--- a/muxcore/daemon/reaper_test.go
+++ b/muxcore/daemon/reaper_test.go
@@ -1,8 +1,10 @@
 package daemon
 
 import (
+	"bytes"
 	"log"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -90,6 +92,59 @@ func TestReaperPersistentSurvivesGrace(t *testing.T) {
 
 	if d.OwnerCount() != 1 {
 		t.Errorf("persistent owner was removed, OwnerCount() = %d", d.OwnerCount())
+	}
+}
+
+func TestReaperRespectsConfigPersistent(t *testing.T) {
+	var logs bytes.Buffer
+	logger := log.New(&logs, "[reaper-test] ", 0)
+	ctlPath := shortSocketPath(t, "persistent.ctl.sock")
+	d, err := New(Config{
+		ControlPath:      ctlPath,
+		IdleTimeout:      5 * time.Second,
+		OwnerIdleTimeout: 100 * time.Millisecond,
+		SkipSnapshot:     true,
+		Logger:           logger,
+		Persistent:       true,
+		SessionHandler:   noopSessionHandler{},
+	})
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	t.Cleanup(func() { d.Shutdown() })
+
+	_, sid, _, err := d.Spawn(control.Request{
+		Cmd:  "spawn",
+		Args: []string{t.Name()},
+		Mode: "global",
+	})
+	if err != nil {
+		t.Fatalf("Spawn() error: %v", err)
+	}
+
+	d.mu.Lock()
+	entry := d.owners[sid]
+	if entry == nil {
+		d.mu.Unlock()
+		t.Fatal("owner entry not found after Spawn")
+	}
+	entry.LastSession = time.Now().Add(-1 * time.Second)
+	d.mu.Unlock()
+
+	time.Sleep(150 * time.Millisecond)
+
+	r := &Reaper{daemon: d, logger: logger}
+	if affected := r.sweep(); affected != 0 {
+		t.Fatalf("sweep() affected %d owners, want 0 for persistent owner", affected)
+	}
+	if d.OwnerCount() != 1 {
+		t.Fatalf("OwnerCount() = %d after sweep, want 1", d.OwnerCount())
+	}
+	if got := d.Entry(sid); got == nil || !got.Persistent {
+		t.Fatal("persistent owner lost after sweep")
+	}
+	if logOutput := logs.String(); strings.Contains(logOutput, "soft-removing") || strings.Contains(logOutput, "upstream dead with 0 sessions, removing") {
+		t.Fatalf("reaper log indicates eviction for persistent owner: %s", logOutput)
 	}
 }
 

--- a/muxcore/daemon/snapshot.go
+++ b/muxcore/daemon/snapshot.go
@@ -143,8 +143,8 @@ func (d *Daemon) loadSnapshot() int {
 	restored := 0
 	for _, ownerSnap := range snap.Owners {
 		sid := ownerSnap.ServerID
-		ipcPath := serverid.IPCPath(sid, "")
-		controlPath := serverid.ControlPath(sid, "")
+		ipcPath := serverid.IPCPath("", d.name, sid)
+		controlPath := serverid.ControlPath("", d.name, sid)
 
 		if ownerSnap.Classification == classify.ModeIsolated &&
 			len(ownerSnap.CwdSet) > 1 {

--- a/muxcore/engine/engine.go
+++ b/muxcore/engine/engine.go
@@ -154,7 +154,7 @@ type MuxEngine struct {
 // Validates config and applies defaults.
 func New(cfg Config) (*MuxEngine, error) {
 	if cfg.Name == "" {
-		return nil, fmt.Errorf("engine: Name is required")
+		return nil, fmt.Errorf("muxcore: engine.Config.Name is required (was empty); pass a name unique to this binary, e.g. \"aimux\", \"mcp-mux\", \"engram\"")
 	}
 	if cfg.Command == "" && cfg.Handler == nil && cfg.SessionHandler == nil {
 		return nil, fmt.Errorf("engine: Command, Handler, or SessionHandler is required")
@@ -289,6 +289,8 @@ func (e *MuxEngine) runDaemon(ctx context.Context) error {
 		HandlerFunc:      handlerFunc,
 		SessionHandler:   e.cfg.SessionHandler,
 		DaemonFlag:       e.cfg.DaemonFlag,
+		Name:             e.cfg.Name,
+		Persistent:       e.cfg.Persistent,
 	})
 	if err != nil {
 		return fmt.Errorf("engine daemon: %w", err)

--- a/muxcore/engine/engine.go
+++ b/muxcore/engine/engine.go
@@ -385,6 +385,7 @@ func (e *MuxEngine) runClient(ctx context.Context) error {
 		Token:          token,
 		Reconnect:      reconnectFn,
 		StdinEOFPolicy: e.cfg.StdinEOFPolicy,
+		EnginePrefix:   e.cfg.Name,
 		Logger:         e.logger,
 	})
 }

--- a/muxcore/engine/engine_test.go
+++ b/muxcore/engine/engine_test.go
@@ -653,6 +653,44 @@ func TestEngine_DaemonModeExposesDaemon(t *testing.T) {
 	}
 }
 
+// TestNewRejectsEmptyName verifies that New returns an error with the exact
+// required message when cfg.Name is empty.
+func TestNewRejectsEmptyName(t *testing.T) {
+	cfg := Config{
+		Command: "echo",
+		// Name intentionally omitted (empty string)
+	}
+	e, err := New(cfg)
+	if err == nil {
+		t.Fatal("New() expected error for empty Name, got nil")
+	}
+	if e != nil {
+		t.Fatal("New() expected nil engine on error, got non-nil")
+	}
+	const wantMsg = `muxcore: engine.Config.Name is required (was empty); pass a name unique to this binary, e.g. "aimux", "mcp-mux", "engram"`
+	if err.Error() != wantMsg {
+		t.Errorf("New() error message mismatch:\n  got:  %q\n  want: %q", err.Error(), wantMsg)
+	}
+}
+
+// TestPersistentPropagatesToDaemonConfig verifies that engine.New preserves
+// cfg.Persistent in the engine config, which runDaemon then passes through to
+// daemon.Config{Persistent: true}.
+func TestPersistentPropagatesToDaemonConfig(t *testing.T) {
+	cfg := Config{
+		Name:           "test-persistent",
+		SessionHandler: noopSessionHandler{},
+		Persistent:     true,
+	}
+	e, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New() unexpected error: %v", err)
+	}
+	if !e.cfg.Persistent {
+		t.Error("engine.cfg.Persistent = false, want true — Persistent not preserved by New()")
+	}
+}
+
 // TestEngine_ProxyModeReady verifies that runProxy calls markReady(ModeProxy)
 // before invoking the handler, so Ready() fires and Mode() == ModeProxy.
 func TestEngine_ProxyModeReady(t *testing.T) {

--- a/muxcore/owner/resilient_client.go
+++ b/muxcore/owner/resilient_client.go
@@ -66,6 +66,11 @@ type ResilientClientConfig struct {
 
 	ProbeGracePeriod time.Duration // default: 10s; 0 disables probe detection
 	Logger           *log.Logger
+
+	// EnginePrefix is the engine name used as the prefix in IPC socket filenames
+	// (e.g. "mcp-mux", "aimux"). When empty, defaults to "mcp-mux" for backward
+	// compatibility with pre-v0.22 callers that don't set it.
+	EnginePrefix string
 }
 
 // initCache stores the first initialize request and response for replay on reconnect.
@@ -464,7 +469,7 @@ func (rc *resilientClient) reconnect(stdoutMu *sync.Mutex, stdinDone <-chan erro
 				continue
 			}
 
-			rc.log.Printf("shim.reconnect.refresh_ok owner=%s", ownerPrefixFromIPCPath(res.path))
+			rc.log.Printf("shim.reconnect.refresh_ok owner=%s", rc.ownerPrefixFromIPCPath(res.path))
 			return conn, nil
 		}
 		if fallbackReason == "" {
@@ -565,10 +570,19 @@ func isUnknownTokenError(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "unknown token")
 }
 
-func ownerPrefixFromIPCPath(ipcPath string) string {
+// ownerPrefixFromIPCPath extracts the short server-ID prefix (up to 8 chars)
+// from an IPC socket path for use in log messages. Strips the engine prefix
+// from rc.cfg.EnginePrefix (defaulting to "mcp-mux" for backward compat).
+// Converted to method to avoid the hardcoded "mcp-mux-" literal — engine name
+// is now caller-supplied via ResilientClientConfig.EnginePrefix.
+func (rc *resilientClient) ownerPrefixFromIPCPath(ipcPath string) string {
+	enginePrefix := rc.cfg.EnginePrefix
+	if enginePrefix == "" {
+		enginePrefix = "mcp-mux"
+	}
 	base := filepath.Base(ipcPath)
 	base = strings.TrimSuffix(base, ".sock")
-	base = strings.TrimPrefix(base, "mcp-mux-")
+	base = strings.TrimPrefix(base, enginePrefix+"-")
 	if idx := strings.IndexByte(base, '.'); idx >= 0 {
 		base = base[:idx]
 	}

--- a/muxcore/owner/resilient_client_reconnect_test.go
+++ b/muxcore/owner/resilient_client_reconnect_test.go
@@ -278,7 +278,13 @@ func TestReconnect_NoGoroutineLeakOnRefreshTimeout(t *testing.T) {
 
 func TestOwnerPrefixFromIPCPath(t *testing.T) {
 	path := filepath.Join(os.TempDir(), "mcp-mux-1234567890abcdef.sock")
-	if got := ownerPrefixFromIPCPath(path); got != "12345678" {
+	// ownerPrefixFromIPCPath is now a method; build a minimal resilientClient
+	// with default EnginePrefix (empty = "mcp-mux") to exercise the same path.
+	rc := &resilientClient{
+		cfg: ResilientClientConfig{EnginePrefix: ""},
+		log: log.New(io.Discard, "", 0),
+	}
+	if got := rc.ownerPrefixFromIPCPath(path); got != "12345678" {
 		t.Fatalf("ownerPrefixFromIPCPath() = %q, want %q", got, "12345678")
 	}
 }

--- a/muxcore/serverid/serverid.go
+++ b/muxcore/serverid/serverid.go
@@ -184,21 +184,24 @@ func resolveBaseDir(baseDir string) string {
 }
 
 // IPCPath returns the platform-specific IPC endpoint path for a given server ID.
-// When baseDir is empty, os.TempDir() is used.
-func IPCPath(id string, baseDir string) string {
-	return filepath.Join(resolveBaseDir(baseDir), fmt.Sprintf("mcp-mux-%s.sock", id))
+// Format: "{baseDir}/{name}-{id}.sock". When baseDir is empty, os.TempDir() is used.
+// Empty name produces "-{id}.sock" (library is pure; callers supply the name).
+func IPCPath(baseDir, name, id string) string {
+	return filepath.Join(resolveBaseDir(baseDir), fmt.Sprintf("%s-%s.sock", name, id))
 }
 
 // ControlPath returns the control socket path for a given server ID.
-// When baseDir is empty, os.TempDir() is used.
-func ControlPath(id string, baseDir string) string {
-	return filepath.Join(resolveBaseDir(baseDir), fmt.Sprintf("mcp-mux-%s.ctl.sock", id))
+// Format: "{baseDir}/{name}-{id}.ctl.sock". When baseDir is empty, os.TempDir() is used.
+// Empty name produces "-{id}.ctl.sock" (library is pure; callers supply the name).
+func ControlPath(baseDir, name, id string) string {
+	return filepath.Join(resolveBaseDir(baseDir), fmt.Sprintf("%s-%s.ctl.sock", name, id))
 }
 
 // LockPath returns the lock file path used for owner election.
-// When baseDir is empty, os.TempDir() is used.
-func LockPath(id string, baseDir string) string {
-	return filepath.Join(resolveBaseDir(baseDir), fmt.Sprintf("mcp-mux-%s.lock", id))
+// Format: "{baseDir}/{name}-{id}.lock". When baseDir is empty, os.TempDir() is used.
+// Empty name produces "-{id}.lock" (library is pure; callers supply the name).
+func LockPath(baseDir, name, id string) string {
+	return filepath.Join(resolveBaseDir(baseDir), fmt.Sprintf("%s-%s.lock", name, id))
 }
 
 // DaemonControlPath returns the control socket path for a named daemon.

--- a/muxcore/serverid/serverid_test.go
+++ b/muxcore/serverid/serverid_test.go
@@ -44,34 +44,79 @@ func TestComputeEmptyFallback(t *testing.T) {
 }
 
 func TestIPCPath(t *testing.T) {
-	path := IPCPath("abc123def456", "")
-	if !strings.HasSuffix(path, ".sock") {
-		t.Errorf("IPCPath = %q, want .sock suffix", path)
+	customDir := t.TempDir()
+	tests := []struct {
+		name     string
+		wantFile string
+	}{
+		{name: "mcp-mux", wantFile: "mcp-mux-abc123def456.sock"},
+		{name: "aimux", wantFile: "aimux-abc123def456.sock"},
+		{name: "aimux-dev", wantFile: "aimux-dev-abc123def456.sock"},
+		{name: "", wantFile: "-abc123def456.sock"},
 	}
-	if !strings.Contains(path, "mcp-mux-abc123def456") {
-		t.Errorf("IPCPath = %q, missing server ID", path)
+	for _, tt := range tests {
+		t.Run("name="+tt.name, func(t *testing.T) {
+			path := IPCPath(customDir, tt.name, "abc123def456")
+			if filepath.Base(path) != tt.wantFile {
+				t.Errorf("IPCPath(%q, %q, %q) base = %q, want %q", customDir, tt.name, "abc123def456", filepath.Base(path), tt.wantFile)
+			}
+			if filepath.Dir(path) != customDir {
+				t.Errorf("IPCPath dir = %q, want %q", filepath.Dir(path), customDir)
+			}
+		})
 	}
 }
 
 func TestControlPath(t *testing.T) {
-	path := ControlPath("abc123def456", "")
-	if !strings.HasSuffix(path, ".ctl.sock") {
-		t.Errorf("ControlPath = %q, want .ctl.sock suffix", path)
+	customDir := t.TempDir()
+	tests := []struct {
+		name     string
+		wantFile string
+	}{
+		{name: "mcp-mux", wantFile: "mcp-mux-abc123def456.ctl.sock"},
+		{name: "aimux", wantFile: "aimux-abc123def456.ctl.sock"},
+		{name: "aimux-dev", wantFile: "aimux-dev-abc123def456.ctl.sock"},
+		{name: "", wantFile: "-abc123def456.ctl.sock"},
 	}
-	if !strings.Contains(path, "mcp-mux-abc123def456") {
-		t.Errorf("ControlPath = %q, missing server ID", path)
+	for _, tt := range tests {
+		t.Run("name="+tt.name, func(t *testing.T) {
+			path := ControlPath(customDir, tt.name, "abc123def456")
+			if filepath.Base(path) != tt.wantFile {
+				t.Errorf("ControlPath(%q, %q, %q) base = %q, want %q", customDir, tt.name, "abc123def456", filepath.Base(path), tt.wantFile)
+			}
+			if filepath.Dir(path) != customDir {
+				t.Errorf("ControlPath dir = %q, want %q", filepath.Dir(path), customDir)
+			}
+		})
 	}
 }
 
 func TestLockPath(t *testing.T) {
-	path := LockPath("test123", "")
-	if !strings.Contains(path, "mcp-mux-test123.lock") {
-		t.Errorf("LockPath = %q, missing expected pattern", path)
+	customDir := t.TempDir()
+	tests := []struct {
+		name     string
+		wantFile string
+	}{
+		{name: "mcp-mux", wantFile: "mcp-mux-test123.lock"},
+		{name: "aimux", wantFile: "aimux-test123.lock"},
+		{name: "aimux-dev", wantFile: "aimux-dev-test123.lock"},
+		{name: "", wantFile: "-test123.lock"},
+	}
+	for _, tt := range tests {
+		t.Run("name="+tt.name, func(t *testing.T) {
+			path := LockPath(customDir, tt.name, "test123")
+			if filepath.Base(path) != tt.wantFile {
+				t.Errorf("LockPath(%q, %q, %q) base = %q, want %q", customDir, tt.name, "test123", filepath.Base(path), tt.wantFile)
+			}
+			if filepath.Dir(path) != customDir {
+				t.Errorf("LockPath dir = %q, want %q", filepath.Dir(path), customDir)
+			}
+		})
 	}
 }
 
 func TestIPCPath_EmptyBaseDir(t *testing.T) {
-	path := IPCPath("abc123", "")
+	path := IPCPath("", "mcp-mux", "abc123")
 	tmpDir := os.TempDir()
 	// macOS: os.TempDir() returns the /var/folders/... alias while the value
 	// that reaches the socket path may be resolved through /private/... —
@@ -88,16 +133,19 @@ func TestIPCPath_EmptyBaseDir(t *testing.T) {
 	if gotDir != tmpDir {
 		t.Errorf("IPCPath with empty baseDir: got dir %q, want os.TempDir() %q", gotDir, tmpDir)
 	}
+	if filepath.Base(path) != "mcp-mux-abc123.sock" {
+		t.Errorf("IPCPath base = %q, want mcp-mux-abc123.sock", filepath.Base(path))
+	}
 }
 
 func TestIPCPath_CustomBaseDir(t *testing.T) {
 	customDir := t.TempDir()
-	path := IPCPath("abc123", customDir)
+	path := IPCPath(customDir, "mcp-mux", "abc123")
 	if filepath.Dir(path) != customDir {
 		t.Errorf("IPCPath with custom baseDir: got dir %q, want %q", filepath.Dir(path), customDir)
 	}
-	if !strings.Contains(path, "mcp-mux-abc123.sock") {
-		t.Errorf("IPCPath = %q, missing expected filename", path)
+	if filepath.Base(path) != "mcp-mux-abc123.sock" {
+		t.Errorf("IPCPath = %q, want filename mcp-mux-abc123.sock", path)
 	}
 }
 

--- a/testdata/smoke_isolated.go
+++ b/testdata/smoke_isolated.go
@@ -58,7 +58,7 @@ func main() {
 		fmt.Printf("cwd2: %s (isolation check)\n", cwd2)
 	}
 
-	ctlPath := serverid.DaemonControlPath("", "")
+	ctlPath := serverid.DaemonControlPath("", "mcp-mux")
 	failures := 0
 
 	// ── TEST 1: Spawn via daemon ──


### PR DESCRIPTION
Closes #102. Closes #103.

## Summary

Single arc covering both reported issues — they share one root: muxcore did not propagate engine identity through the layered facade (engine.Config -> daemon.Config -> OwnerEntry -> FS path).

- **#102** — mux_list saw aimux's owner sockets as mcp-mux-managed because muxcore's serverid package hardcoded the literal mcp-mux- prefix for all engine instances. Operator footgun: mux_restart <foreign-id> would kill the wrong process.
- **#103** — engine.Config.Persistent: true was a documented public API contract that grep proved was never read. aimux daemons died after every Ctrl+C in CC despite the flag.

This PR ships **muxcore/v0.22.0** (breaking) + **mcp-mux v0.22.0** (consumer adoption + tools refactor) atomically.

## Architecture

Five ADRs in .agent/specs/muxcore-multi-tenant-isolation/architecture.md:

| ADR | Decision | Reversibility |
|-----|----------|---------------|
| 010 | serverid path functions get a name parameter | IRREVERSIBLE |
| 011 | daemon.Config.Name additive | REVERSIBLE |
| 012 | mux_list/stop/restart query daemon, not FS | PARTIALLY |
| 013 | OwnerEntry.Persistent hydrated from engine.Config.Persistent | REVERSIBLE |
| 014 | One arc, two issues, single release | REVERSIBLE |

## What changed

- muxcore/serverid — owner socket paths are now {name}-{id}.{ext}, scoped per engine.
- engine.Config.Name is mandatory; empty Name returns a clear diagnostic error.
- daemon.Config accepts Name and Persistent; both fully propagate from engine.
- OwnerEntry.Persistent is hydrated for SessionHandler topology (closes #103).
- New daemon.HandleListOwners control RPC; mcp-mux mux_list/mux_stop/mux_restart now query it instead of scanning TEMP.
- cleanStaleSockets is name-scoped; v0.22 mcp-mux + v0.21 aimux on one host coexist cleanly.
- cmd/mcp-mux introduces const engineName at package level; 11 hardcoded literals removed.

## Tests added

8 named tests covering R1/R2 from #103 issue body + cross-engine isolation + foreign-id refusal.
TestCrossEngineIsolation proves end-to-end FS namespace partitioning.

R3 from #103 (mcp-launcher persist regression) is in-house tooling — runs at deploy time on the actual aimux v0.22.0 binary.

## Migration

Downstream consumers bump muxcore dep:

  go get github.com/thebtf/mcp-mux/muxcore@v0.22.0

aimux/engram must pass Name in engine.New(Config{...}).

## Verification

- go build ./... clean (root + muxcore module)
- go test ./... — 19 muxcore packages PASS, 2 root packages PASS
- go vet ./... clean
- TestCrossEngineIsolation proves end-to-end FS partitioning works

Workstation manual smoke deferred to T019 deploy phase (after merge + tag).

## Spec artifacts

Full pipeline checked in under .agent/specs/muxcore-multi-tenant-isolation/:
- architecture.md, spec.md, plan.md, tasks.md, validate.md, clarifications/

## Tasks executed in this PR

T001-T012 + T013 GATE + T014-T015. Remaining T016 (tag), T017 (releases), T018 (close issues), T019 (workstation deploy + verify), T020 (arc gate) execute after this PR merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Новые возможности**
  * Изоляция мульти‑тенантного файлового пространства по имени движка для сокетов/блокировок.
  * Новый демоновый RPC list_owners для авторитетного перечисления владельцев.

* **Критические изменения**
  * Порядок генерации путей: (baseDir, name, id); пустое имя движка теперь считается ошибкой.
  * mux_list/mux_stop/mux_restart опрашивают демон вместо файлового сканирования.
  * Параметр Persistent сохраняется за владельцами и учитывается при очистке.

* **Тесты и документация**
  * Добавлены юнит‑/интеграционные тесты, план выпуска, ADRы и миграционные инструкции.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->