### PR TITLE
fix(upgrade): use versioned launcher engine

### DIFF
--- a/.agent/arch/decisions/009-upgrade-strategy.md
+++ b/.agent/arch/decisions/009-upgrade-strategy.md
@@ -1,7 +1,10 @@
 # ADR-009: Upgrade Strategy — Rename-Swap Without Daemon Restart
 
 ## Status
-Accepted
+Superseded by ADR 012 for Windows-safe engine updates. The stdio pipe
+ownership analysis still stands, but the binary replacement mechanism is now a
+stable launcher plus versioned engine pointer rather than self-renaming the
+configured executable.
 
 ## Context
 mcp-mux daemon manages N upstream processes via stdio pipes (kernel pipe objects).

--- a/.agent/arch/decisions/012-versioned-launcher-upgrade.md
+++ b/.agent/arch/decisions/012-versioned-launcher-upgrade.md
@@ -1,0 +1,75 @@
+# ADR 012 -- Versioned Launcher Upgrade
+
+Status: Accepted
+
+Date: 2026-05-20
+
+## Context
+
+The previous upgrade strategy assumed the configured `mcp-mux.exe` could be
+renamed while active Windows processes were running from that image. The
+release playbook for PR #116 falsified that assumption on the workstation:
+`mcp-mux.exe upgrade --restart` failed with `rename current to old: Access is
+denied` while many live shim/daemon processes held the configured executable.
+
+This is a product-contract problem, not only a deploy note. The configured
+binary is the stable entrypoint that MCP consumers launch, so it is exactly the
+file most likely to be locked during an update.
+
+## Decision
+
+`mcp-mux.exe` becomes a stable launcher/fallback entrypoint. Runtime logic moves
+behind a versioned engine selected by an active pointer:
+
+```text
+consumer -> mcp-mux.exe launcher -> mcp-mux.versions/<hash>/mcp-mux-engine.exe
+                               \-> mcp-mux.versions/active.txt
+```
+
+`mcp-mux upgrade` no longer renames the configured launcher. It installs the
+pending `mcp-mux.exe~` as a content-addressed engine under
+`mcp-mux.versions/<hash>/mcp-mux-engine.exe`, updates `active.txt`, and keeps
+the launcher path stable. If a directory ACL prevents rename/delete of the
+staged file, the installer falls back to copy+hash-verify and treats staged-file
+cleanup as best effort after the active engine is safely installed.
+
+`upgrade --restart` asks the daemon to graceful-restart. Successor daemon spawn
+resolves the active engine pointer through `MCPMUX_ACTIVE_ENGINE_FILE` (or an
+explicit `MCPMUX_SUCCESSOR_EXE`) instead of blindly spawning `os.Executable()`.
+The `cmd/mcp-mux` daemon config explicitly sets `DaemonFlag: "daemon"` so the
+successor enters the correct CLI subcommand.
+
+## Consequences
+
+Positive:
+
+- Windows updates no longer depend on renaming a locked configured executable.
+- Old shims/daemons can keep running from their old engine path while new shims
+  use the active engine.
+- The stable MCP config path does not change between releases.
+
+Negative:
+
+- There is one extra launcher process per shim while the active engine runs.
+- Launcher changes themselves still require a maintenance replacement, but that
+  should be rare compared with engine/runtime updates.
+- The first deployment from a pre-launcher binary may still need a maintenance
+  replacement if live old-style `mcp-mux.exe` processes lock the configured
+  executable. After the stable launcher is installed, normal engine updates no
+  longer touch that path.
+- `mcp-mux.versions/` is runtime state and must stay out of git.
+
+## Verification
+
+Fresh evidence for the accepting implementation:
+
+- `go test .\cmd\mcp-mux -count=1`
+- `go test .\muxcore\daemon -count=1`
+- `go test ./... -count=1`
+- `Push-Location muxcore; go test ./... -count=1; Pop-Location`
+- `go vet ./...`
+- `scripts\smoke-time-upstream.ps1` using a stable launcher with an installed
+  active versioned engine returned `PASS`.
+- Isolated `upgrade --restart` with repo-local `TEMP` installed the engine,
+  started a daemon through the active engine, returned `status`, and stopped
+  cleanly.

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ dist/
 *.exe~
 *.exe.old
 *.exe.old.*
+mcp-mux.versions/
 coverage.out
 coverage.html
 .gomodcache/

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ MCP_MUX_NO_DAEMON=1 mcp-mux uvx my-server
 
 mcp-mux shims automatically reconnect when the daemon restarts. This means:
 
-- `mcp-mux upgrade` swaps the binary without dropping connections
+- `mcp-mux upgrade` switches the active versioned engine without dropping connections
 - `mcp-mux stop --force` triggers automatic reconnect within seconds
 - Daemon crashes are recovered transparently
 
@@ -308,7 +308,7 @@ mcp-mux status
 # Stop all running instances and the daemon
 mcp-mux stop [--drain-timeout 30s] [--force]
 
-# Atomic binary upgrade (see section below)
+# Versioned engine upgrade (see section below)
 mcp-mux upgrade
 
 # Start a detached daemon process (normally auto-started by shims)
@@ -318,7 +318,7 @@ mcp-mux daemon
 mcp-mux serve
 ```
 
-## Atomic Upgrade with Graceful Restart
+## Versioned Engine Upgrade with Graceful Restart
 
 Upgrading the mcp-mux binary while sessions are active is safe and fast:
 
@@ -329,22 +329,30 @@ go build -o mcp-mux.exe~ ./cmd/mcp-mux && mcp-mux upgrade --restart
 
 **What happens:**
 
-1. Binary swap: `current` → `.old`, `pending~` → `current` (atomic rename)
-2. Graceful restart: daemon serializes state snapshot (cached init/tools/prompts/resources
+1. The stable `mcp-mux` launcher is left in place; it is not renamed while live shims hold it.
+2. The pending `mcp-mux.exe~` engine is copied or moved into
+   `mcp-mux.versions/<hash>/mcp-mux-engine.exe`.
+3. `mcp-mux.versions/active.txt` is switched to the new engine path.
+4. Graceful restart: daemon serializes state snapshot (cached init/tools/prompts/resources
    responses, classification, session metadata) to a JSON file
-3. Daemon shuts down, shims detect IPC EOF
-4. Shims auto-reconnect, starting a new daemon from the updated binary
-5. New daemon loads snapshot → owners restored with pre-populated caches
-6. Shims get instant cached replay (~1 second reconnect vs 5-15 second cold start)
+5. Daemon shuts down, shims detect IPC EOF
+6. Shims auto-reconnect, starting a new daemon from the active versioned engine
+7. New daemon loads snapshot → owners restored with pre-populated caches
+8. Shims get instant cached replay (~1 second reconnect vs 5-15 second cold start)
 
-**Without `--restart`** (hot swap only):
+The launcher indirection is intentional on Windows: live `mcp-mux.exe` shim and daemon
+processes keep the executable image locked, so a self-rename of the configured binary is
+not a reliable update primitive. Versioned engines avoid that lock; old processes keep
+running from their old engine path while new shims use the active engine pointer.
+
+**Without `--restart`** (active pointer switch only):
 
 ```sh
 mcp-mux upgrade
 ```
 
-The daemon keeps running with the old binary. New shim processes use the new binary.
-The daemon updates on next natural restart.
+The daemon keeps running with its current engine. New shim processes use the new
+active engine. The daemon updates on next natural restart.
 
 **Graceful restart preserves (v0.21.0+):**
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -282,7 +282,7 @@ mcp-mux status
 # Остановить все запущенные экземпляры и daemon
 mcp-mux stop [--drain-timeout 30s] [--force]
 
-# Атомарное обновление бинарника (см. раздел ниже)
+# Обновление versioned engine (см. раздел ниже)
 mcp-mux upgrade
 
 # Запустить отдельный daemon-процесс (обычно запускается автоматически shim-ами)
@@ -292,21 +292,25 @@ mcp-mux daemon
 mcp-mux serve
 ```
 
-## Атомарное обновление
+## Обновление versioned engine
 
