### PR TITLE
fix(muxcore): preserve SessionHandler snapshot restore

### DIFF
--- a/muxcore/daemon/snapshot.go
+++ b/muxcore/daemon/snapshot.go
@@ -175,6 +175,8 @@ func (d *Daemon) loadSnapshot() int {
 			ControlPath:    controlPath,
 			ServerID:       sid,
 			TokenHandshake: true,
+			HandlerFunc:    d.handlerFunc,
+			SessionHandler: d.sessionHandler,
 			// Forward v0.24 multi-tenant callbacks to restored owners. Fresh
 			// spawn in spawnOnce already does this; without it, snapshot/
 			// handoff-restored owners would silently lose AuthorizeSession +

--- a/muxcore/daemon/snapshot_reattach_test.go
+++ b/muxcore/daemon/snapshot_reattach_test.go
@@ -272,6 +272,72 @@ func TestLoadSnapshot_Reattach_SocketUnreachable(t *testing.T) {
 	}
 }
 
+func TestLoadSnapshot_SessionHandlerRestoreDoesNotSpawnCommand(t *testing.T) {
+	os.Remove(SnapshotPath())
+
+	sid := "b86e71a0093a84a9-sessionhandler-snapshot"
+	snapshot := DaemonSnapshot{
+		Version:   mcpsnapshot.SnapshotVersion,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Owners: []mcpsnapshot.OwnerSnapshot{
+			{
+				ServerID:       sid,
+				Command:        "definitely-not-a-real-sessionhandler-snapshot-command",
+				Cwd:            t.TempDir(),
+				Mode:           "global",
+				Classification: classify.ModeShared,
+				CachedInit:     "e30=",
+				CachedTools:    "e30=",
+			},
+		},
+	}
+	data, err := json.Marshal(snapshot)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	if err := os.WriteFile(SnapshotPath(), data, 0o644); err != nil {
+		t.Fatalf("WriteFile snapshot: %v", err)
+	}
+	defer os.Remove(SnapshotPath())
+
+	buf := &syncBuffer{}
+	ctlPath := shortSocketPath(t, "daemon.ctl.sock")
+	logger := log.New(buf, "[daemon-test] ", log.LstdFlags)
+	d, err := New(Config{
+		ControlPath:    ctlPath,
+		GracePeriod:    1 * time.Second,
+		IdleTimeout:    5 * time.Second,
+		SkipSnapshot:   true,
+		SessionHandler: noopSessionHandler{},
+		Logger:         logger,
+	})
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	t.Cleanup(func() { d.Shutdown() })
+
+	if restored := d.loadSnapshot(); restored != 1 {
+		t.Fatalf("loadSnapshot() restored %d owners, want 1", restored)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		logs := buf.String()
+		if strings.Contains(logs, "background SessionHandler-only spawn: no upstream process") {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("missing SessionHandler-only no-op marker in logs:\n%s", logs)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	logs := buf.String()
+	if strings.Contains(logs, "background upstream spawn failed") {
+		t.Fatalf("snapshot restore attempted snapshotted command for SessionHandler owner:\n%s", logs)
+	}
+}
+
 // TestLoadSnapshot_Reattach_PartialHandoff exercises FR-7: when the handoff
 // delivers FDs for a subset of the snapshot's owners, the remainder MUST
 // fall through to the legacy SpawnUpstreamBackground path. The snapshot

--- a/muxcore/owner/owner.go
+++ b/muxcore/owner/owner.go
@@ -109,10 +109,10 @@ type Owner struct {
 	// PR #113). nil = handler does not implement the upgrade.
 	notificationHandlerWithMeta muxcore.NotificationHandlerWithSessionMeta
 	sessionHandlerWithMeta      muxcore.SessionHandlerWithSessionMeta
-	upstreamWriter io.Writer                                                          // injected writer (non-nil = skip subprocess, write directly; tests only)
-	serverID       string                                                             // server identity hash
-	listener       net.Listener
-	logger         *log.Logger
+	upstreamWriter              io.Writer // injected writer (non-nil = skip subprocess, write directly; tests only)
+	serverID                    string    // server identity hash
+	listener                    net.Listener
+	logger                      *log.Logger
 
 	onZeroSessions       func(serverID string)
 	onUpstreamExit       func(serverID string)
@@ -309,27 +309,27 @@ func NewOwnerFromSnapshot(cfg OwnerConfig, snap OwnerSnapshot) (*Owner, error) {
 	}
 
 	o := &Owner{
-		ipcPath:                cfg.IPCPath,
-		cwd:                    cfg.Cwd,
-		cwdSet:                 cwdSet,
-		command:                cfg.Command,
-		args:                   cfg.Args,
-		env:                    cfg.Env,
-		handlerFunc:            cfg.HandlerFunc,
-		sessionHandler:         cfg.SessionHandler,
-		serverID:               cfg.ServerID,
-		listener:               ln,
-		logger:                 logger,
-		onZeroSessions:         cfg.OnZeroSessions,
-		onUpstreamExit:         cfg.OnUpstreamExit,
-		onPersistentDetected:   cfg.OnPersistentDetected,
-		onCacheReady:           cfg.OnCacheReady,
-		authorizeSession:       cfg.AuthorizeSession,
-		onFrameReceived:        cfg.OnFrameReceived,
-		sessions:               make(map[int]*Session),
-		cachedInitSessions:     make(map[int]bool),
-		sessionMgr:             NewSessionManager(),
-		tokenHandshake:         cfg.TokenHandshake,
+		ipcPath:              cfg.IPCPath,
+		cwd:                  cfg.Cwd,
+		cwdSet:               cwdSet,
+		command:              cfg.Command,
+		args:                 cfg.Args,
+		env:                  cfg.Env,
+		handlerFunc:          cfg.HandlerFunc,
+		sessionHandler:       cfg.SessionHandler,
+		serverID:             cfg.ServerID,
+		listener:             ln,
+		logger:               logger,
+		onZeroSessions:       cfg.OnZeroSessions,
+		onUpstreamExit:       cfg.OnUpstreamExit,
+		onPersistentDetected: cfg.OnPersistentDetected,
+		onCacheReady:         cfg.OnCacheReady,
+		authorizeSession:     cfg.AuthorizeSession,
+		onFrameReceived:      cfg.OnFrameReceived,
+		sessions:             make(map[int]*Session),
+		cachedInitSessions:   make(map[int]bool),
+		sessionMgr:           NewSessionManager(),
+		tokenHandshake:       cfg.TokenHandshake,
 		// rejectionLogger is created lazily below, only when tokenHandshake is
 		// enabled — legacy/test owners with tokenHandshake=false never rate-limit
 		// anything, so the per-Owner ticker goroutine adds cost without value
@@ -429,6 +429,16 @@ func (o *Owner) SpawnUpstreamBackground() {
 		case <-o.done:
 			return
 		default:
+		}
+		if o.sessionHandler != nil && o.handlerFunc == nil {
+			o.logger.Printf("background SessionHandler-only spawn: no upstream process")
+			o.mu.Lock()
+			if o.backgroundSpawnCh != nil {
+				close(o.backgroundSpawnCh)
+				o.backgroundSpawnCh = nil
+			}
+			o.mu.Unlock()
+			return
 		}
 
 		var proc *upstream.Process
@@ -561,29 +571,29 @@ func NewOwner(cfg OwnerConfig) (*Owner, error) {
 	}
 
 	o := &Owner{
-		upstream:               proc,
-		ipcPath:                cfg.IPCPath,
-		cwd:                    cfg.Cwd,
-		cwdSet:                 map[string]bool{serverid.CanonicalizePath(cfg.Cwd): true},
-		command:                cfg.Command,
-		args:                   cfg.Args,
-		env:                    cfg.Env,
-		handlerFunc:            cfg.HandlerFunc,
-		sessionHandler:         cfg.SessionHandler,
-		upstreamWriter:         cfg.UpstreamWriter,
-		serverID:               cfg.ServerID,
-		listener:               ln,
-		logger:                 logger,
-		onZeroSessions:         cfg.OnZeroSessions,
-		onUpstreamExit:         cfg.OnUpstreamExit,
-		onPersistentDetected:   cfg.OnPersistentDetected,
-		onCacheReady:           cfg.OnCacheReady,
-		authorizeSession:       cfg.AuthorizeSession,
-		onFrameReceived:        cfg.OnFrameReceived,
-		sessions:               make(map[int]*Session),
-		cachedInitSessions:     make(map[int]bool),
-		sessionMgr:             NewSessionManager(),
-		tokenHandshake:         cfg.TokenHandshake,
+		upstream:             proc,
+		ipcPath:              cfg.IPCPath,
+		cwd:                  cfg.Cwd,
+		cwdSet:               map[string]bool{serverid.CanonicalizePath(cfg.Cwd): true},
+		command:              cfg.Command,
+		args:                 cfg.Args,
+		env:                  cfg.Env,
+		handlerFunc:          cfg.HandlerFunc,
+		sessionHandler:       cfg.SessionHandler,
+		upstreamWriter:       cfg.UpstreamWriter,
+		serverID:             cfg.ServerID,
+		listener:             ln,
+		logger:               logger,
+		onZeroSessions:       cfg.OnZeroSessions,
+		onUpstreamExit:       cfg.OnUpstreamExit,
+		onPersistentDetected: cfg.OnPersistentDetected,
+		onCacheReady:         cfg.OnCacheReady,
+		authorizeSession:     cfg.AuthorizeSession,
+		onFrameReceived:      cfg.OnFrameReceived,
+		sessions:             make(map[int]*Session),
+		cachedInitSessions:   make(map[int]bool),
+		sessionMgr:           NewSessionManager(),
+		tokenHandshake:       cfg.TokenHandshake,
 		// rejectionLogger is created lazily below, only when tokenHandshake is
 		// enabled — legacy/test owners with tokenHandshake=false never rate-limit
 		// anything, so the per-Owner ticker goroutine adds cost without value

--- a/muxcore/owner/owner_test.go
+++ b/muxcore/owner/owner_test.go
@@ -1,9 +1,11 @@
 package owner
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
+	"log"
 	"strings"
 	"sync"
 	"testing"
@@ -264,6 +266,87 @@ func TestServe_SessionHandlerOnly_BlocksUntilDone(t *testing.T) {
 		// Expected
 	case <-time.After(500 * time.Millisecond):
 		t.Error("done channel not closed after Shutdown")
+	}
+}
+
+func TestSpawnUpstreamBackground_SessionHandlerOnly_NoSubprocess(t *testing.T) {
+	ipcPath := testIPCPath(t)
+	var logs bytes.Buffer
+
+	snap := OwnerSnapshot{
+		ServerID: "test-sessionhandler-background-spawn",
+		Command:  "definitely-not-a-real-sessionhandler-upstream-command",
+		Cwd:      t.TempDir(),
+		CwdSet:   []string{},
+		Mode:     "global",
+	}
+
+	handler := &mockSessionHandler{}
+	o, err := NewOwnerFromSnapshot(OwnerConfig{
+		Command:        snap.Command,
+		Cwd:            snap.Cwd,
+		IPCPath:        ipcPath,
+		ServerID:       snap.ServerID,
+		SessionHandler: handler,
+		Logger:         log.New(&logs, "[test] ", 0),
+	}, snap)
+	if err != nil {
+		t.Fatalf("NewOwnerFromSnapshot() error: %v", err)
+	}
+	defer o.Shutdown()
+
+	bgCh := o.backgroundSpawnCh
+	if bgCh == nil {
+		t.Fatal("snapshot owner should start with pending backgroundSpawnCh")
+	}
+
+	o.SpawnUpstreamBackground()
+
+	select {
+	case <-bgCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("SessionHandler-only background spawn did not finish")
+	}
+
+	o.mu.RLock()
+	upstream := o.upstream
+	backgroundSpawnCh := o.backgroundSpawnCh
+	o.mu.RUnlock()
+	if upstream != nil {
+		t.Fatalf("SessionHandler-only background spawn created upstream: %v", upstream)
+	}
+	if backgroundSpawnCh != nil {
+		t.Fatal("SessionHandler-only background spawn did not clear backgroundSpawnCh")
+	}
+
+	logText := logs.String()
+	if strings.Contains(logText, "background upstream spawn failed") {
+		t.Fatalf("SessionHandler-only background spawn attempted subprocess:\n%s", logText)
+	}
+	if !strings.Contains(logText, "background SessionHandler-only spawn: no upstream process") {
+		t.Fatalf("missing SessionHandler-only no-op marker in logs:\n%s", logText)
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- o.Serve(context.Background())
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	select {
+	case err := <-errCh:
+		t.Fatalf("Serve returned immediately for restored SessionHandler-only owner: %v", err)
+	default:
+	}
+
+	o.Shutdown()
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, suture.ErrDoNotRestart) {
+			t.Fatalf("Serve returned %v after Shutdown, want suture.ErrDoNotRestart", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Serve did not return after Shutdown")
 	}
 }
 

--- a/muxcore/owner/resilient_client.go
+++ b/muxcore/owner/resilient_client.go
@@ -169,25 +169,8 @@ func RunResilientClient(cfg ResilientClientConfig) error {
 	// invoked once per ResilientClient lifecycle, so this code path itself
 	// already provides the single-fire guarantee — no sync.Once needed.
 	if cfg.OnInject != nil {
-		inject := func(b []byte) error {
-			if rc.closed.Load() {
-				rc.log.Printf("proxy.inject.dropped reason=closed")
-				return ErrInjectClosed
-			}
-			// Copy the caller's buffer — they may reuse or pool it after inject returns.
-			data := make([]byte, len(b))
-			copy(data, b)
-			select {
-			case rc.msgFromCC <- data:
-				rc.log.Printf("proxy.inject.delivered bytes=%d", len(b))
-				return nil
-			default:
-				rc.log.Printf("proxy.inject.dropped reason=full")
-				return ErrInjectFull
-			}
-		}
 		rc.log.Printf("proxy.inject.armed")
-		go cfg.OnInject(inject)
+		go cfg.OnInject(rc.injectFrame)
 	}
 
 	// stdinReader: reads CC stdin, sends raw message bytes to msgFromCC.
@@ -695,6 +678,24 @@ func (rc *resilientClient) replayInit(conn interface {
 	}
 	rc.log.Printf("resilient: discarded init replay response (%d bytes)", len(buf))
 	return nil
+}
+
+func (rc *resilientClient) injectFrame(b []byte) error {
+	if rc.closed.Load() {
+		rc.log.Printf("proxy.inject.dropped reason=closed")
+		return ErrInjectClosed
+	}
+	// Copy the caller's buffer — they may reuse or pool it after inject returns.
+	data := make([]byte, len(b))
+	copy(data, b)
+	select {
+	case rc.msgFromCC <- data:
+		rc.log.Printf("proxy.inject.delivered bytes=%d", len(b))
+		return nil
+	default:
+		rc.log.Printf("proxy.inject.dropped reason=full")
+		return ErrInjectFull
+	}
 }
 
 // sendListChangedNotifications sends *_list_changed notifications to CC after reconnect.

--- a/muxcore/owner/resilient_client_test.go
+++ b/muxcore/owner/resilient_client_test.go
@@ -485,63 +485,13 @@ func TestResilientClient_OnInject_DeliversFrames(t *testing.T) {
 }
 
 func TestResilientClient_OnInject_BufferFull(t *testing.T) {
-	path := newTestIPCPath(t)
-
-	ln, err := net.Listen("unix", path)
-	if err != nil {
-		t.Fatalf("listen %s: %v", path, err)
-	}
-	defer func() {
-		ln.Close()
-		os.Remove(path)
-	}()
-
-	blockConn := make(chan net.Conn, 1)
-	go func() {
-		conn, err := ln.Accept()
-		if err != nil {
-			return
-		}
-		if unixConn, ok := conn.(*net.UnixConn); ok {
-			_ = unixConn.SetReadBuffer(1)
-		}
-		blockConn <- conn
-		select {}
-	}()
-
-	ccStdinR, ccStdinW := io.Pipe()
-	ccStdoutR, ccStdoutW := io.Pipe()
-
-	injectCh := make(chan func([]byte) error, 1)
-
-	cfg := ResilientClientConfig{
-		ProbeGracePeriod:  time.Nanosecond,
-		Stdin:             ccStdinR,
-		Stdout:            ccStdoutW,
-		InitialIPCPath:    path,
-		Token:             "test-token",
-		ReconnectTimeout:  10 * time.Second,
-		KeepaliveInterval: 10 * time.Second,
-		Logger:            log.New(io.Discard, "", 0),
-		OnInject: func(inject func([]byte) error) {
-			injectCh <- inject
-		},
+	rc := &resilientClient{
+		msgFromCC: make(chan []byte, 1),
+		log:       log.New(io.Discard, "", 0),
 	}
 
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- RunResilientClient(cfg)
-	}()
-
-	go func() {
-		io.Copy(io.Discard, ccStdoutR)
-	}()
-
-	var inject func([]byte) error
-	select {
-	case inject = <-injectCh:
-	case <-time.After(2 * time.Second):
-		t.Fatal("timeout: OnInject callback did not fire")
+	if err := rc.injectFrame([]byte("{}\n")); err != nil {
+		t.Fatalf("first injectFrame() error: %v", err)
 	}
 
 	// Threshold tolerant to busy CI: select-default returns instantly on Go
@@ -549,40 +499,14 @@ func TestResilientClient_OnInject_BufferFull(t *testing.T) {
 	// a few ms. 50 ms still proves "non-blocking" — orders of magnitude below
 	// the inflight drain deadline.
 	const nonBlockingThreshold = 50 * time.Millisecond
-	var fullErr error
-	for range 1100 {
-		start := time.Now()
-		err := inject([]byte("{}\n"))
-		if err == nil {
-			continue
-		}
-		if time.Since(start) > nonBlockingThreshold {
-			t.Fatalf("inject blocked too long (%v) before returning %v — exceeded %v threshold", time.Since(start), err, nonBlockingThreshold)
-		}
-		if !errors.Is(err, ErrInjectFull) {
-			t.Fatalf("expected ErrInjectFull, got %v", err)
-		}
-		fullErr = err
-		break
+	start := time.Now()
+	err := rc.injectFrame([]byte("{}\n"))
+	if time.Since(start) > nonBlockingThreshold {
+		t.Fatalf("injectFrame blocked too long (%v) before returning %v — exceeded %v threshold",
+			time.Since(start), err, nonBlockingThreshold)
 	}
-	if fullErr == nil {
-		t.Fatal("expected at least one ErrInjectFull from inject")
-	}
-
-	// Unblock the IPC server connection so runIPCWriter can drain msgFromCC
-	// after stdin closes. Without this, the runProxy 5s drain deadline can be
-	// exceeded by the saturated buffer + slow blocked writer.
-	select {
-	case conn := <-blockConn:
-		conn.Close()
-	case <-time.After(100 * time.Millisecond):
-	}
-
-	ccStdinW.Close()
-	select {
-	case <-errCh:
-	case <-time.After(15 * time.Second):
-		t.Fatal("timeout: RunResilientClient did not exit")
+	if !errors.Is(err, ErrInjectFull) {
+		t.Fatalf("expected ErrInjectFull, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- forward daemon HandlerFunc and SessionHandler callbacks into snapshot-restored owner configs
- make SessionHandler-only SpawnUpstreamBackground close the pending channel and skip upstream.Start
- add regressions for snapshot restore and template/background-spawn behavior using invalid commands

## Verification
- cd muxcore; go test ./owner ./daemon -run 'TestSpawnUpstreamBackground_SessionHandlerOnly_NoSubprocess|TestLoadSnapshot_SessionHandlerRestoreDoesNotSpawnCommand' -count=1
- cd muxcore; go test ./owner ./daemon -count=1
- cd muxcore; go test ./... -count=1
- go test ./... -count=1

Engram: #190 target-side resolved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Примечания к выпуску

* **New Features**
  * Поддержка пользовательских обработчиков и session-колбэков при восстановлении снимков.
  * Поддержка сценариев "только сессия" и встроенного контроля верхнего уровня без запуска внешнего процесса.

* **Refactor**
  * Переработан путь инъекции фреймов для упрощения и тестируемости.

* **Tests**
  * Расширено покрытие: проверка восстановления без запуска внешнего процесса и лёгкий юнит-тест поведения инъекции при переполнении.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->