### PR TITLE
fix(muxcore): recover control accept loop after close

### DIFF
--- a/muxcore/control/control_test.go
+++ b/muxcore/control/control_test.go
@@ -2,11 +2,13 @@ package control
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"log"
 	"net"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -175,18 +177,18 @@ func TestSendWithTimeout(t *testing.T) {
 // mockDaemonHandler implements both CommandHandler and DaemonHandler for testing.
 type mockDaemonHandler struct {
 	mockHandler
-	spawnCalled  bool
-	removeCalled bool
+	spawnCalled   bool
+	removeCalled  bool
 	refreshCalled bool
-	giveUpCalled bool
-	spawnErr     error
-	removeErr    error
-	refreshErr   error
-	spawnIPCPath string
-	spawnSrvID   string
-	removeArg    string
-	refreshArg   string
-	giveUpArg    string
+	giveUpCalled  bool
+	spawnErr      error
+	removeErr     error
+	refreshErr    error
+	spawnIPCPath  string
+	spawnSrvID    string
+	removeArg     string
+	refreshArg    string
+	giveUpArg     string
 }
 
 func (m *mockDaemonHandler) HandleSpawn(req Request) (string, string, string, error) {
@@ -601,6 +603,100 @@ func TestCloseIdempotent(t *testing.T) {
 
 	srv.Close()
 	srv.Close() // second close must be a no-op, not a panic
+}
+
+type panicAcceptListener struct {
+	value any
+}
+
+func (l panicAcceptListener) Accept() (net.Conn, error) {
+	panic(l.value)
+}
+
+func (l panicAcceptListener) Close() error {
+	return nil
+}
+
+func (l panicAcceptListener) Addr() net.Addr {
+	return dummyAddr("panic-listener")
+}
+
+type dummyAddr string
+
+func (a dummyAddr) Network() string {
+	return "test"
+}
+
+func (a dummyAddr) String() string {
+	return string(a)
+}
+
+func TestAcceptLoopClosedServerRecoversAcceptPanic(t *testing.T) {
+	srv := &Server{
+		listener: panicAcceptListener{value: "The handle is invalid."},
+		logger:   testLogger(t),
+		done:     make(chan struct{}),
+	}
+	srv.closed = true
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		srv.acceptLoop()
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("acceptLoop did not exit after closed-listener panic")
+	}
+}
+
+func TestAcceptLoopUnexpectedPanicPropagates(t *testing.T) {
+	srv := &Server{
+		listener: panicAcceptListener{value: "unexpected accept panic"},
+		logger:   testLogger(t),
+		done:     make(chan struct{}),
+	}
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("acceptLoop swallowed unexpected panic")
+		}
+	}()
+
+	srv.acceptLoop()
+}
+
+type errorAcceptListener struct {
+	err error
+}
+
+func (l errorAcceptListener) Accept() (net.Conn, error) {
+	return nil, l.err
+}
+
+func (l errorAcceptListener) Close() error {
+	return nil
+}
+
+func (l errorAcceptListener) Addr() net.Addr {
+	return dummyAddr("error-listener")
+}
+
+func TestAcceptLoopUnexpectedNetErrClosedLogs(t *testing.T) {
+	var buf bytes.Buffer
+	srv := &Server{
+		listener: errorAcceptListener{err: net.ErrClosed},
+		logger:   log.New(&buf, "", 0),
+		done:     make(chan struct{}),
+	}
+
+	srv.acceptLoop()
+
+	if got := buf.String(); !strings.Contains(got, "unexpected listener close") {
+		t.Fatalf("missing unexpected close log, got %q", got)
+	}
 }
 
 // TestControlServer_ReadDeadlineFiresOnSilentClient is a regression test for FR-5.