-Обновление бинарника mcp-mux при активных сессиях безопасно:
+Обновление mcp-mux при активных сессиях безопасно:
 
 ```sh
-# 1. Собрать новый бинарник во временный путь
-go build -o mcp-mux.exe~ ./cmd/mcp-mux
-
-# 2. Атомарная замена — останавливает активные сессии, заменяет бинарник, upstream-процессы остаются нетронутыми
-mcp-mux upgrade
+# Обновление с graceful restart
+go build -o mcp-mux.exe~ ./cmd/mcp-mux && mcp-mux upgrade --restart
 ```
 
-`upgrade` выполняет атомарное переименование файлов в два шага (`current` → `.old`, `pending~` → `current`). Если временный бинарник отсутствует или переименование не удалось, `upgrade` завершается с ошибкой, а существующий бинарник остаётся нетронутым.
+`mcp-mux.exe` теперь играет роль стабильного launcher. `upgrade` не переименовывает
+запущенный launcher: staged `mcp-mux.exe~` переносится или копируется в
+`mcp-mux.versions/<hash>/mcp-mux-engine.exe`, а `mcp-mux.versions/active.txt`
+переключается на новую версию engine. Это важно для Windows: живые shim/daemon
+процессы держат image lock на настроенном `mcp-mux.exe`, поэтому self-rename
+этого файла не является надёжной операцией обновления.
 
-После обновления MCP-серверы автоматически перезапустятся при следующем вызове инструмента CC — shim переподключится к новому daemon, запущенному новым бинарником.
+С `--restart` daemon делает snapshot, завершает старый процесс и запускает successor
+из active versioned engine. Без `--restart` daemon продолжает работать на старом
+engine до естественного рестарта, а новые shim-процессы уже используют active engine.
 
 ## Жизненный цикл upstream — выживание при рестарте daemon (v0.21.0+)
 

