### PR TITLE
Hardening for #104 — unknown_token early break + daemon pid in status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ graphify-out/
 .claude/
 .serena/
 .gocache/
+.repro/

--- a/muxcore/daemon/daemon.go
+++ b/muxcore/daemon/daemon.go
@@ -1337,6 +1337,7 @@ func (d *Daemon) HandleStatus() map[string]any {
 
 	return map[string]any{
 		"daemon":                          true,
+		"pid":                             os.Getpid(),
 		"owner_count":                     len(servers), // excludes placeholders still being created
 		"servers":                         servers,
 		"owner_idle_timeout":              d.ownerIdleTimeout.String(),

--- a/muxcore/daemon/daemon_test.go
+++ b/muxcore/daemon/daemon_test.go
@@ -170,6 +170,15 @@ func TestDaemonSpawnAndStatus(t *testing.T) {
 	if !status["daemon"].(bool) {
 		t.Error("status daemon should be true")
 	}
+	// Status must expose daemon pid for external tooling (mux_list,
+	// mcp-launcher kill-reconnect, monitoring) — see issue #104.
+	pid, ok := status["pid"].(int)
+	if !ok {
+		t.Fatalf("status pid type = %T, want int", status["pid"])
+	}
+	if pid != os.Getpid() {
+		t.Errorf("status pid = %d, want %d", pid, os.Getpid())
+	}
 }
 
 func TestDaemonSpawnReusesExisting(t *testing.T) {

--- a/muxcore/owner/resilient_client.go
+++ b/muxcore/owner/resilient_client.go
@@ -455,6 +455,14 @@ func (rc *resilientClient) reconnect(stdoutMu *sync.Mutex, stdinDone <-chan erro
 					fallbackReason = "owner_gone"
 					break
 				}
+				if isUnknownTokenError(err) {
+					// New daemon (e.g. after hard-kill + respawn) has no record
+					// of our session token; further refresh attempts will fail
+					// identically. Break early and fall back to fresh spawn.
+					rc.log.Printf("shim.reconnect.refresh_fail reason=unknown_token")
+					fallbackReason = "unknown_token"
+					break
+				}
 				rc.log.Printf("shim.reconnect.refresh_fail reason=%s", refreshFailureReason(err))
 				continue
 			}

--- a/muxcore/owner/resilient_client.go
+++ b/muxcore/owner/resilient_client.go
@@ -450,17 +450,13 @@ func (rc *resilientClient) reconnect(stdoutMu *sync.Mutex, stdinDone <-chan erro
 				if err == io.EOF {
 					return nil, io.EOF
 				}
-				if isOwnerGoneError(err) {
-					rc.log.Printf("shim.reconnect.refresh_fail reason=owner_gone")
-					fallbackReason = "owner_gone"
-					break
-				}
-				if isUnknownTokenError(err) {
-					// New daemon (e.g. after hard-kill + respawn) has no record
-					// of our session token; further refresh attempts will fail
-					// identically. Break early and fall back to fresh spawn.
-					rc.log.Printf("shim.reconnect.refresh_fail reason=unknown_token")
-					fallbackReason = "unknown_token"
+				// Terminal refresh errors (owner_gone, unknown_token) cannot
+				// be resolved by retrying — every attempt would fail identically.
+				// Break early and fall back to fresh spawn. Other errors are
+				// treated as transient and retried up to MaxRefreshAttempts.
+				if reason := terminalRefreshErrorReason(err); reason != "" {
+					rc.log.Printf("shim.reconnect.refresh_fail reason=%s", reason)
+					fallbackReason = reason
 					break
 				}
 				rc.log.Printf("shim.reconnect.refresh_fail reason=%s", refreshFailureReason(err))
@@ -576,6 +572,21 @@ func isOwnerGoneError(err error) bool {
 
 func isUnknownTokenError(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "unknown token")
+}
+
+// terminalRefreshErrorReason returns a non-empty fallback reason if err is
+// known to be unrecoverable across retries (the new daemon will never accept
+// the cached token regardless of how many times we ask). Returns "" for
+// transient errors that should be retried up to MaxRefreshAttempts.
+func terminalRefreshErrorReason(err error) string {
+	switch {
+	case isOwnerGoneError(err):
+		return "owner_gone"
+	case isUnknownTokenError(err):
+		return "unknown_token"
+	default:
+		return ""
+	}
 }
 
 // ownerPrefixFromIPCPath extracts the short server-ID prefix (up to 8 chars)

--- a/muxcore/owner/resilient_client_reconnect_test.go
+++ b/muxcore/owner/resilient_client_reconnect_test.go
@@ -115,7 +115,11 @@ func TestReconnect_RefreshesAndSucceeds(t *testing.T) {
 	}
 }
 
-func TestReconnect_FallsBackToSpawnAfterNRejects(t *testing.T) {
+func TestReconnect_ImmediateSpawnOnUnknownToken(t *testing.T) {
+	// After daemon hard-kill + respawn, the new daemon has no record of the
+	// old session token. Refresh must break early instead of retrying all
+	// MaxRefreshAttempts times — every retry would fail identically since
+	// the new daemon's session manager is empty for this token.
 	var logs bytes.Buffer
 	logger := log.New(&logs, "", 0)
 	rc := newReconnectClient(t, io.Discard, logger)
@@ -143,8 +147,8 @@ func TestReconnect_FallsBackToSpawnAfterNRejects(t *testing.T) {
 	}
 	defer closeReconnectConn(t, conn)
 
-	if refreshCalls != 3 {
-		t.Fatalf("refreshCalls = %d, want 3", refreshCalls)
+	if refreshCalls != 1 {
+		t.Fatalf("refreshCalls = %d, want 1 (early break on unknown_token)", refreshCalls)
 	}
 	if reconnectCalls != 1 {
 		t.Fatalf("reconnectCalls = %d, want 1", reconnectCalls)
@@ -153,11 +157,54 @@ func TestReconnect_FallsBackToSpawnAfterNRejects(t *testing.T) {
 		t.Fatalf("rc.token = %q, want %q", rc.token, "spawn-token")
 	}
 	logText := logs.String()
-	if strings.Count(logText, "shim.reconnect.refresh_fail reason=unknown_token") != 3 {
-		t.Fatalf("refresh_fail logs = %d, want 3; logs=%q", strings.Count(logText, "shim.reconnect.refresh_fail reason=unknown_token"), logText)
+	if strings.Count(logText, "shim.reconnect.refresh_fail reason=unknown_token") != 1 {
+		t.Fatalf("refresh_fail logs = %d, want 1; logs=%q", strings.Count(logText, "shim.reconnect.refresh_fail reason=unknown_token"), logText)
 	}
-	if !strings.Contains(logText, "shim.reconnect.fallback_spawn reason=N_refresh_fail") {
-		t.Fatalf("missing fallback_spawn log, got %q", logText)
+	if !strings.Contains(logText, "shim.reconnect.fallback_spawn reason=unknown_token") {
+		t.Fatalf("missing fallback_spawn reason=unknown_token log, got %q", logText)
+	}
+}
+
+func TestReconnect_FallsBackToSpawnAfterNTransientFailures(t *testing.T) {
+	// Generic transient errors (neither unknown_token nor owner_gone) must
+	// retry up to MaxRefreshAttempts before falling back to spawn — this
+	// preserves the original retry path for transient issues like network
+	// blips or server-side temporary failures.
+	var logs bytes.Buffer
+	logger := log.New(&logs, "", 0)
+	rc := newReconnectClient(t, io.Discard, logger)
+	rc.token = "prev-token"
+
+	spawnPath := tempReconnectSocketPath(t, "abcdef123456")
+	srv, _ := startEchoIPCServer(t, spawnPath)
+	defer srv.closeAll()
+
+	stdinDone := make(chan error)
+	refreshCalls := 0
+	reconnectCalls := 0
+	rc.cfg.RefreshToken = func() (string, string, error) {
+		refreshCalls++
+		return "", "", errors.New("transient: connection refused")
+	}
+	rc.cfg.Reconnect = func() (string, string, error) {
+		reconnectCalls++
+		return spawnPath, "spawn-token", nil
+	}
+
+	conn, err := rc.reconnect(&sync.Mutex{}, stdinDone)
+	if err != nil {
+		t.Fatalf("reconnect() error = %v", err)
+	}
+	defer closeReconnectConn(t, conn)
+
+	if refreshCalls != 3 {
+		t.Fatalf("refreshCalls = %d, want 3 (transient errors must retry)", refreshCalls)
+	}
+	if reconnectCalls != 1 {
+		t.Fatalf("reconnectCalls = %d, want 1", reconnectCalls)
+	}
+	if !strings.Contains(logs.String(), "shim.reconnect.fallback_spawn reason=N_refresh_fail") {
+		t.Fatalf("missing fallback_spawn reason=N_refresh_fail log, got %q", logs.String())
 	}
 }
 


### PR DESCRIPTION
## Context

Issue #104 reported 110 s reconnect time after daemon hard-kill. Phase 0 investigation (`.agent/debug/reconnect-110s-104/investigation.md`) reproduced the scenario on muxcore v0.22.0 and **could not reproduce the 110 s symptom**:

- Single-shim recovery: **1.5 s** end-to-end
- 3-shim concurrent contention: **≤ 1.5 s** all three
- Issue's 30 s "Phase A" was aimux v5.0.3 SessionHandler warmup blocking spawn — out-of-scope for muxcore
- Issue's 80 s "Phase B" was not reproduced under any tested scenario

Recommendation collapsed to **defensive hardening**.

## Changes (2 small, additive)

### 1. `unknown_token` early break in refresh loop

`muxcore/owner/resilient_client.go` reconnect loop previously retried 3 times on every refresh failure including `unknown token`. After daemon hard-kill + respawn, the new daemon has empty session manager — every retry fails identically. Add `isUnknownTokenError` early-break parallel to the existing `isOwnerGoneError` branch.

```diff
+ if isUnknownTokenError(err) {
+     fallbackReason = "unknown_token"
+     break
+ }
  rc.log.Printf("shim.reconnect.refresh_fail reason=%s", refreshFailureReason(err))
  continue
```

Verified post-fix: hard-kill repro shows **1 × `refresh_fail reason=unknown_token` → `fallback_spawn reason=unknown_token`** (was: 3 × refresh_fail before fallback).

Test deltas:
- `TestReconnect_FallsBackToSpawnAfterNRejects` renamed to `TestReconnect_ImmediateSpawnOnUnknownToken`; assertion flipped to `refreshCalls = 1`.
- New `TestReconnect_FallsBackToSpawnAfterNTransientFailures` preserves the 3-attempts-before-fallback contract for generic transient errors.

### 2. `pid` field in daemon `HandleStatus`

`muxcore/daemon/daemon.go` HandleStatus map gains `pid: os.Getpid()`. Closes a tooling gap — mcp-launcher kill-reconnect mode (and any external monitoring script) had no reliable way to identify the daemon process from a status RPC, especially on Windows where parent-tracking via process tree is unreliable.

Additive field. Zero behavioural change for existing consumers.

Test extension: `TestDaemonSpawnAndShutdown` now asserts `status["pid"] == os.Getpid()`.

## Verification

- All 19 muxcore packages + cmd/mcp-mux + internal/mcpserver test suites green
- `go vet ./...` clean
- Manual repro on hardened binary in `.repro/104/` — confirms 1-attempt early break

## Why not breaking

Both changes are additive — no signature change, no removed field, no reordered behaviour for transient errors. Existing consumers see strictly improved recovery semantics under hard-kill scenarios. Suitable for a `muxcore/v0.22.1` patch bump.

## Issue closure

Recommend closing #104 as muxcore-side mitigated; the residual 30 s "Phase A" gap is aimux SessionHandler warmup and warrants a separate issue against `D:\Dev\aimux`.

Closes #104 (after merge + release)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Новые функции**
  * Статус демона теперь включает идентификатор процесса (PID).

* **Исправления**
  * Улучшена логика повторных попытов при обновлении токена: ошибки, классифицируемые как терминальные (например, неизвестный токен), прерывают цикл и переходят к запасному пути.

* **Тесты**
  * Обновлены тесты статуса и повторных подключений для проверки нового поведения и корректных причин отказа.

* **Прочее**
  * .gitignore обновлён для исключения временной директории (.repro/).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->