--- a/muxcore/control/server.go
+++ b/muxcore/control/server.go
@@ -45,13 +45,24 @@ func NewServer(socketPath string, handler CommandHandler, logger *log.Logger) (*
 }
 
 func (s *Server) acceptLoop() {
+	defer func() {
+		if r := recover(); r != nil {
+			if s.isClosed() {
+				s.logger.Printf("control: accept loop exiting after listener close panic: %v", r)
+				return
+			}
+			panic(r)
+		}
+	}()
+
 	for {
 		conn, err := s.listener.Accept()
 		if err != nil {
-			s.mu.Lock()
-			closed := s.closed
-			s.mu.Unlock()
-			if closed {
+			if s.isClosed() {
+				return
+			}
+			if errors.Is(err, net.ErrClosed) {
+				s.logger.Printf("control: accept loop exiting after unexpected listener close: %v", err)
 				return
 			}
 			s.logger.Printf("control: accept error: %v", err)
@@ -61,6 +72,12 @@ func (s *Server) acceptLoop() {
 		s.wg.Add(1)
 		go s.handleConn(conn)
 	}
+}
+
+func (s *Server) isClosed() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.closed
 }
 
 func (s *Server) handleConn(conn net.Conn) {

--- a/muxcore/daemon/handoff_dup_unix_test.go
+++ b/muxcore/daemon/handoff_dup_unix_test.go
@@ -1,0 +1,18 @@
+//go:build !windows
+
+package daemon
+
+import (
+	"os"
+	"syscall"
+	"testing"
+)
+
+func dupFDForHandoff(t *testing.T, f *os.File) uintptr {
+	t.Helper()
+	fd, err := syscall.Dup(int(f.Fd()))
+	if err != nil {
+		t.Fatalf("dup handoff fd: %v", err)
+	}
+	return uintptr(fd)
+}

--- a/muxcore/daemon/handoff_dup_windows_test.go
+++ b/muxcore/daemon/handoff_dup_windows_test.go
@@ -1,0 +1,27 @@
+//go:build windows
+
+package daemon
+
+import (
+	"os"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+func dupFDForHandoff(t *testing.T, f *os.File) uintptr {
+	t.Helper()
+	var dup windows.Handle
+	if err := windows.DuplicateHandle(
+		windows.CurrentProcess(),
+		windows.Handle(f.Fd()),
+		windows.CurrentProcess(),
+		&dup,
+		0,
+		false,
+		windows.DUPLICATE_SAME_ACCESS,
+	); err != nil {
+		t.Fatalf("duplicate handoff handle: %v", err)
+	}
+	return uintptr(dup)
+}

--- a/muxcore/daemon/snapshot_reattach_test.go
+++ b/muxcore/daemon/snapshot_reattach_test.go
@@ -124,6 +124,8 @@ func TestLoadSnapshot_Reattach_HappyPath(t *testing.T) {
 	// Capture the performHandoff error on a buffered channel so we can
 	// propagate sender-side failures to the test instead of relying on
 	// receiveHandoff to time out on a half-done protocol.
+	stdinFD := dupFDForHandoff(t, stdinR)
+	stdoutFD := dupFDForHandoff(t, stdoutW)
 	senderErrCh := make(chan error, 1)
 	go func() {
 		upstreams := []HandoffUpstream{
@@ -131,8 +133,8 @@ func TestLoadSnapshot_Reattach_HappyPath(t *testing.T) {
 				ServerID: sid,
 				Command:  "echo",
 				PID:      os.Getpid(), // valid PID > 0; not verified by AttachFromFDs
-				StdinFD:  stdinR.Fd(),
-				StdoutFD: stdoutW.Fd(),
+				StdinFD:  stdinFD,
+				StdoutFD: stdoutFD,
 			},
 		}
 		ctx := context.Background()
@@ -414,6 +416,8 @@ func TestLoadSnapshot_Reattach_PartialHandoff(t *testing.T) {
 
 	oldDaemonConn, successorConn := newMockFDConnPair()
 
+	stdinFD := dupFDForHandoff(t, stdinR)
+	stdoutFD := dupFDForHandoff(t, stdoutW)
 	senderErrCh := make(chan error, 1)
 	go func() {
 		upstreams := []HandoffUpstream{
@@ -421,8 +425,8 @@ func TestLoadSnapshot_Reattach_PartialHandoff(t *testing.T) {
 				ServerID: sid1, // Only sid1 transferred — sid2 falls through.
 				Command:  "echo",
 				PID:      os.Getpid(),
-				StdinFD:  stdinR.Fd(),
-				StdoutFD: stdoutW.Fd(),
+				StdinFD:  stdinFD,
+				StdoutFD: stdoutFD,
 			},
 		}
 		_, err := performHandoff(context.Background(), oldDaemonConn, testToken, upstreams)


### PR DESCRIPTION
## Summary

Fixes the Windows master CI failure seen after PR #114 merged. On Windows, closing an AF_UNIX listener can panic inside Go's internal poll accept path with The handle is invalid instead of returning 
et.ErrClosed. The control server accept loop now treats that panic as a normal shutdown only when the server is already closed, while still re-panicking unexpected accept panics.

## Verification

`ash
$ cd D:\\Dev\\mcp-mux\\muxcore
$ go test ./control -run 'TestAcceptLoopClosedServerRecoversAcceptPanic|TestAcceptLoopUnexpectedPanicPropagates|TestCloseIdempotent' -count=1
ok   github.com/thebtf/mcp-mux/muxcore/control 0.281s

$ go test ./control ./daemon -count=1 -timeout 300s
ok   github.com/thebtf/mcp-mux/muxcore/control 5.346s
ok   github.com/thebtf/mcp-mux/muxcore/daemon  9.998s

$ go test -race ./control ./daemon -count=1 -timeout 300s
ok   github.com/thebtf/mcp-mux/muxcore/control 6.485s
ok   github.com/thebtf/mcp-mux/muxcore/daemon  14.998s

$ go test ./... -count=1 -timeout 300s
ok   github.com/thebtf/mcp-mux/muxcore/... (all packages passed)

$ go test -race -count=1 -timeout 300s ./...
ok   github.com/thebtf/mcp-mux/muxcore/... (all packages passed)

$ cd D:\\Dev\\mcp-mux
$ go test ./... -count=1
ok   github.com/thebtf/mcp-mux/cmd/mcp-mux       0.277s
ok   github.com/thebtf/mcp-mux/internal/mcpserver 1.580s
`

Release blocker for muxcore/v0.24.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Исправления ошибок**
  * Повышена безопасность завершения сервера: добавлено восстановление от паник в цикле Accept, корректная обработка закрытого слушателя и предотвращение утечек горутин.

* **Тесты**
  * Добавлены и расширены тесты устойчивости к паникам в Accept.
  * Добавлены кроссплатформенные тестовые помощники для дублирования дескрипторов (Unix/Windows) и обновлены тесты переаттача снимков для использования их.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->