--- a/cmd/mcp-mux/daemon.go
+++ b/cmd/mcp-mux/daemon.go
@@ -93,6 +93,7 @@ func runGlobalDaemon() {
 		IdleTimeout:      idleTimeout,
 		Logger:           logger,
 		Name:             engineName,
+		DaemonFlag:       "daemon",
 	})
 	if err != nil {
 		logger.Fatalf("failed to start daemon: %v", err)

--- a/cmd/mcp-mux/daemon.go
+++ b/cmd/mcp-mux/daemon.go
@@ -124,6 +124,14 @@ func runGlobalDaemon() {
 // Emits structured "ensure_daemon substep=<name>" log lines so the shim's
 // startup timeline can be reconstructed from the CC mcp-logs jsonl.
 func ensureDaemon(logger *log.Logger) error {
+	return ensureDaemonWithin(logger, 15*time.Second)
+}
+
+func ensureDaemonWithin(logger *log.Logger, budget time.Duration) error {
+	if budget <= 0 {
+		return fmt.Errorf("daemon did not start within reconnect budget")
+	}
+	deadline := time.Now().Add(budget)
 	ctlPath := serverid.DaemonControlPath("", engineName)
 
 	// Fast path: daemon already running (no lock needed).
@@ -154,7 +162,7 @@ func ensureDaemon(logger *log.Logger) error {
 		logger.Printf("ensure_daemon substep=lock_attempt status=contended duration=%v err=%q",
 			time.Since(lockStart), err.Error())
 		waitStart := time.Now()
-		waitErr := waitForDaemon(ctlPath, 15*time.Second)
+		waitErr := waitForDaemon(ctlPath, remainingBudget(deadline, 15*time.Second))
 		if waitErr != nil {
 			logger.Printf("ensure_daemon substep=wait_for_other_shim status=error duration=%v err=%q",
 				time.Since(waitStart), waitErr.Error())
@@ -189,7 +197,7 @@ func ensureDaemon(logger *log.Logger) error {
 		time.Since(spawnStart))
 
 	waitStart := time.Now()
-	if err := waitForDaemon(ctlPath, 10*time.Second); err != nil {
+	if err := waitForDaemon(ctlPath, remainingBudget(deadline, 10*time.Second)); err != nil {
 		logger.Printf("ensure_daemon substep=wait_for_self status=timeout duration=%v err=%q",
 			time.Since(waitStart), err.Error())
 		return err
@@ -197,6 +205,17 @@ func ensureDaemon(logger *log.Logger) error {
 	logger.Printf("ensure_daemon substep=wait_for_self status=ok duration=%v",
 		time.Since(waitStart))
 	return nil
+}
+
+func remainingBudget(deadline time.Time, cap time.Duration) time.Duration {
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		return time.Nanosecond
+	}
+	if remaining < cap {
+		return remaining
+	}
+	return cap
 }
 
 // waitForDaemon polls until the daemon control socket responds (up to timeout).
@@ -266,6 +285,13 @@ func spawnViaDaemon(command string, args []string, cwd, mode string, env map[str
 }
 
 func spawnViaDaemonWithReason(command string, args []string, cwd, mode string, env map[string]string, reconnectReason string, logger *log.Logger) (string, string, error) {
+	return spawnViaDaemonWithReasonTimeout(command, args, cwd, mode, env, reconnectReason, logger, 30*time.Second)
+}
+
+func spawnViaDaemonWithReasonTimeout(command string, args []string, cwd, mode string, env map[string]string, reconnectReason string, logger *log.Logger, timeout time.Duration) (string, string, error) {
+	if timeout <= 0 {
+		return "", "", fmt.Errorf("spawn via daemon: reconnect budget exhausted")
+	}
 	ctlPath := serverid.DaemonControlPath("", engineName)
 
 	// Spawn returns immediately after creating the owner — proactive init runs
@@ -279,7 +305,7 @@ func spawnViaDaemonWithReason(command string, args []string, cwd, mode string, e
 		Mode:            mode,
 		Env:             env,
 		ReconnectReason: reconnectReason,
-	}, 30*time.Second)
+	}, timeout)
 	rpcDur := time.Since(rpcStart)
 	if err != nil {
 		logger.Printf("daemon_rpc_spawn status=error duration=%v err=%q", rpcDur, err.Error())
@@ -287,6 +313,9 @@ func spawnViaDaemonWithReason(command string, args []string, cwd, mode string, e
 	}
 	if !resp.OK {
 		logger.Printf("daemon_rpc_spawn status=not_ok duration=%v msg=%q", rpcDur, resp.Message)
+		if resp.Message == daemon.ErrDaemonShuttingDown.Error() {
+			return "", "", fmt.Errorf("daemon spawn failed: %w", daemon.ErrDaemonShuttingDown)
+		}
 		return "", "", fmt.Errorf("daemon spawn failed: %s", resp.Message)
 	}
 

--- a/cmd/mcp-mux/launcher.go
+++ b/cmd/mcp-mux/launcher.go
@@ -46,15 +46,17 @@ func maybeRunLauncher() (bool, int) {
 }
 
 func runEngineProcess(launcherPath, enginePath string, args []string) (bool, int) {
-	cmd := exec.Command(enginePath, args...)
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	cmd.Env = launcherEnv(launcherPath)
-	if err := cmd.Start(); err != nil {
-		fmt.Fprintf(os.Stderr, "mcp-mux launcher: start active engine %s: %v\n", enginePath, err)
-		fmt.Fprintln(os.Stderr, "mcp-mux launcher: falling back to stable launcher binary")
+	cmd, fallbackToCaller, err := startEngineOrStableLauncher(launcherPath, enginePath, args, true, func(cmd *exec.Cmd) {
+		cmd.Stdin = os.Stdin
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+	})
+	if fallbackToCaller {
 		return false, 0
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mcp-mux launcher: %v\n", err)
+		return true, 1
 	}
 	if err := cmd.Wait(); err != nil {
 		var exitErr *exec.ExitError
@@ -65,6 +67,34 @@ func runEngineProcess(launcherPath, enginePath string, args []string) (bool, int
 		return true, 1
 	}
 	return true, 0
+}
+
+func startEngineOrStableLauncher(launcherPath, enginePath string, args []string, fallbackToCaller bool, configure func(*exec.Cmd)) (*exec.Cmd, bool, error) {
+	cmd := newLauncherEnvCommand(launcherPath, enginePath, args)
+	configure(cmd)
+	if err := cmd.Start(); err == nil {
+		return cmd, false, nil
+	} else if fallbackToCaller {
+		fmt.Fprintf(os.Stderr, "mcp-mux launcher: start active engine %s: %v\n", enginePath, err)
+		fmt.Fprintln(os.Stderr, "mcp-mux launcher: falling back to stable launcher binary")
+		return nil, true, nil
+	} else {
+		fmt.Fprintf(os.Stderr, "mcp-mux launcher: start active engine %s: %v\n", enginePath, err)
+		fmt.Fprintln(os.Stderr, "mcp-mux launcher: starting daemon via stable launcher binary")
+		startErr := err
+		cmd = newLauncherEnvCommand(launcherPath, launcherPath, args)
+		configure(cmd)
+		if err := cmd.Start(); err != nil {
+			return nil, false, fmt.Errorf("start active engine %s: %v; start stable launcher fallback %s: %w", enginePath, startErr, launcherPath, err)
+		}
+		return cmd, false, nil
+	}
+}
+
+func newLauncherEnvCommand(launcherPath, executablePath string, args []string) *exec.Cmd {
+	cmd := exec.Command(executablePath, args...)
+	cmd.Env = launcherEnv(launcherPath)
+	return cmd
 }
 
 func launcherEnv(launcherPath string) []string {
@@ -284,13 +314,13 @@ func startDaemonAndWait(launcherPath, enginePath, ctlPath string) error {
 }
 
 func startDaemonProcessFrom(launcherPath, enginePath string) error {
-	cmd := exec.Command(enginePath, "daemon")
-	cmd.Stdout = nil
-	cmd.Stderr = nil
-	cmd.Stdin = nil
-	cmd.Env = launcherEnv(launcherPath)
-	setSysProcAttr(cmd)
-	if err := cmd.Start(); err != nil {
+	cmd, _, err := startEngineOrStableLauncher(launcherPath, enginePath, []string{"daemon"}, false, func(cmd *exec.Cmd) {
+		cmd.Stdout = nil
+		cmd.Stderr = nil
+		cmd.Stdin = nil
+		setSysProcAttr(cmd)
+	})
+	if err != nil {
 		return fmt.Errorf("start daemon process: %w", err)
 	}
 	if err := cmd.Process.Release(); err != nil {

--- a/cmd/mcp-mux/launcher.go
+++ b/cmd/mcp-mux/launcher.go
@@ -42,24 +42,29 @@ func maybeRunLauncher() (bool, int) {
 		return false, 0
 	}
 
-	return true, runEngineProcess(exe, enginePath, os.Args[1:])
+	return runEngineProcess(exe, enginePath, os.Args[1:])
 }
 
-func runEngineProcess(launcherPath, enginePath string, args []string) int {
+func runEngineProcess(launcherPath, enginePath string, args []string) (bool, int) {
 	cmd := exec.Command(enginePath, args...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Env = launcherEnv(launcherPath)
-	if err := cmd.Run(); err != nil {
+	if err := cmd.Start(); err != nil {
+		fmt.Fprintf(os.Stderr, "mcp-mux launcher: start active engine %s: %v\n", enginePath, err)
+		fmt.Fprintln(os.Stderr, "mcp-mux launcher: falling back to stable launcher binary")
+		return false, 0
+	}
+	if err := cmd.Wait(); err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
-			return exitErr.ExitCode()
+			return true, exitErr.ExitCode()
 		}
-		fmt.Fprintf(os.Stderr, "mcp-mux launcher: start engine %s: %v\n", enginePath, err)
-		return 1
+		fmt.Fprintf(os.Stderr, "mcp-mux launcher: active engine %s exited with wait error: %v\n", enginePath, err)
+		return true, 1
 	}
-	return 0
+	return true, 0
 }
 
 func launcherEnv(launcherPath string) []string {

--- a/cmd/mcp-mux/launcher.go
+++ b/cmd/mcp-mux/launcher.go
@@ -226,14 +226,22 @@ func restartDaemonAfterEngineSwitch(launcherPath, enginePath string) error {
 	if lockErr == nil {
 		if flockErr := lockFile(lock); flockErr == nil {
 			defer func() {
-				unlockFile(lock)
-				lock.Close()
+				if err := unlockFile(lock); err != nil {
+					fmt.Fprintf(os.Stderr, "Warning: could not release daemon lock %s: %v\n", lockPath, err)
+				}
+				if err := lock.Close(); err != nil {
+					fmt.Fprintf(os.Stderr, "Warning: could not close daemon lock %s: %v\n", lockPath, err)
+				}
 			}()
 			fmt.Fprintln(os.Stderr, "Acquired daemon lock (shims blocked from respawning).")
 		} else {
-			lock.Close()
+			if err := lock.Close(); err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: could not close daemon lock %s: %v\n", lockPath, err)
+			}
 			fmt.Fprintf(os.Stderr, "Warning: could not acquire daemon lock: %v (proceeding anyway)\n", flockErr)
 		}
+	} else {
+		fmt.Fprintf(os.Stderr, "Warning: could not open daemon lock %s: %v (proceeding anyway)\n", lockPath, lockErr)
 	}
 
 	fmt.Fprintln(os.Stderr, "Graceful restart: serializing state...")
@@ -315,16 +323,8 @@ func writeActiveEngine(launcherPath, enginePath string) error {
 		return fmt.Errorf("write active engine pointer: %w", err)
 	}
 	if err := replaceFile(tmp, activeFile); err != nil {
-		data, readErr := os.ReadFile(tmp)
-		if readErr != nil {
-			_ = os.Remove(tmp)
-			return fmt.Errorf("replace active engine pointer: %w", err)
-		}
-		if writeErr := os.WriteFile(activeFile, data, 0644); writeErr != nil {
-			_ = os.Remove(tmp)
-			return fmt.Errorf("replace active engine pointer: %w", err)
-		}
-		_ = removeWithRetry(tmp, 10, 50*time.Millisecond)
+		_ = os.Remove(tmp)
+		return fmt.Errorf("replace active engine pointer: %w", err)
 	}
 	return nil
 }

--- a/cmd/mcp-mux/launcher.go
+++ b/cmd/mcp-mux/launcher.go
@@ -1,0 +1,373 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/thebtf/mcp-mux/muxcore/control"
+	"github.com/thebtf/mcp-mux/muxcore/serverid"
+)
+
+const (
+	envEngineMode       = "MCPMUX_ENGINE"
+	envDisableLauncher  = "MCPMUX_DISABLE_LAUNCHER"
+	envLauncherExe      = "MCPMUX_LAUNCHER_EXE"
+	envActiveEngineFile = "MCPMUX_ACTIVE_ENGINE_FILE"
+)
+
+func maybeRunLauncher() (bool, int) {
+	if os.Getenv(envEngineMode) == "1" || os.Getenv(envDisableLauncher) == "1" {
+		return false, 0
+	}
+
+	exe, err := os.Executable()
+	if err != nil {
+		return false, 0
+	}
+
+	if len(os.Args) > 1 && os.Args[1] == "upgrade" {
+		return true, runLauncherUpgrade(exe, os.Args[2:])
+	}
+
+	enginePath, ok := resolveActiveEngine(exe)
+	if !ok || samePath(enginePath, exe) {
+		return false, 0
+	}
+
+	return true, runEngineProcess(exe, enginePath, os.Args[1:])
+}
+
+func runEngineProcess(launcherPath, enginePath string, args []string) int {
+	cmd := exec.Command(enginePath, args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = launcherEnv(launcherPath)
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return exitErr.ExitCode()
+		}
+		fmt.Fprintf(os.Stderr, "mcp-mux launcher: start engine %s: %v\n", enginePath, err)
+		return 1
+	}
+	return 0
+}
+
+func launcherEnv(launcherPath string) []string {
+	env := append([]string{}, os.Environ()...)
+	env = setEnv(env, envEngineMode, "1")
+	env = setEnv(env, envLauncherExe, launcherPath)
+	env = setEnv(env, envActiveEngineFile, activeEngineFile(launcherPath))
+	return env
+}
+
+func runLauncherUpgrade(launcherPath string, args []string) int {
+	upgradeFlags := flag.NewFlagSet("upgrade", flag.ContinueOnError)
+	upgradeFlags.SetOutput(os.Stderr)
+	restart := upgradeFlags.Bool("restart", false, "Restart daemon after active engine switch")
+	if err := upgradeFlags.Parse(args); err != nil {
+		return 2
+	}
+
+	pendingPath := launcherPath + "~"
+	enginePath, installed, err := installVersionedEngine(launcherPath, pendingPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		fmt.Fprintln(os.Stderr, "")
+		fmt.Fprintln(os.Stderr, "Build the pending engine binary first:")
+		fmt.Fprintf(os.Stderr, "  go build -trimpath -o %s .\\cmd\\mcp-mux\n", pendingPath)
+		return 1
+	}
+
+	if installed {
+		fmt.Fprintf(os.Stderr, "Installed engine: %s\n", enginePath)
+	} else {
+		fmt.Fprintf(os.Stderr, "Engine already installed: %s\n", enginePath)
+	}
+	fmt.Fprintf(os.Stderr, "Active engine: %s\n", enginePath)
+
+	if *restart {
+		if err := restartDaemonAfterEngineSwitch(launcherPath, enginePath); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: daemon restart incomplete: %v\n", err)
+			fmt.Fprintln(os.Stderr, "Shims will start the active engine on next reconnect.")
+			return 1
+		}
+	}
+	return 0
+}
+
+func installVersionedEngine(launcherPath, pendingPath string) (enginePath string, installed bool, err error) {
+	if _, err := os.Stat(pendingPath); err != nil {
+		if os.IsNotExist(err) {
+			return "", false, fmt.Errorf("no pending update found at %s", pendingPath)
+		}
+		return "", false, fmt.Errorf("stat pending update: %w", err)
+	}
+
+	hash, err := fileHash(pendingPath)
+	if err != nil {
+		return "", false, fmt.Errorf("hash pending update: %w", err)
+	}
+	versionID := hash
+	if len(versionID) > 12 {
+		versionID = versionID[:12]
+	}
+	enginePath = filepath.Join(versionStoreDir(launcherPath), versionID, engineFileName())
+
+	if current, ok := resolveActiveEngine(launcherPath); ok && samePath(current, enginePath) {
+		if sameFile(current, pendingPath) {
+			_ = removeWithRetry(pendingPath, 10, 50*time.Millisecond)
+			return enginePath, false, nil
+		}
+	}
+
+	if err := os.MkdirAll(filepath.Dir(enginePath), 0755); err != nil {
+		return "", false, fmt.Errorf("create version dir: %w", err)
+	}
+
+	if _, statErr := os.Stat(enginePath); statErr == nil {
+		if !sameFile(enginePath, pendingPath) {
+			return "", false, fmt.Errorf("version path exists with different content: %s", enginePath)
+		}
+		_ = removeWithRetry(pendingPath, 10, 50*time.Millisecond)
+		installed = false
+	} else if os.IsNotExist(statErr) {
+		if err := movePendingEngine(pendingPath, enginePath); err != nil {
+			return "", false, fmt.Errorf("move pending update into version store: %w", err)
+		}
+		installed = true
+	} else {
+		return "", false, fmt.Errorf("stat version path: %w", statErr)
+	}
+
+	if err := writeActiveEngine(launcherPath, enginePath); err != nil {
+		return "", installed, err
+	}
+	return enginePath, installed, nil
+}
+
+func movePendingEngine(src, dst string) error {
+	if err := os.Rename(src, dst); err == nil {
+		return nil
+	}
+	if err := copyFile(src, dst, 0755); err != nil {
+		return err
+	}
+	if !sameFile(src, dst) {
+		_ = os.Remove(dst)
+		return fmt.Errorf("copied engine hash mismatch")
+	}
+	_ = removeWithRetry(src, 10, 50*time.Millisecond)
+	return nil
+}
+
+func copyFile(src, dst string, perm os.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_EXCL|os.O_WRONLY, perm)
+	if err != nil {
+		return err
+	}
+	ok := false
+	defer func() {
+		_ = out.Close()
+		if !ok {
+			_ = os.Remove(dst)
+		}
+	}()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	if err := out.Sync(); err != nil {
+		return err
+	}
+	ok = true
+	return nil
+}
+
+func removeWithRetry(path string, attempts int, delay time.Duration) error {
+	var last error
+	for i := 0; i < attempts; i++ {
+		if err := os.Remove(path); err == nil || os.IsNotExist(err) {
+			return nil
+		} else {
+			last = err
+		}
+		time.Sleep(delay)
+	}
+	return last
+}
+
+func restartDaemonAfterEngineSwitch(launcherPath, enginePath string) error {
+	ctlPath := serverid.DaemonControlPath("", engineName)
+	if !isDaemonRunning(ctlPath) {
+		if err := startDaemonProcessFrom(launcherPath, enginePath); err != nil {
+			return err
+		}
+		return waitForDaemon(ctlPath, 10*time.Second)
+	}
+
+	lockPath := serverid.DaemonLockPath("", engineName)
+	lock, lockErr := os.OpenFile(lockPath, os.O_CREATE|os.O_WRONLY, 0600)
+	if lockErr == nil {
+		if flockErr := lockFile(lock); flockErr == nil {
+			defer func() {
+				unlockFile(lock)
+				lock.Close()
+			}()
+			fmt.Fprintln(os.Stderr, "Acquired daemon lock (shims blocked from respawning).")
+		} else {
+			lock.Close()
+			fmt.Fprintf(os.Stderr, "Warning: could not acquire daemon lock: %v (proceeding anyway)\n", flockErr)
+		}
+	}
+
+	fmt.Fprintln(os.Stderr, "Graceful restart: serializing state...")
+	resp, err := control.SendWithTimeout(ctlPath, control.Request{
+		Cmd:            "graceful-restart",
+		DrainTimeoutMs: 30000,
+	}, 60*time.Second)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  graceful-restart not available: %v, falling back to shutdown\n", err)
+		_, _ = control.Send(ctlPath, control.Request{Cmd: "shutdown"})
+		waitForDaemonExit(ctlPath, "  Waiting for old daemon to exit...")
+		return startDaemonAndWait(launcherPath, enginePath, ctlPath)
+	}
+	if !resp.OK {
+		fmt.Fprintf(os.Stderr, "  graceful-restart failed: %s, falling back to shutdown\n", resp.Message)
+		_, _ = control.Send(ctlPath, control.Request{Cmd: "shutdown"})
+		waitForDaemonExit(ctlPath, "  Waiting for old daemon to exit...")
+		return startDaemonAndWait(launcherPath, enginePath, ctlPath)
+	}
+
+	waitForDaemonExit(ctlPath, "  snapshot written. Waiting for daemon to exit...")
+	if err := waitForDaemon(ctlPath, 10*time.Second); err == nil {
+		fmt.Fprintln(os.Stderr, "  New daemon ready. Releasing lock — shims will reconnect.")
+		return nil
+	}
+	fmt.Fprintln(os.Stderr, "  Successor daemon not ready; starting active engine daemon...")
+	return startDaemonAndWait(launcherPath, enginePath, ctlPath)
+}
+
+func startDaemonAndWait(launcherPath, enginePath, ctlPath string) error {
+	if err := startDaemonProcessFrom(launcherPath, enginePath); err != nil {
+		return err
+	}
+	return waitForDaemon(ctlPath, 10*time.Second)
+}
+
+func startDaemonProcessFrom(launcherPath, enginePath string) error {
+	cmd := exec.Command(enginePath, "daemon")
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	cmd.Stdin = nil
+	cmd.Env = launcherEnv(launcherPath)
+	setSysProcAttr(cmd)
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start daemon process: %w", err)
+	}
+	if err := cmd.Process.Release(); err != nil {
+		return fmt.Errorf("release daemon process: %w", err)
+	}
+	return nil
+}
+
+func resolveActiveEngine(launcherPath string) (string, bool) {
+	data, err := os.ReadFile(activeEngineFile(launcherPath))
+	if err != nil {
+		return "", false
+	}
+	raw := strings.TrimSpace(string(data))
+	if raw == "" {
+		return "", false
+	}
+	if filepath.IsAbs(raw) {
+		return filepath.Clean(raw), true
+	}
+	return filepath.Clean(filepath.Join(versionStoreDir(launcherPath), raw)), true
+}
+
+func writeActiveEngine(launcherPath, enginePath string) error {
+	activeFile := activeEngineFile(launcherPath)
+	if err := os.MkdirAll(filepath.Dir(activeFile), 0755); err != nil {
+		return fmt.Errorf("create version store: %w", err)
+	}
+	rel, err := filepath.Rel(versionStoreDir(launcherPath), enginePath)
+	if err != nil {
+		rel = enginePath
+	}
+	tmp := fmt.Sprintf("%s.tmp.%d", activeFile, os.Getpid())
+	if err := os.WriteFile(tmp, []byte(rel+"\n"), 0644); err != nil {
+		return fmt.Errorf("write active engine pointer: %w", err)
+	}
+	if err := replaceFile(tmp, activeFile); err != nil {
+		data, readErr := os.ReadFile(tmp)
+		if readErr != nil {
+			_ = os.Remove(tmp)
+			return fmt.Errorf("replace active engine pointer: %w", err)
+		}
+		if writeErr := os.WriteFile(activeFile, data, 0644); writeErr != nil {
+			_ = os.Remove(tmp)
+			return fmt.Errorf("replace active engine pointer: %w", err)
+		}
+		_ = removeWithRetry(tmp, 10, 50*time.Millisecond)
+	}
+	return nil
+}
+
+func activeEngineFile(launcherPath string) string {
+	return filepath.Join(versionStoreDir(launcherPath), "active.txt")
+}
+
+func versionStoreDir(launcherPath string) string {
+	return filepath.Join(filepath.Dir(launcherPath), "mcp-mux.versions")
+}
+
+func engineFileName() string {
+	if runtime.GOOS == "windows" {
+		return "mcp-mux-engine.exe"
+	}
+	return "mcp-mux-engine"
+}
+
+func samePath(a, b string) bool {
+	absA, errA := filepath.Abs(a)
+	absB, errB := filepath.Abs(b)
+	if errA == nil {
+		a = absA
+	}
+	if errB == nil {
+		b = absB
+	}
+	a = filepath.Clean(a)
+	b = filepath.Clean(b)
+	if runtime.GOOS == "windows" {
+		return strings.EqualFold(a, b)
+	}
+	return a == b
+}
+
+func setEnv(env []string, key, value string) []string {
+	prefix := key + "="
+	for i, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			env[i] = prefix + value
+			return env
+		}
+	}
+	return append(env, prefix+value)
+}

--- a/cmd/mcp-mux/launcher_test.go
+++ b/cmd/mcp-mux/launcher_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeTestFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0755); err != nil {
+		t.Fatalf("WriteFile(%s): %v", path, err)
+	}
+}
+
+func TestInstallVersionedEngineDoesNotRenameLauncher(t *testing.T) {
+	dir := t.TempDir()
+	launcherPath := filepath.Join(dir, "mcp-mux.exe")
+	pendingPath := launcherPath + "~"
+	writeTestFile(t, launcherPath, "stable launcher")
+	writeTestFile(t, pendingPath, "engine v1")
+
+	enginePath, installed, err := installVersionedEngine(launcherPath, pendingPath)
+	if err != nil {
+		t.Fatalf("installVersionedEngine() error = %v", err)
+	}
+	if !installed {
+		t.Fatal("installVersionedEngine() installed = false, want true")
+	}
+
+	launcherBytes, err := os.ReadFile(launcherPath)
+	if err != nil {
+		t.Fatalf("read launcher: %v", err)
+	}
+	if string(launcherBytes) != "stable launcher" {
+		t.Fatalf("launcher content changed to %q", launcherBytes)
+	}
+	if _, err := os.Stat(pendingPath); !os.IsNotExist(err) {
+		t.Fatalf("pending path still exists after install: %v", err)
+	}
+
+	activePath, ok := resolveActiveEngine(launcherPath)
+	if !ok {
+		t.Fatal("active engine pointer was not written")
+	}
+	if !samePath(activePath, enginePath) {
+		t.Fatalf("active engine = %q, want %q", activePath, enginePath)
+	}
+	engineBytes, err := os.ReadFile(enginePath)
+	if err != nil {
+		t.Fatalf("read engine: %v", err)
+	}
+	if string(engineBytes) != "engine v1" {
+		t.Fatalf("engine content = %q, want engine v1", engineBytes)
+	}
+}
+
+func TestInstallVersionedEngineSwitchesPointerAndKeepsOldVersion(t *testing.T) {
+	dir := t.TempDir()
+	launcherPath := filepath.Join(dir, "mcp-mux.exe")
+	pendingPath := launcherPath + "~"
+	writeTestFile(t, launcherPath, "stable launcher")
+	writeTestFile(t, pendingPath, "engine v1")
+
+	firstPath, _, err := installVersionedEngine(launcherPath, pendingPath)
+	if err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+
+	writeTestFile(t, pendingPath, "engine v2")
+	secondPath, installed, err := installVersionedEngine(launcherPath, pendingPath)
+	if err != nil {
+		t.Fatalf("second install: %v", err)
+	}
+	if !installed {
+		t.Fatal("second install installed = false, want true")
+	}
+	if samePath(firstPath, secondPath) {
+		t.Fatalf("second install reused first version path: %s", secondPath)
+	}
+	if _, err := os.Stat(firstPath); err != nil {
+		t.Fatalf("old engine version should remain readable: %v", err)
+	}
+	activePath, ok := resolveActiveEngine(launcherPath)
+	if !ok || !samePath(activePath, secondPath) {
+		t.Fatalf("active engine = %q ok=%v, want %q", activePath, ok, secondPath)
+	}
+}
+
+func TestWriteActiveEngineStoresRelativePointer(t *testing.T) {
+	dir := t.TempDir()
+	launcherPath := filepath.Join(dir, "mcp-mux.exe")
+	enginePath := filepath.Join(versionStoreDir(launcherPath), "abc123", engineFileName())
+	writeTestFile(t, enginePath, "engine")
+
+	if err := writeActiveEngine(launcherPath, enginePath); err != nil {
+		t.Fatalf("writeActiveEngine() error = %v", err)
+	}
+
+	data, err := os.ReadFile(activeEngineFile(launcherPath))
+	if err != nil {
+		t.Fatalf("read active pointer: %v", err)
+	}
+	pointer := strings.TrimSpace(string(data))
+	if filepath.IsAbs(pointer) {
+		t.Fatalf("active pointer should be relative, got %q", pointer)
+	}
+	resolved, ok := resolveActiveEngine(launcherPath)
+	if !ok || !samePath(resolved, enginePath) {
+		t.Fatalf("resolved active engine = %q ok=%v, want %q", resolved, ok, enginePath)
+	}
+}

--- a/cmd/mcp-mux/launcher_test.go
+++ b/cmd/mcp-mux/launcher_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -126,5 +127,22 @@ func TestRunEngineProcessStartFailureFallsBackToLauncher(t *testing.T) {
 	}
 	if code != 0 {
 		t.Fatalf("fallback code = %d, want 0", code)
+	}
+}
+
+func TestDaemonStartReportsActiveAndFallbackStartFailures(t *testing.T) {
+	dir := t.TempDir()
+	launcherPath := filepath.Join(dir, "mcp-mux.exe")
+	missingEnginePath := filepath.Join(versionStoreDir(launcherPath), "missing", engineFileName())
+
+	_, fallbackToCaller, err := startEngineOrStableLauncher(launcherPath, missingEnginePath, []string{"daemon"}, false, func(cmd *exec.Cmd) {})
+	if fallbackToCaller {
+		t.Fatal("daemon start requested caller fallback, want child-process fallback")
+	}
+	if err == nil {
+		t.Fatal("daemon start with missing engine and launcher succeeded, want error")
+	}
+	if !strings.Contains(err.Error(), "start stable launcher fallback") {
+		t.Fatalf("error = %q, want stable launcher fallback context", err)
 	}
 }

--- a/cmd/mcp-mux/launcher_test.go
+++ b/cmd/mcp-mux/launcher_test.go
@@ -114,3 +114,17 @@ func TestWriteActiveEngineStoresRelativePointer(t *testing.T) {
 		t.Fatalf("resolved active engine = %q ok=%v, want %q", resolved, ok, enginePath)
 	}
 }
+
+func TestRunEngineProcessStartFailureFallsBackToLauncher(t *testing.T) {
+	dir := t.TempDir()
+	launcherPath := filepath.Join(dir, "mcp-mux.exe")
+	missingEnginePath := filepath.Join(versionStoreDir(launcherPath), "missing", engineFileName())
+
+	handled, code := runEngineProcess(launcherPath, missingEnginePath, []string{"status"})
+	if handled {
+		t.Fatal("runEngineProcess handled missing active engine, want launcher fallback")
+	}
+	if code != 0 {
+		t.Fatalf("fallback code = %d, want 0", code)
+	}
+}

--- a/cmd/mcp-mux/main.go
+++ b/cmd/mcp-mux/main.go
@@ -50,6 +50,10 @@ const engineName = "mcp-mux"
 const ownSocketPrefix = engineName + "-"
 
 func main() {
+	if handled, exitCode := maybeRunLauncher(); handled {
+		os.Exit(exitCode)
+	}
+
 	// Check for subcommands BEFORE flag.Parse() — subcommands have their own flags.
 	if len(os.Args) > 1 {
 		switch os.Args[1] {
@@ -65,7 +69,7 @@ func main() {
 			return
 		case "upgrade":
 			upgradeFlags := flag.NewFlagSet("upgrade", flag.ExitOnError)
-			restart := upgradeFlags.Bool("restart", false, "Restart daemon after binary swap (shims auto-reconnect)")
+			restart := upgradeFlags.Bool("restart", false, "Restart daemon after upgrade (shims auto-reconnect)")
 			upgradeFlags.Parse(os.Args[2:])
 			runUpgrade(*restart)
 			return
@@ -198,16 +202,29 @@ func main() {
 					jitter := time.Duration(os.Getpid()%500) * time.Millisecond
 					time.Sleep(jitter)
 
-					if err := ensureDaemon(logger); err != nil {
-						return "", "", err
+					deadline := time.Now().Add(10 * time.Second)
+					for {
+						if err := ensureDaemon(logger); err != nil {
+							if isTransientDaemonReconnectErr(err) && time.Now().Before(deadline) {
+								logger.Printf("shim.reconnect.fallback_spawn transient=%q retrying", err.Error())
+								time.Sleep(100 * time.Millisecond)
+								continue
+							}
+							return "", "", err
+						}
+						newIPC, newToken, err := spawnViaDaemonWithReason(command, cmdArgs, cwd, modeStr, shimEnv, "fallback_spawn", logger)
+						if err != nil {
+							if isTransientDaemonReconnectErr(err) && time.Now().Before(deadline) {
+								logger.Printf("shim.reconnect.fallback_spawn transient=%q retrying", err.Error())
+								time.Sleep(100 * time.Millisecond)
+								continue
+							}
+							return "", "", err
+						}
+						currentIPC = newIPC
+						currentToken = newToken
+						return newIPC, newToken, nil
 					}
-					newIPC, newToken, err := spawnViaDaemonWithReason(command, cmdArgs, cwd, modeStr, shimEnv, "fallback_spawn", logger)
-					if err != nil {
-						return "", "", err
-					}
-					currentIPC = newIPC
-					currentToken = newToken
-					return newIPC, newToken, nil
 				}
 				resilientStart := time.Now()
 				if err := owner.RunResilientClient(owner.ResilientClientConfig{
@@ -694,6 +711,18 @@ func collectEnv() map[string]string {
 		}
 	}
 	return env
+}
+
+func isTransientDaemonReconnectErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "daemon shutting down") ||
+		strings.Contains(msg, "control: dial") ||
+		strings.Contains(msg, "control: read response") ||
+		strings.Contains(msg, "use of closed network connection") ||
+		strings.Contains(msg, "daemon did not start")
 }
 
 func runStatus() {

--- a/cmd/mcp-mux/main.go
+++ b/cmd/mcp-mux/main.go
@@ -20,6 +20,7 @@ package main
 import (
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -33,6 +34,7 @@ import (
 
 	"github.com/thebtf/mcp-mux/internal/mcpserver"
 	"github.com/thebtf/mcp-mux/muxcore/control"
+	"github.com/thebtf/mcp-mux/muxcore/daemon"
 	"github.com/thebtf/mcp-mux/muxcore/ipc"
 	"github.com/thebtf/mcp-mux/muxcore/owner"
 	"github.com/thebtf/mcp-mux/muxcore/serverid"
@@ -68,6 +70,10 @@ func main() {
 			runStop(*drainTimeout, *force)
 			return
 		case "upgrade":
+			if os.Getenv(envEngineMode) == "1" {
+				fmt.Fprintln(os.Stderr, "error: upgrade command is only supported through the stable launcher.")
+				os.Exit(1)
+			}
 			upgradeFlags := flag.NewFlagSet("upgrade", flag.ExitOnError)
 			restart := upgradeFlags.Bool("restart", false, "Restart daemon after upgrade (shims auto-reconnect)")
 			upgradeFlags.Parse(os.Args[2:])
@@ -204,19 +210,23 @@ func main() {
 
 					deadline := time.Now().Add(10 * time.Second)
 					for {
-						if err := ensureDaemon(logger); err != nil {
+						if err := ensureDaemonWithin(logger, time.Until(deadline)); err != nil {
 							if isTransientDaemonReconnectErr(err) && time.Now().Before(deadline) {
 								logger.Printf("shim.reconnect.fallback_spawn transient=%q retrying", err.Error())
-								time.Sleep(100 * time.Millisecond)
+								if !sleepWithin(deadline, 100*time.Millisecond) {
+									return "", "", err
+								}
 								continue
 							}
 							return "", "", err
 						}
-						newIPC, newToken, err := spawnViaDaemonWithReason(command, cmdArgs, cwd, modeStr, shimEnv, "fallback_spawn", logger)
+						newIPC, newToken, err := spawnViaDaemonWithReasonTimeout(command, cmdArgs, cwd, modeStr, shimEnv, "fallback_spawn", logger, time.Until(deadline))
 						if err != nil {
 							if isTransientDaemonReconnectErr(err) && time.Now().Before(deadline) {
 								logger.Printf("shim.reconnect.fallback_spawn transient=%q retrying", err.Error())
-								time.Sleep(100 * time.Millisecond)
+								if !sleepWithin(deadline, 100*time.Millisecond) {
+									return "", "", err
+								}
 								continue
 							}
 							return "", "", err
@@ -717,12 +727,28 @@ func isTransientDaemonReconnectErr(err error) bool {
 	if err == nil {
 		return false
 	}
+	if errors.Is(err, daemon.ErrDaemonShuttingDown) {
+		return true
+	}
 	msg := err.Error()
 	return strings.Contains(msg, "daemon shutting down") ||
 		strings.Contains(msg, "control: dial") ||
 		strings.Contains(msg, "control: read response") ||
 		strings.Contains(msg, "use of closed network connection") ||
 		strings.Contains(msg, "daemon did not start")
+}
+
+func sleepWithin(deadline time.Time, requested time.Duration) bool {
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		return false
+	}
+	if remaining < requested {
+		time.Sleep(remaining)
+		return false
+	}
+	time.Sleep(requested)
+	return true
 }
 
 func runStatus() {

--- a/cmd/mcp-mux/replacefile_unix.go
+++ b/cmd/mcp-mux/replacefile_unix.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package main
+
+import "os"
+
+func replaceFile(src, dst string) error {
+	return os.Rename(src, dst)
+}

--- a/cmd/mcp-mux/replacefile_windows.go
+++ b/cmd/mcp-mux/replacefile_windows.go
@@ -1,0 +1,17 @@
+//go:build windows
+
+package main
+
+import "golang.org/x/sys/windows"
+
+func replaceFile(src, dst string) error {
+	srcp, err := windows.UTF16PtrFromString(src)
+	if err != nil {
+		return err
+	}
+	dstp, err := windows.UTF16PtrFromString(dst)
+	if err != nil {
+		return err
+	}
+	return windows.MoveFileEx(srcp, dstp, windows.MOVEFILE_REPLACE_EXISTING|windows.MOVEFILE_WRITE_THROUGH)
+}

--- a/docs/PRODUCTION-TESTING-PLAYBOOK.md
+++ b/docs/PRODUCTION-TESTING-PLAYBOOK.md
@@ -104,7 +104,11 @@ go build -trimpath -o .\mcp-mux.exe~ .\cmd\mcp-mux
 
 Expected:
 
-- The pending binary `mcp-mux.exe~` is consumed by `upgrade --restart`.
+- The stable launcher `mcp-mux.exe` remains in place; upgrade does not attempt
+  to rename the configured binary while live shim/daemon processes may hold it.
+- The pending binary `mcp-mux.exe~` is installed under
+  `mcp-mux.versions/<hash>/mcp-mux-engine.exe`, and
+  `mcp-mux.versions/active.txt` points at that engine.
 - `status` responds without handshake failure.
 - Existing consumers reconnect through the shim/daemon path rather than
   requiring manual config edits.
@@ -112,6 +116,7 @@ Expected:
 Broken signals:
 
 - The build cannot write `mcp-mux.exe~`.
+- `upgrade --restart` reports `rename current to old: Access is denied`.
 - `upgrade --restart` reports socket handoff failure without fallback recovery.
 - `status` cannot contact the daemon after restart.
 

--- a/go.mod
+++ b/go.mod
@@ -2,13 +2,15 @@ module github.com/thebtf/mcp-mux
 
 go 1.25.4
 
-require github.com/thebtf/mcp-mux/muxcore v0.21.0
+require (
+	github.com/thebtf/mcp-mux/muxcore v0.21.0
+	golang.org/x/sys v0.43.0
+)
 
 require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/thejerf/suture/v4 v4.0.6 // indirect
-	golang.org/x/sys v0.43.0 // indirect
 )
 
 replace github.com/thebtf/mcp-mux/muxcore => ./muxcore

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/thebtf/mcp-mux
 go 1.25.4
 
 require (
-	github.com/thebtf/mcp-mux/muxcore v0.21.0
+	github.com/thebtf/mcp-mux/muxcore v0.24.0
 	golang.org/x/sys v0.43.0
 )
 

--- a/muxcore/control/client.go
+++ b/muxcore/control/client.go
@@ -44,12 +44,19 @@ func Send(socketPath string, req Request) (*Response, error) {
 
 // SendWithTimeout is like Send but uses a custom deadline for long operations like drain.
 func SendWithTimeout(socketPath string, req Request, timeout time.Duration) (*Response, error) {
-	conn, err := net.DialTimeout("unix", socketPath, clientDeadline)
+	dialTimeout := clientDeadline
+	if timeout > 0 && timeout < dialTimeout {
+		dialTimeout = timeout
+	}
+	conn, err := net.DialTimeout("unix", socketPath, dialTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("control: dial %s: %w", socketPath, err)
 	}
 	defer conn.Close()
 
+	if timeout <= 0 {
+		timeout = clientDeadline
+	}
 	if err := conn.SetDeadline(time.Now().Add(timeout)); err != nil {
 		return nil, fmt.Errorf("control: set deadline: %w", err)
 	}

--- a/muxcore/daemon/daemon.go
+++ b/muxcore/daemon/daemon.go
@@ -43,6 +43,10 @@ var ErrUnknownToken = errors.New("unknown token")
 // belonged to is no longer alive enough to accept a refreshed bind.
 var ErrOwnerGone = errors.New("owner gone")
 
+// ErrDaemonShuttingDown indicates the daemon is no longer accepting new owner
+// spawns because shutdown or graceful restart has already begun.
+var ErrDaemonShuttingDown = errors.New("daemon shutting down")
+
 // maxSpawnRetries bounds the retry budget in Spawn. Three iterations handle the
 // realistic cases (stuck placeholder cleanup + one isolated-mode promotion);
 // exhaustion is treated as a hard failure and returned to the caller.
@@ -153,6 +157,7 @@ type Daemon struct {
 	zombieDetectedRestore int
 
 	shutdownOnce sync.Once
+	shuttingDown atomic.Bool
 
 	// stats holds atomic handoff counters exposed via HandleStatus (NFR-4 / T025).
 	stats handoffStats
@@ -1007,6 +1012,9 @@ func (d *Daemon) SoftRemove(serverID string) error {
 
 // HandleSpawn implements control.DaemonHandler.
 func (d *Daemon) HandleSpawn(req control.Request) (string, string, string, error) {
+	if d.shuttingDown.Load() {
+		return "", "", "", ErrDaemonShuttingDown
+	}
 	ipcPath, serverID, token, err := d.Spawn(req)
 	if err == nil && req.ReconnectReason == "fallback_spawn" {
 		d.reconnectFallbackSpawned.Add(1)
@@ -1021,6 +1029,7 @@ func (d *Daemon) HandleRemove(serverID string) error {
 
 // HandleShutdown implements control.CommandHandler.
 func (d *Daemon) HandleShutdown(drainTimeoutMs int) string {
+	d.shuttingDown.Store(true)
 	go d.Shutdown()
 	return "daemon shutting down"
 }
@@ -1088,7 +1097,7 @@ func (d *Daemon) retryControlBind(socketPath string) error {
 // daemon can locate the handoff socket and authenticate (FR-11). The caller does
 // NOT wait for the process — it runs independently and will dial back.
 func spawnSuccessor(tokenPath, socketPath, daemonFlag string) error {
-	exe, err := os.Executable()
+	exe, err := successorExecutable()
 	if err != nil {
 		return fmt.Errorf("handoff: resolve executable: %w", err)
 	}
@@ -1110,6 +1119,25 @@ func spawnSuccessor(tokenPath, socketPath, daemonFlag string) error {
 		return fmt.Errorf("handoff: release successor: %w", err)
 	}
 	return nil
+}
+
+func successorExecutable() (string, error) {
+	if explicit := strings.TrimSpace(os.Getenv("MCPMUX_SUCCESSOR_EXE")); explicit != "" {
+		return explicit, nil
+	}
+	if pointer := strings.TrimSpace(os.Getenv("MCPMUX_ACTIVE_ENGINE_FILE")); pointer != "" {
+		data, err := os.ReadFile(pointer)
+		if err == nil {
+			target := strings.TrimSpace(string(data))
+			if target != "" {
+				if filepath.IsAbs(target) {
+					return filepath.Clean(target), nil
+				}
+				return filepath.Clean(filepath.Join(filepath.Dir(pointer), target)), nil
+			}
+		}
+	}
+	return os.Executable()
 }
 
 // collectHandoffUpstreams calls ShutdownForHandoff on every live owner and
@@ -1253,6 +1281,7 @@ func (d *Daemon) HandleGracefulRestart(drainTimeoutMs int) (string, func(), erro
 	if err != nil {
 		return "", nil, fmt.Errorf("snapshot: %w", err)
 	}
+	d.shuttingDown.Store(true)
 
 	// Tag owners BEFORE attemptHandoff. collectHandoffUpstreams (inside
 	// attemptHandoff) detaches owners → supervisor fires termination events
@@ -1349,6 +1378,7 @@ func (d *Daemon) HandleStatus() map[string]any {
 
 	return map[string]any{
 		"daemon":                          true,
+		"shutting_down":                   d.shuttingDown.Load(),
 		"pid":                             os.Getpid(),
 		"daemon_generation":               d.daemonGeneration,
 		"reaped_owner_count":              d.ownerRemoval.ByReason[ownerRemovalReasonIdle],
@@ -1737,6 +1767,7 @@ func envTransient(key string) bool {
 // Shutdown gracefully stops all owners and the daemon.
 func (d *Daemon) Shutdown() {
 	d.shutdownOnce.Do(func() {
+		d.shuttingDown.Store(true)
 		d.logger.Printf("daemon shutting down...")
 
 		// Cancel supervisor context first — prevents suture from restarting

--- a/muxcore/daemon/daemon.go
+++ b/muxcore/daemon/daemon.go
@@ -1275,13 +1275,15 @@ func (d *Daemon) attemptHandoff() error {
 // (FR-1/FR-2/FR-3). On any handoff failure the "handoff.fallback" log line is
 // emitted and the function falls through to legacy kill-and-respawn (FR-8).
 func (d *Daemon) HandleGracefulRestart(drainTimeoutMs int) (string, func(), error) {
+	d.shuttingDown.Store(true)
+
 	// Serialize snapshot first — needed for FR-8 fallback and successor seed
 	// regardless of whether handoff succeeds.
 	snapshotPath, err := d.SerializeSnapshot()
 	if err != nil {
+		d.shuttingDown.Store(false)
 		return "", nil, fmt.Errorf("snapshot: %w", err)
 	}
-	d.shuttingDown.Store(true)
 
 	// Tag owners BEFORE attemptHandoff. collectHandoffUpstreams (inside
 	// attemptHandoff) detaches owners → supervisor fires termination events

--- a/muxcore/daemon/daemon_test.go
+++ b/muxcore/daemon/daemon_test.go
@@ -489,6 +489,26 @@ func TestHandleSpawnRejectsAfterShutdownBegins(t *testing.T) {
 	}
 }
 
+func TestGracefulRestartSnapshotFailureReopensSpawn(t *testing.T) {
+	d := testDaemon(t)
+
+	badTemp := filepath.Join(t.TempDir(), "temp-is-file")
+	if err := os.WriteFile(badTemp, []byte("not a directory"), 0600); err != nil {
+		t.Fatalf("WriteFile bad temp: %v", err)
+	}
+	t.Setenv("TMP", badTemp)
+	t.Setenv("TEMP", badTemp)
+	t.Setenv("TMPDIR", badTemp)
+
+	_, _, err := d.HandleGracefulRestart(0)
+	if err == nil {
+		t.Fatal("HandleGracefulRestart() error = nil, want snapshot failure")
+	}
+	if d.shuttingDown.Load() {
+		t.Fatal("shuttingDown stayed true after snapshot failure")
+	}
+}
+
 // TestDaemon_LegacyShimFallbackAfterTokenConsumed asserts back-compat for
 // pre-v0.21.1 shims that have no knowledge of the refresh-token control
 // command (SC-3 requirement).

--- a/muxcore/daemon/daemon_test.go
+++ b/muxcore/daemon/daemon_test.go
@@ -469,6 +469,26 @@ func TestLegacyReconnectSpawnIncrementsFallbackCounter(t *testing.T) {
 	}
 }
 
+func TestHandleSpawnRejectsAfterShutdownBegins(t *testing.T) {
+	d := testDaemon(t)
+	d.shuttingDown.Store(true)
+
+	_, _, _, err := d.HandleSpawn(control.Request{
+		Cmd:     "spawn",
+		Command: "go",
+		Args:    []string{"run", "../../testdata/mock_server.go"},
+		Mode:    "global",
+	})
+	if !errors.Is(err, ErrDaemonShuttingDown) {
+		t.Fatalf("HandleSpawn() error = %v, want ErrDaemonShuttingDown", err)
+	}
+
+	status := d.HandleStatus()
+	if got := status["shutting_down"]; got != true {
+		t.Fatalf("status shutting_down = %v, want true", got)
+	}
+}
+
 // TestDaemon_LegacyShimFallbackAfterTokenConsumed asserts back-compat for
 // pre-v0.21.1 shims that have no knowledge of the refresh-token control
 // command (SC-3 requirement).

--- a/muxcore/daemon/handoff_test.go
+++ b/muxcore/daemon/handoff_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -191,5 +192,48 @@ func TestRetireOldOwnerSocketsRemovesPathsAndCounts(t *testing.T) {
 		if _, err := os.Stat(path); !os.IsNotExist(err) {
 			t.Fatalf("old owner socket path %s still reachable: %v", path, err)
 		}
+	}
+}
+
+func TestSuccessorExecutableUsesActiveEnginePointer(t *testing.T) {
+	dir := t.TempDir()
+	enginePath := filepath.Join(dir, "versions", "abc123", "mcp-mux-engine.exe")
+	if err := os.MkdirAll(filepath.Dir(enginePath), 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(enginePath, []byte("engine"), 0755); err != nil {
+		t.Fatalf("WriteFile engine: %v", err)
+	}
+	pointerPath := filepath.Join(dir, "active.txt")
+	rel, err := filepath.Rel(filepath.Dir(pointerPath), enginePath)
+	if err != nil {
+		t.Fatalf("Rel: %v", err)
+	}
+	if err := os.WriteFile(pointerPath, []byte(rel+"\n"), 0644); err != nil {
+		t.Fatalf("WriteFile pointer: %v", err)
+	}
+
+	t.Setenv("MCPMUX_SUCCESSOR_EXE", "")
+	t.Setenv("MCPMUX_ACTIVE_ENGINE_FILE", pointerPath)
+	got, err := successorExecutable()
+	if err != nil {
+		t.Fatalf("successorExecutable() error = %v", err)
+	}
+	if filepath.Clean(got) != filepath.Clean(enginePath) {
+		t.Fatalf("successorExecutable() = %q, want %q", got, enginePath)
+	}
+}
+
+func TestSuccessorExecutableExplicitOverrideWins(t *testing.T) {
+	t.Setenv("MCPMUX_ACTIVE_ENGINE_FILE", filepath.Join(t.TempDir(), "missing-active.txt"))
+	want := filepath.Join(t.TempDir(), "explicit-engine.exe")
+	t.Setenv("MCPMUX_SUCCESSOR_EXE", want)
+
+	got, err := successorExecutable()
+	if err != nil {
+		t.Fatalf("successorExecutable() error = %v", err)
+	}
+	if filepath.Clean(got) != filepath.Clean(want) {
+		t.Fatalf("successorExecutable() = %q, want %q", got, want)
 	}
 }

--- a/muxcore/daemon/supervisor_test.go
+++ b/muxcore/daemon/supervisor_test.go
@@ -58,7 +58,7 @@ func TestDaemonSupervisorInitialized(t *testing.T) {
 // lifecycle (avoid race with d.Shutdown cancelling early).
 func TestSupervisorEventHookFires(t *testing.T) {
 	var hookFires atomic.Int32
-	done := make(chan struct{})
+	done := make(chan struct{}, 1)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
## Summary

- replace locked one-binary self-swap with a stable launcher plus versioned engine store
- route graceful-restart successors through the active engine pointer
- reject fallback spawns once daemon shutdown/restart has begun and retry transient reconnect errors from shims
- update ADR/docs/playbook for the Windows-safe upgrade contract

## Verification

- `go test ./... -count=1`
- `go test ./... -count=1` from `muxcore`
- `go vet ./...`
- `git diff --check`
- `$env:MCP_LAUNCHER='D:\Dev\mcp-launcher\mcp-launcher.exe'; .\tests\critical\run-all.ps1 -WatchSeconds 1 -TimeoutSeconds 60` -> PASS, 3/3

## Notes

MCP `pr`, `mcp-mux`, `serena`, and `socraticode` tools returned `Transport closed` in this session, so PR creation/recovery used `gh`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Версионированные движки: стабильный лаунчер остаётся, переключение активного движка через pointer; команда upgrade поддерживает установку версий и --restart с graceful-restart.

* **Bug Fixes / Reliability**
  * Надёжные retry/timeout для reconnect/daemon RPC; atomic shutdown-флаг и явная ошибка при остановке; безопасные replace/install на Windows/Unix.

* **Documentation**
  * Обновлены README (ru/en) и playbook с описанием versioned engine и проверки.

* **Tests**
  * Добавлены тесты для launcher, daemon shutdown/handoff и установки версий.

* **Chores**
  * Обновлён .gitignore и go.mod.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thebtf/mcp-mux/pull/117?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->