### PR TITLE
feat(muxcore): add apply update restart helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,13 +57,59 @@ CC 4 ──stdio──> mcp-mux ──IPC──┘
 | **Reasoning first** | Document WHY before implementing |
 | **Spec compliance** | MCP protocol spec is authoritative — verify all protocol behavior against it |
 
-## muxcore Library API (v0.24.0)
+## muxcore Library API (v0.24.x)
 
 ### Upgrade
 
 ```bash
-go get github.com/thebtf/mcp-mux/muxcore@v0.24.0
+go get github.com/thebtf/mcp-mux/muxcore@v0.24.4
 ```
+
+### v0.24.4 — engine.ApplyUpdateAndRestart for SessionHandler consumers (#239)
+
+**No breaking changes.** The new update helper is additive; existing
+`upgrade.Swap`, control commands, and engine configuration keep their current
+behavior.
+
+| API | Semantics |
+|-----|-----------|
+| `engine.UpdateAndRestartOptions` | Caller supplies `CurrentExe`, `StagedExe`, drain/restart/shutdown/ready timeouts, stale cleanup preference, and optional lock-failure behavior. |
+| `engine.UpdateAndRestartResult` | Reports partial success: `OldPath`, daemon-running state, lock acquisition, graceful restart, shutdown fallback, replacement start/readiness, stale cleanup count, and warnings. |
+| `(*engine.MuxEngine).ApplyUpdateAndRestart(ctx, opts)` | Runs the reusable provider sequence: `upgrade.Swap`, daemon namespace lock, `graceful-restart`, shutdown fallback, wait-for-exit, replacement daemon start, and ready wait. |
+| `control.Request.SuccessorExe` + `control.GracefulRestartOptionsHandler` | Additive control-plane extension so a caller can tell the old daemon which executable should become the successor during graceful restart. Older handlers fall back to the legacy `HandleGracefulRestart(int)` path. |
+
+**Migration for aimux after muxcore release:**
+
+```go
+result, err := eng.ApplyUpdateAndRestart(ctx, engine.UpdateAndRestartOptions{
+    CurrentExe:      currentExe,
+    StagedExe:       currentExe + "~",
+    DrainTimeout:    30 * time.Second,
+    RestartTimeout:  60 * time.Second,
+    ShutdownTimeout: 10 * time.Second,
+    ReadyTimeout:    10 * time.Second,
+    CleanStale:      true,
+})
+```
+
+Contract: surviving shims reconnect automatically to the replacement daemon
+when possible. This is transport continuity, not request replay; in-flight
+requests may receive explicit JSON-RPC errors by original ID.
+
+**Tests landed in this release:**
+- `TestApplyUpdateAndRestart_GracefulSuccessUsesSuccessorExe`
+- `TestApplyUpdateAndRestart_DaemonNotRunningOnlySwaps`
+- `TestApplyUpdateAndRestart_SwapFailureStopsBeforeDaemonCalls`
+- `TestApplyUpdateAndRestart_GracefulErrorFallsBackToShutdownAndStart`
+- `TestApplyUpdateAndRestart_LockFailureIsPhaseError`
+- `TestApplyUpdateAndRestart_FallbackExitTimeoutIsPhaseError`
+- `TestApplyUpdateAndRestart_StartFailureIsPhaseError`
+- `TestApplyUpdateAndRestart_ReadyTimeoutIsPhaseError`
+- `TestApplyUpdateAndRestart_SessionHandlerConsumerUsesEngineNamespace`
+- `TestGracefulRestartPassesSuccessorExeToOptionsHandler`
+- `TestSuccessorExecutableRequestOverrideWins`
+
+---
 
 ### v0.24.0 — multi-tenant extensions: ConnInfo + SessionMeta + AuthorizeSession + OnFrameReceived (#109, #110, #111, #112)
 
@@ -372,9 +418,9 @@ oldPath, err := upgrade.Swap(currentExe, newExe)
 cleaned := upgrade.CleanStale(exePath)
 ```
 
-For full graceful restart with snapshot serialization, the daemon-specific logic
-(signal, wait, re-start) remains in the consumer's main.go — `upgrade.Swap` handles
-only the atomic file rename.
+For current consumers, prefer `engine.ApplyUpdateAndRestart` for the full live
+update flow. `upgrade.Swap` remains the low-level atomic file rename primitive;
+by itself it does not signal, wait for, or restart a daemon.
 
 #### Bug fixes included in v0.18.0–v0.19.0
 
@@ -397,7 +443,7 @@ cd aimux && go get github.com/thebtf/mcp-mux/muxcore@v0.23.0
 
 Key changes to adopt:
 1. **SessionHandler** — replace `srv.StdioHandler()` with SessionHandler implementation to get per-CC-session ProjectContext
-2. **upgrade.Swap** — replace manual binary rename with `upgrade.Swap(exe, newExe)` + `upgrade.CleanStale(exe)`
+2. **ApplyUpdateAndRestart** — for live update flows, stage the new binary and call `eng.ApplyUpdateAndRestart(...)`; use `upgrade.Swap` only for low-level rename-only cases.
 3. **v0.19.3 concurrency fixes** — included automatically, no code changes needed. The CPU-spin-on-failed-background-spawn (BUG-001) and ownerNotifier.Notify RLock hold (BUG-002) are both hidden behind existing aimux code paths and required no consumer-side changes.
 4. **Circuit breaker** — included automatically, protects against upstream crash loops
 

--- a/muxcore/README.md
+++ b/muxcore/README.md
@@ -265,6 +265,51 @@ behind a versioned engine pointer.
 but it is not a full production update strategy for binaries that may be held
 open by many live shim processes.
 
+### Apply Update and Restart
+
+Engine consumers that use `engine.New` should prefer
+`MuxEngine.ApplyUpdateAndRestart` over hand-rolled upgrade code. It combines
+the Windows-safe binary swap with daemon lifecycle orchestration:
+
+```go
+result, err := eng.ApplyUpdateAndRestart(ctx, engine.UpdateAndRestartOptions{
+    CurrentExe:      currentExe,
+    StagedExe:       currentExe + "~",
+    DrainTimeout:    30 * time.Second,
+    RestartTimeout:  60 * time.Second,
+    ShutdownTimeout: 10 * time.Second,
+    ReadyTimeout:    10 * time.Second,
+    CleanStale:      true,
+})
+if err != nil {
+    var updateErr *engine.UpdateAndRestartError
+    if errors.As(err, &updateErr) {
+        // updateErr.Phase tells whether the failure happened during swap,
+        // daemon lock, graceful restart, fallback shutdown, replacement
+        // start, or ready wait. updateErr.Result reports partial success.
+    }
+    return err
+}
+_ = result
+```
+
+The helper:
+
+1. Calls `upgrade.Swap(CurrentExe, StagedExe)`.
+2. Acquires the daemon namespace lock for `engine.Config.Name` and `BaseDir`.
+3. Sends `graceful-restart` with `successor_exe` set to `CurrentExe`.
+4. Falls back to `shutdown` if graceful restart is unavailable or rejected.
+5. Starts the replacement daemon from `CurrentExe` when a successor is not
+   already ready.
+6. Waits for the replacement daemon to answer `ping` before releasing the lock.
+
+SessionHandler consumers such as aimux can use this in their own
+`upgrade(action=apply)` path after staging a new binary. The shim process must
+survive for transparent reconnect to work. Muxcore keeps the shim transport
+alive and reconnects it to the replacement daemon when possible; it does not
+promise that every in-flight request succeeds. Requests active during reconnect
+may receive explicit JSON-RPC errors by original ID.
+
 ## What muxcore Enforces
 
 These guardrails exist in current muxcore:
@@ -277,6 +322,7 @@ These guardrails exist in current muxcore:
 | Daemon-managed owner connections require one-time tokens. | daemon spawn + owner accept loop |
 | Reconnect first tries token refresh, then falls back to daemon spawn. | resilient client |
 | Spawn is rejected while daemon shutdown/restart is in progress. | daemon spawn path |
+| Live updates use one engine helper for swap, daemon lock, restart, fallback, start, and ready wait. | `engine.ApplyUpdateAndRestart` |
 | Owner sockets are scoped by engine name. | serverid/daemon/owner paths |
 | Stale-socket cleanup is name-scoped. | daemon startup |
 | `AuthorizeSession` panics cannot crash the daemon. | owner accept loop |

--- a/muxcore/control/control_test.go
+++ b/muxcore/control/control_test.go
@@ -236,6 +236,18 @@ func (m *mockDaemonHandler) HandleListOwners(req Request) (ListOwnersResponse, e
 	return ListOwnersResponse{}, nil
 }
 
+type mockGracefulOptionsHandler struct {
+	mockDaemonHandler
+	optsCalled bool
+	opts       GracefulRestartOptions
+}
+
+func (m *mockGracefulOptionsHandler) HandleGracefulRestartWithOptions(opts GracefulRestartOptions) (string, func(), error) {
+	m.optsCalled = true
+	m.opts = opts
+	return "/tmp/options-snapshot.json", nil, nil
+}
+
 // TestSocketPath verifies SocketPath returns the address used at creation.
 func TestSocketPath(t *testing.T) {
 	path := testSocketPath(t)
@@ -249,6 +261,37 @@ func TestSocketPath(t *testing.T) {
 	got := srv.SocketPath()
 	if got != path {
 		t.Errorf("SocketPath = %q, want %q", got, path)
+	}
+}
+
+func TestGracefulRestartPassesSuccessorExeToOptionsHandler(t *testing.T) {
+	path := testSocketPath(t)
+	handler := &mockGracefulOptionsHandler{}
+	srv, err := NewServer(path, handler, testLogger(t))
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	defer srv.Close()
+
+	resp, err := Send(path, Request{
+		Cmd:            "graceful-restart",
+		DrainTimeoutMs: 1234,
+		SuccessorExe:   "/tmp/new-engine",
+	})
+	if err != nil {
+		t.Fatalf("Send graceful-restart: %v", err)
+	}
+	if !resp.OK {
+		t.Fatalf("graceful-restart not OK: %s", resp.Message)
+	}
+	if !handler.optsCalled {
+		t.Fatal("HandleGracefulRestartWithOptions was not called")
+	}
+	if handler.opts.DrainTimeoutMs != 1234 || handler.opts.SuccessorExe != "/tmp/new-engine" {
+		t.Fatalf("options = %+v, want drain=1234 successor=/tmp/new-engine", handler.opts)
+	}
+	if resp.IPCPath != "/tmp/options-snapshot.json" {
+		t.Fatalf("snapshot path = %q, want /tmp/options-snapshot.json", resp.IPCPath)
 	}
 }
 

--- a/muxcore/control/protocol.go
+++ b/muxcore/control/protocol.go
@@ -11,8 +11,12 @@ import "encoding/json"
 // Supported daemon commands include "spawn", "remove", "graceful-restart",
 // and "refresh-token".
 type Request struct {
-	Cmd            string            `json:"cmd"`
-	DrainTimeoutMs int               `json:"drain_timeout_ms,omitempty"`
+	Cmd            string `json:"cmd"`
+	DrainTimeoutMs int    `json:"drain_timeout_ms,omitempty"`
+	// SuccessorExe optionally tells a graceful-restart capable daemon which
+	// executable should be launched as the successor. When empty, the daemon
+	// falls back to its environment-driven successor resolution.
+	SuccessorExe string `json:"successor_exe,omitempty"`
 
 	// Spawn fields (daemon control protocol)
 	Command string            `json:"command,omitempty"`
@@ -74,4 +78,18 @@ type DaemonHandler interface {
 	HandleRefreshSessionToken(prevToken string) (newToken string, err error)
 	HandleReconnectGiveUp(reason string) error
 	HandleListOwners(req Request) (ListOwnersResponse, error)
+}
+
+// GracefulRestartOptions carries additive graceful-restart parameters. Daemon
+// handlers that implement GracefulRestartOptionsHandler receive this richer
+// shape; older handlers continue through HandleGracefulRestart.
+type GracefulRestartOptions struct {
+	DrainTimeoutMs int
+	SuccessorExe   string
+}
+
+// GracefulRestartOptionsHandler is an optional daemon handler upgrade for
+// graceful-restart requests that need to specify the successor executable.
+type GracefulRestartOptionsHandler interface {
+	HandleGracefulRestartWithOptions(opts GracefulRestartOptions) (snapshotPath string, afterResponse func(), err error)
 }

--- a/muxcore/control/server.go
+++ b/muxcore/control/server.go
@@ -167,7 +167,17 @@ func (s *Server) dispatch(req Request) (Response, func()) {
 		if !ok {
 			return Response{OK: false, Message: "graceful-restart not supported (not a daemon)"}, nil
 		}
-		snapshotPath, afterFn, err := dh.HandleGracefulRestart(req.DrainTimeoutMs)
+		var snapshotPath string
+		var afterFn func()
+		var err error
+		if oh, ok := dh.(GracefulRestartOptionsHandler); ok {
+			snapshotPath, afterFn, err = oh.HandleGracefulRestartWithOptions(GracefulRestartOptions{
+				DrainTimeoutMs: req.DrainTimeoutMs,
+				SuccessorExe:   req.SuccessorExe,
+			})
+		} else {
+			snapshotPath, afterFn, err = dh.HandleGracefulRestart(req.DrainTimeoutMs)
+		}
 		if err != nil {
 			return Response{OK: false, Message: fmt.Sprintf("graceful-restart: %v", err)}, nil
 		}

--- a/muxcore/daemon/daemon.go
+++ b/muxcore/daemon/daemon.go
@@ -1096,8 +1096,8 @@ func (d *Daemon) retryControlBind(socketPath string) error {
 // injecting MCPMUX_HANDOFF_TOKEN_PATH and MCPMUX_HANDOFF_SOCKET so the successor
 // daemon can locate the handoff socket and authenticate (FR-11). The caller does
 // NOT wait for the process — it runs independently and will dial back.
-func spawnSuccessor(tokenPath, socketPath, daemonFlag string) error {
-	exe, err := successorExecutable()
+func spawnSuccessor(tokenPath, socketPath, daemonFlag, successorExe string) error {
+	exe, err := successorExecutableFor(successorExe)
 	if err != nil {
 		return fmt.Errorf("handoff: resolve executable: %w", err)
 	}
@@ -1122,6 +1122,13 @@ func spawnSuccessor(tokenPath, socketPath, daemonFlag string) error {
 }
 
 func successorExecutable() (string, error) {
+	return successorExecutableFor("")
+}
+
+func successorExecutableFor(explicitOverride string) (string, error) {
+	if explicit := strings.TrimSpace(explicitOverride); explicit != "" {
+		return explicit, nil
+	}
 	if explicit := strings.TrimSpace(os.Getenv("MCPMUX_SUCCESSOR_EXE")); explicit != "" {
 		return explicit, nil
 	}
@@ -1186,7 +1193,7 @@ func (d *Daemon) collectHandoffUpstreams() []HandoffUpstream {
 //   - ErrTokenMismatch (successor presented wrong token — FR-11)
 //   - ErrProtocolVersionMismatch (binary skew — FR-6)
 //   - Any other performHandoff protocol error (conn drop, JSON decode failure)
-func (d *Daemon) attemptHandoff() error {
+func (d *Daemon) attemptHandoff(successorExe string) error {
 	d.stats.attempted.Add(1)
 	startedAt := time.Now()
 	baseDir := os.TempDir()
@@ -1218,7 +1225,7 @@ func (d *Daemon) attemptHandoff() error {
 	}()
 
 	// Spawn successor with handoff credentials.
-	if spawnErr := spawnSuccessor(tokenPath, socketPath, d.daemonFlag); spawnErr != nil {
+	if spawnErr := spawnSuccessor(tokenPath, socketPath, d.daemonFlag, successorExe); spawnErr != nil {
 		// Do NOT drain connCh here — the listener goroutine will self-terminate
 		// once handoffAcceptTimeout expires (buffered channel prevents goroutine
 		// leak; the accepted conn, if any arrives despite the spawn failure, is
@@ -1275,6 +1282,11 @@ func (d *Daemon) attemptHandoff() error {
 // (FR-1/FR-2/FR-3). On any handoff failure the "handoff.fallback" log line is
 // emitted and the function falls through to legacy kill-and-respawn (FR-8).
 func (d *Daemon) HandleGracefulRestart(drainTimeoutMs int) (string, func(), error) {
+	return d.HandleGracefulRestartWithOptions(control.GracefulRestartOptions{DrainTimeoutMs: drainTimeoutMs})
+}
+
+// HandleGracefulRestartWithOptions implements control.GracefulRestartOptionsHandler.
+func (d *Daemon) HandleGracefulRestartWithOptions(opts control.GracefulRestartOptions) (string, func(), error) {
 	d.shuttingDown.Store(true)
 
 	// Serialize snapshot first — needed for FR-8 fallback and successor seed
@@ -1298,7 +1310,7 @@ func (d *Daemon) HandleGracefulRestart(drainTimeoutMs int) (string, func(), erro
 	// Attempt FD-passing handoff. Every identifiable failure mode routes through
 	// the fallback log line; callers never see a handoff error — FR-8 is silent
 	// to the control-plane caller (it still gets a valid snapshot path).
-	if handoffErr := d.attemptHandoff(); handoffErr != nil {
+	if handoffErr := d.attemptHandoff(opts.SuccessorExe); handoffErr != nil {
 		d.stats.fallback.Add(1)
 		d.logger.Printf("handoff.fallback reason=%v — using legacy shutdown+respawn", handoffErr)
 	}

--- a/muxcore/daemon/handoff_test.go
+++ b/muxcore/daemon/handoff_test.go
@@ -237,3 +237,17 @@ func TestSuccessorExecutableExplicitOverrideWins(t *testing.T) {
 		t.Fatalf("successorExecutable() = %q, want %q", got, want)
 	}
 }
+
+func TestSuccessorExecutableRequestOverrideWins(t *testing.T) {
+	envPath := filepath.Join(t.TempDir(), "env-engine.exe")
+	requestPath := filepath.Join(t.TempDir(), "request-engine.exe")
+	t.Setenv("MCPMUX_SUCCESSOR_EXE", envPath)
+
+	got, err := successorExecutableFor(requestPath)
+	if err != nil {
+		t.Fatalf("successorExecutableFor() error = %v", err)
+	}
+	if filepath.Clean(got) != filepath.Clean(requestPath) {
+		t.Fatalf("successorExecutableFor() = %q, want request override %q", got, requestPath)
+	}
+}

--- a/muxcore/engine/lock_unix.go
+++ b/muxcore/engine/lock_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package engine
+
+import (
+	"os"
+	"syscall"
+)
+
+func lockDaemonFile(f *os.File) error {
+	return syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+}
+
+func unlockDaemonFile(f *os.File) error {
+	return syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+}

--- a/muxcore/engine/lock_windows.go
+++ b/muxcore/engine/lock_windows.go
@@ -1,0 +1,47 @@
+//go:build windows
+
+package engine
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+var (
+	modkernel32Engine    = syscall.NewLazyDLL("kernel32.dll")
+	procLockFileExEngine = modkernel32Engine.NewProc("LockFileEx")
+	procUnlockFileEngine = modkernel32Engine.NewProc("UnlockFileEx")
+)
+
+func lockDaemonFile(f *os.File) error {
+	const flags = 0x00000002 | 0x00000001 // LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY
+	ol := &syscall.Overlapped{}
+	r1, _, err := procLockFileExEngine.Call(
+		uintptr(f.Fd()),
+		uintptr(flags),
+		0,
+		1,
+		0,
+		uintptr(unsafe.Pointer(ol)),
+	)
+	if r1 == 0 {
+		return err
+	}
+	return nil
+}
+
+func unlockDaemonFile(f *os.File) error {
+	ol := &syscall.Overlapped{}
+	r1, _, err := procUnlockFileEngine.Call(
+		uintptr(f.Fd()),
+		0,
+		1,
+		0,
+		uintptr(unsafe.Pointer(ol)),
+	)
+	if r1 == 0 {
+		return err
+	}
+	return nil
+}

--- a/muxcore/engine/update.go
+++ b/muxcore/engine/update.go
@@ -1,0 +1,330 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/thebtf/mcp-mux/muxcore/control"
+	"github.com/thebtf/mcp-mux/muxcore/serverid"
+	"github.com/thebtf/mcp-mux/muxcore/upgrade"
+)
+
+const (
+	defaultUpdateDrainTimeout    = 30 * time.Second
+	defaultUpdateRestartTimeout  = 60 * time.Second
+	defaultUpdateShutdownTimeout = 10 * time.Second
+	defaultUpdateReadyTimeout    = 10 * time.Second
+)
+
+// UpdatePhase identifies the phase that failed during ApplyUpdateAndRestart.
+type UpdatePhase string
+
+const (
+	UpdatePhaseValidate UpdatePhase = "validate"
+	UpdatePhaseSwap     UpdatePhase = "swap"
+	UpdatePhaseLock     UpdatePhase = "lock"
+	UpdatePhaseRestart  UpdatePhase = "graceful_restart"
+	UpdatePhaseWaitExit UpdatePhase = "wait_exit"
+	UpdatePhaseStart    UpdatePhase = "start_replacement"
+	UpdatePhaseReady    UpdatePhase = "wait_ready"
+)
+
+// UpdateAndRestartOptions configures ApplyUpdateAndRestart.
+type UpdateAndRestartOptions struct {
+	// CurrentExe is the stable executable path that should exist after the swap.
+	CurrentExe string
+	// StagedExe is the replacement binary to move into CurrentExe.
+	StagedExe string
+	// DrainTimeout is sent to the daemon's graceful-restart command.
+	DrainTimeout time.Duration
+	// RestartTimeout bounds the graceful-restart control RPC.
+	RestartTimeout time.Duration
+	// ShutdownTimeout bounds waiting for the old daemon to stop responding.
+	ShutdownTimeout time.Duration
+	// ReadyTimeout bounds waiting for the replacement daemon to answer ping.
+	ReadyTimeout time.Duration
+	// CleanStale removes stale old-binary artifacts after the restart attempt.
+	CleanStale bool
+	// ProceedWithoutLock allows restart to continue when the daemon namespace
+	// lock cannot be acquired. The default is fail-closed.
+	ProceedWithoutLock bool
+}
+
+// UpdateAndRestartResult reports each observable step of ApplyUpdateAndRestart.
+type UpdateAndRestartResult struct {
+	OldPath            string
+	DaemonWasRunning   bool
+	LockAcquired       bool
+	GracefulRestarted  bool
+	FallbackShutdown   bool
+	ReplacementStarted bool
+	ReplacementReady   bool
+	CleanedStale       int
+	Warnings           []string
+}
+
+// UpdateAndRestartError wraps a phase-specific failure and preserves the
+// partial result so callers can report whether the binary swap already landed.
+type UpdateAndRestartError struct {
+	Phase  UpdatePhase
+	Result UpdateAndRestartResult
+	Err    error
+}
+
+func (e *UpdateAndRestartError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return fmt.Sprintf("apply update and restart failed during %s: %v", e.Phase, e.Err)
+}
+
+func (e *UpdateAndRestartError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+type daemonLock interface {
+	Close() error
+}
+
+type fileDaemonLock struct {
+	f *os.File
+}
+
+func (l *fileDaemonLock) Close() error {
+	if l == nil || l.f == nil {
+		return nil
+	}
+	unlockErr := unlockDaemonFile(l.f)
+	closeErr := l.f.Close()
+	if unlockErr != nil {
+		return unlockErr
+	}
+	return closeErr
+}
+
+var (
+	engineUpgradeSwap            = upgrade.Swap
+	engineCleanStale             = upgrade.CleanStale
+	engineControlSend            = control.Send
+	engineControlSendWithTimeout = control.SendWithTimeout
+	engineIsDaemonRunning        = isDaemonRunning
+	engineStartDaemonExecutable  = startDaemonExecutable
+	engineWaitForDaemonReady     = waitForDaemonReady
+	engineWaitForDaemonExit      = waitForDaemonExit
+	engineAcquireDaemonLock      = acquireDaemonLock
+)
+
+// ApplyUpdateAndRestart swaps in a staged binary and restarts this engine's
+// daemon namespace using muxcore's graceful-restart control path. It is intended
+// for embedded SessionHandler consumers that need the same restart choreography
+// as the mcp-mux binary without copying cmd/mcp-mux code.
+func (e *MuxEngine) ApplyUpdateAndRestart(ctx context.Context, opts UpdateAndRestartOptions) (result UpdateAndRestartResult, err error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	opts = opts.withDefaults()
+	if err := ctx.Err(); err != nil {
+		return result, phaseError(UpdatePhaseValidate, result, err)
+	}
+	if opts.CurrentExe == "" {
+		return result, phaseError(UpdatePhaseValidate, result, errors.New("CurrentExe is required"))
+	}
+	if opts.StagedExe == "" {
+		return result, phaseError(UpdatePhaseValidate, result, errors.New("StagedExe is required"))
+	}
+
+	oldPath, err := engineUpgradeSwap(opts.CurrentExe, opts.StagedExe)
+	if err != nil {
+		return result, phaseError(UpdatePhaseSwap, result, err)
+	}
+	result.OldPath = oldPath
+	defer func() {
+		if opts.CleanStale {
+			result.CleanedStale = engineCleanStale(opts.CurrentExe)
+			var updateErr *UpdateAndRestartError
+			if errors.As(err, &updateErr) {
+				updateErr.Result.CleanedStale = result.CleanedStale
+			}
+		}
+	}()
+
+	ctlPath := e.ControlSocketPath()
+	if !engineIsDaemonRunning(ctlPath) {
+		return result, nil
+	}
+	result.DaemonWasRunning = true
+
+	var lock daemonLock
+	lockPath := serverid.DaemonLockPath(e.cfg.BaseDir, e.cfg.Name)
+	lock, err = engineAcquireDaemonLock(lockPath)
+	if err != nil {
+		if !opts.ProceedWithoutLock {
+			return result, phaseError(UpdatePhaseLock, result, err)
+		}
+		result.Warnings = append(result.Warnings, fmt.Sprintf("could not acquire daemon lock %s: %v", lockPath, err))
+	} else {
+		result.LockAcquired = true
+		defer func() {
+			if closeErr := lock.Close(); closeErr != nil {
+				result.Warnings = append(result.Warnings, fmt.Sprintf("could not release daemon lock %s: %v", lockPath, closeErr))
+			}
+		}()
+	}
+
+	if err := ctx.Err(); err != nil {
+		return result, phaseError(UpdatePhaseRestart, result, err)
+	}
+	resp, err := engineControlSendWithTimeout(ctlPath, control.Request{
+		Cmd:            "graceful-restart",
+		DrainTimeoutMs: durationMillis(opts.DrainTimeout),
+		SuccessorExe:   opts.CurrentExe,
+	}, opts.RestartTimeout)
+	if err != nil {
+		result.Warnings = append(result.Warnings, fmt.Sprintf("graceful-restart unavailable: %v", err))
+		result.FallbackShutdown = true
+	} else if !resp.OK {
+		result.Warnings = append(result.Warnings, fmt.Sprintf("graceful-restart failed: %s", resp.Message))
+		result.FallbackShutdown = true
+	} else {
+		result.GracefulRestarted = true
+	}
+
+	if result.FallbackShutdown {
+		if shutdownResp, shutdownErr := engineControlSend(ctlPath, control.Request{Cmd: "shutdown"}); shutdownErr != nil {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("shutdown fallback send failed: %v", shutdownErr))
+		} else if !shutdownResp.OK {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("shutdown fallback failed: %s", shutdownResp.Message))
+		}
+	}
+
+	waitErr := engineWaitForDaemonExit(ctx, ctlPath, opts.ShutdownTimeout)
+	if waitErr != nil {
+		return result, phaseError(UpdatePhaseWaitExit, result, waitErr)
+	}
+
+	if result.GracefulRestarted {
+		if readyErr := engineWaitForDaemonReady(ctx, ctlPath, opts.ReadyTimeout); readyErr == nil {
+			result.ReplacementReady = true
+			result.ReplacementStarted = true
+			return result, nil
+		} else {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("graceful successor not ready: %v", readyErr))
+		}
+	}
+
+	if err := ctx.Err(); err != nil {
+		return result, phaseError(UpdatePhaseStart, result, err)
+	}
+	if err := engineStartDaemonExecutable(opts.CurrentExe, e.cfg.DaemonFlag); err != nil {
+		return result, phaseError(UpdatePhaseStart, result, err)
+	}
+	result.ReplacementStarted = true
+
+	if err := engineWaitForDaemonReady(ctx, ctlPath, opts.ReadyTimeout); err != nil {
+		return result, phaseError(UpdatePhaseReady, result, err)
+	}
+	result.ReplacementReady = true
+	return result, nil
+}
+
+func (opts UpdateAndRestartOptions) withDefaults() UpdateAndRestartOptions {
+	if opts.DrainTimeout <= 0 {
+		opts.DrainTimeout = defaultUpdateDrainTimeout
+	}
+	if opts.RestartTimeout <= 0 {
+		opts.RestartTimeout = defaultUpdateRestartTimeout
+	}
+	if opts.ShutdownTimeout <= 0 {
+		opts.ShutdownTimeout = defaultUpdateShutdownTimeout
+	}
+	if opts.ReadyTimeout <= 0 {
+		opts.ReadyTimeout = defaultUpdateReadyTimeout
+	}
+	return opts
+}
+
+func phaseError(phase UpdatePhase, result UpdateAndRestartResult, err error) error {
+	return &UpdateAndRestartError{Phase: phase, Result: result, Err: err}
+}
+
+func durationMillis(d time.Duration) int {
+	ms := d / time.Millisecond
+	if ms <= 0 {
+		return 1
+	}
+	return int(ms)
+}
+
+func acquireDaemonLock(lockPath string) (daemonLock, error) {
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		return nil, err
+	}
+	if err := lockDaemonFile(f); err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	return &fileDaemonLock{f: f}, nil
+}
+
+func startDaemonExecutable(exe, daemonFlag string) error {
+	cmd := exec.Command(exe, daemonFlag)
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	cmd.Stdin = nil
+	setDetached(cmd)
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start daemon process: %w", err)
+	}
+	if err := cmd.Process.Release(); err != nil {
+		return fmt.Errorf("release daemon process: %w", err)
+	}
+	return nil
+}
+
+func waitForDaemonReady(ctx context.Context, ctlPath string, timeout time.Duration) error {
+	return waitForDaemonCondition(ctx, timeout, func() bool {
+		return engineIsDaemonRunning(ctlPath)
+	}, fmt.Sprintf("daemon did not start within %s", timeout))
+}
+
+func waitForDaemonExit(ctx context.Context, ctlPath string, timeout time.Duration) error {
+	return waitForDaemonCondition(ctx, timeout, func() bool {
+		return !engineIsDaemonRunning(ctlPath)
+	}, fmt.Sprintf("daemon did not exit within %s", timeout))
+}
+
+func waitForDaemonCondition(ctx context.Context, timeout time.Duration, done func() bool, timeoutMsg string) error {
+	if timeout <= 0 {
+		timeout = defaultUpdateReadyTimeout
+	}
+	if done() {
+		return nil
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	ticker := time.NewTicker(daemonPollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-timer.C:
+			if done() {
+				return nil
+			}
+			return errors.New(timeoutMsg)
+		case <-ticker.C:
+			if done() {
+				return nil
+			}
+		}
+	}
+}

--- a/muxcore/engine/update_test.go
+++ b/muxcore/engine/update_test.go
@@ -1,0 +1,451 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	muxcore "github.com/thebtf/mcp-mux/muxcore"
+	"github.com/thebtf/mcp-mux/muxcore/control"
+)
+
+type fakeDaemonLock struct {
+	closed bool
+}
+
+func (l *fakeDaemonLock) Close() error {
+	l.closed = true
+	return nil
+}
+
+type updateSeams struct {
+	swap            func(string, string) (string, error)
+	clean           func(string) int
+	send            func(string, control.Request) (*control.Response, error)
+	sendWithTimeout func(string, control.Request, time.Duration) (*control.Response, error)
+	running         func(string) bool
+	start           func(string, string) error
+	waitReady       func(context.Context, string, time.Duration) error
+	waitExit        func(context.Context, string, time.Duration) error
+	acquireLock     func(string) (daemonLock, error)
+}
+
+func captureUpdateSeams() updateSeams {
+	return updateSeams{
+		swap:            engineUpgradeSwap,
+		clean:           engineCleanStale,
+		send:            engineControlSend,
+		sendWithTimeout: engineControlSendWithTimeout,
+		running:         engineIsDaemonRunning,
+		start:           engineStartDaemonExecutable,
+		waitReady:       engineWaitForDaemonReady,
+		waitExit:        engineWaitForDaemonExit,
+		acquireLock:     engineAcquireDaemonLock,
+	}
+}
+
+func restoreUpdateSeams(t *testing.T) {
+	t.Helper()
+	orig := captureUpdateSeams()
+	t.Cleanup(func() {
+		engineUpgradeSwap = orig.swap
+		engineCleanStale = orig.clean
+		engineControlSend = orig.send
+		engineControlSendWithTimeout = orig.sendWithTimeout
+		engineIsDaemonRunning = orig.running
+		engineStartDaemonExecutable = orig.start
+		engineWaitForDaemonReady = orig.waitReady
+		engineWaitForDaemonExit = orig.waitExit
+		engineAcquireDaemonLock = orig.acquireLock
+	})
+}
+
+func newUpdateTestEngine(t *testing.T) *MuxEngine {
+	t.Helper()
+	eng, err := New(Config{
+		Name:       "update-test",
+		Command:    "test-command",
+		BaseDir:    t.TempDir(),
+		DaemonFlag: "--test-daemon",
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return eng
+}
+
+func baseUpdateOptions() UpdateAndRestartOptions {
+	return UpdateAndRestartOptions{
+		CurrentExe:      "current.exe",
+		StagedExe:       "current.exe~",
+		DrainTimeout:    30 * time.Second,
+		RestartTimeout:  time.Minute,
+		ShutdownTimeout: time.Second,
+		ReadyTimeout:    time.Second,
+		CleanStale:      true,
+	}
+}
+
+func TestApplyUpdateAndRestart_GracefulSuccessUsesSuccessorExe(t *testing.T) {
+	restoreUpdateSeams(t)
+	eng := newUpdateTestEngine(t)
+	lock := &fakeDaemonLock{}
+	var gracefulReq control.Request
+	startCalls := 0
+
+	engineUpgradeSwap = func(current, staged string) (string, error) {
+		if current != "current.exe" || staged != "current.exe~" {
+			t.Fatalf("Swap(%q, %q), want current/staged", current, staged)
+		}
+		return "current.exe.old.1", nil
+	}
+	engineCleanStale = func(path string) int {
+		if path != "current.exe" {
+			t.Fatalf("CleanStale(%q), want current.exe", path)
+		}
+		return 2
+	}
+	engineIsDaemonRunning = func(string) bool { return true }
+	engineAcquireDaemonLock = func(string) (daemonLock, error) { return lock, nil }
+	engineControlSendWithTimeout = func(_ string, req control.Request, timeout time.Duration) (*control.Response, error) {
+		gracefulReq = req
+		if timeout != time.Minute {
+			t.Fatalf("restart timeout = %s, want 1m", timeout)
+		}
+		return &control.Response{OK: true}, nil
+	}
+	engineWaitForDaemonExit = func(context.Context, string, time.Duration) error { return nil }
+	engineWaitForDaemonReady = func(context.Context, string, time.Duration) error { return nil }
+	engineStartDaemonExecutable = func(string, string) error {
+		startCalls++
+		return nil
+	}
+
+	got, err := eng.ApplyUpdateAndRestart(context.Background(), baseUpdateOptions())
+	if err != nil {
+		t.Fatalf("ApplyUpdateAndRestart: %v", err)
+	}
+	if gracefulReq.Cmd != "graceful-restart" {
+		t.Fatalf("graceful cmd = %q, want graceful-restart", gracefulReq.Cmd)
+	}
+	if gracefulReq.SuccessorExe != "current.exe" {
+		t.Fatalf("SuccessorExe = %q, want current.exe", gracefulReq.SuccessorExe)
+	}
+	if !got.DaemonWasRunning || !got.LockAcquired || !got.GracefulRestarted || !got.ReplacementReady {
+		t.Fatalf("unexpected result flags: %+v", got)
+	}
+	if got.OldPath != "current.exe.old.1" || got.CleanedStale != 2 {
+		t.Fatalf("unexpected swap/cleanup result: %+v", got)
+	}
+	if startCalls != 0 {
+		t.Fatalf("explicit start calls = %d, want 0 when graceful successor is ready", startCalls)
+	}
+	if !lock.closed {
+		t.Fatal("daemon lock was not released")
+	}
+}
+
+func TestApplyUpdateAndRestart_DaemonNotRunningOnlySwaps(t *testing.T) {
+	restoreUpdateSeams(t)
+	eng := newUpdateTestEngine(t)
+	lockCalls, controlCalls, startCalls := 0, 0, 0
+
+	engineUpgradeSwap = func(string, string) (string, error) { return "old", nil }
+	engineCleanStale = func(string) int { return 1 }
+	engineIsDaemonRunning = func(string) bool { return false }
+	engineAcquireDaemonLock = func(string) (daemonLock, error) {
+		lockCalls++
+		return &fakeDaemonLock{}, nil
+	}
+	engineControlSendWithTimeout = func(string, control.Request, time.Duration) (*control.Response, error) {
+		controlCalls++
+		return &control.Response{OK: true}, nil
+	}
+	engineStartDaemonExecutable = func(string, string) error {
+		startCalls++
+		return nil
+	}
+
+	got, err := eng.ApplyUpdateAndRestart(context.Background(), baseUpdateOptions())
+	if err != nil {
+		t.Fatalf("ApplyUpdateAndRestart: %v", err)
+	}
+	if got.DaemonWasRunning || got.ReplacementStarted || got.ReplacementReady {
+		t.Fatalf("unexpected daemon flags when daemon is stopped: %+v", got)
+	}
+	if lockCalls != 0 || controlCalls != 0 || startCalls != 0 {
+		t.Fatalf("side effects lock/control/start = %d/%d/%d, want all zero", lockCalls, controlCalls, startCalls)
+	}
+	if got.CleanedStale != 1 {
+		t.Fatalf("CleanedStale = %d, want 1", got.CleanedStale)
+	}
+}
+
+func TestApplyUpdateAndRestart_SwapFailureStopsBeforeDaemonCalls(t *testing.T) {
+	restoreUpdateSeams(t)
+	eng := newUpdateTestEngine(t)
+	swapErr := errors.New("new binary not found")
+	daemonChecks := 0
+
+	engineUpgradeSwap = func(string, string) (string, error) { return "", swapErr }
+	engineIsDaemonRunning = func(string) bool {
+		daemonChecks++
+		return true
+	}
+
+	_, err := eng.ApplyUpdateAndRestart(context.Background(), baseUpdateOptions())
+	var updateErr *UpdateAndRestartError
+	if !errors.As(err, &updateErr) {
+		t.Fatalf("error = %v, want UpdateAndRestartError", err)
+	}
+	if updateErr.Phase != UpdatePhaseSwap || !errors.Is(updateErr.Err, swapErr) {
+		t.Fatalf("phase/err = %s/%v, want swap/new binary not found", updateErr.Phase, updateErr.Err)
+	}
+	if daemonChecks != 0 {
+		t.Fatalf("daemon checks = %d, want 0 before successful swap", daemonChecks)
+	}
+}
+
+func TestApplyUpdateAndRestart_GracefulErrorFallsBackToShutdownAndStart(t *testing.T) {
+	restoreUpdateSeams(t)
+	eng := newUpdateTestEngine(t)
+	var sent []string
+	var startedExe, startedFlag string
+
+	engineUpgradeSwap = func(string, string) (string, error) { return "old", nil }
+	engineCleanStale = func(string) int { return 0 }
+	engineIsDaemonRunning = func(string) bool { return true }
+	engineAcquireDaemonLock = func(string) (daemonLock, error) { return &fakeDaemonLock{}, nil }
+	engineControlSendWithTimeout = func(_ string, req control.Request, _ time.Duration) (*control.Response, error) {
+		sent = append(sent, req.Cmd)
+		return nil, errors.New("dial failed")
+	}
+	engineControlSend = func(_ string, req control.Request) (*control.Response, error) {
+		sent = append(sent, req.Cmd)
+		return &control.Response{OK: true}, nil
+	}
+	engineWaitForDaemonExit = func(context.Context, string, time.Duration) error { return nil }
+	engineStartDaemonExecutable = func(exe, flag string) error {
+		startedExe, startedFlag = exe, flag
+		return nil
+	}
+	engineWaitForDaemonReady = func(context.Context, string, time.Duration) error { return nil }
+
+	got, err := eng.ApplyUpdateAndRestart(context.Background(), baseUpdateOptions())
+	if err != nil {
+		t.Fatalf("ApplyUpdateAndRestart: %v", err)
+	}
+	if len(sent) != 2 || sent[0] != "graceful-restart" || sent[1] != "shutdown" {
+		t.Fatalf("sent commands = %#v, want graceful-restart then shutdown", sent)
+	}
+	if !got.FallbackShutdown || !got.ReplacementStarted || !got.ReplacementReady {
+		t.Fatalf("unexpected fallback result: %+v", got)
+	}
+	if startedExe != "current.exe" || startedFlag != "--test-daemon" {
+		t.Fatalf("started %q %q, want current.exe --test-daemon", startedExe, startedFlag)
+	}
+}
+
+func TestApplyUpdateAndRestart_LockFailureIsPhaseError(t *testing.T) {
+	restoreUpdateSeams(t)
+	eng := newUpdateTestEngine(t)
+	lockErr := errors.New("locked")
+
+	engineUpgradeSwap = func(string, string) (string, error) { return "old", nil }
+	engineCleanStale = func(string) int { return 0 }
+	engineIsDaemonRunning = func(string) bool { return true }
+	engineAcquireDaemonLock = func(string) (daemonLock, error) { return nil, lockErr }
+
+	_, err := eng.ApplyUpdateAndRestart(context.Background(), baseUpdateOptions())
+	var updateErr *UpdateAndRestartError
+	if !errors.As(err, &updateErr) {
+		t.Fatalf("error = %v, want UpdateAndRestartError", err)
+	}
+	if updateErr.Phase != UpdatePhaseLock || !errors.Is(updateErr.Err, lockErr) {
+		t.Fatalf("phase/err = %s/%v, want lock/locked", updateErr.Phase, updateErr.Err)
+	}
+}
+
+func TestApplyUpdateAndRestart_FallbackExitTimeoutIsPhaseError(t *testing.T) {
+	restoreUpdateSeams(t)
+	eng := newUpdateTestEngine(t)
+	exitErr := errors.New("still running")
+
+	engineUpgradeSwap = func(string, string) (string, error) { return "old", nil }
+	engineCleanStale = func(string) int { return 0 }
+	engineIsDaemonRunning = func(string) bool { return true }
+	engineAcquireDaemonLock = func(string) (daemonLock, error) { return &fakeDaemonLock{}, nil }
+	engineControlSendWithTimeout = func(string, control.Request, time.Duration) (*control.Response, error) {
+		return &control.Response{OK: false, Message: "nope"}, nil
+	}
+	engineControlSend = func(string, control.Request) (*control.Response, error) {
+		return &control.Response{OK: true}, nil
+	}
+	engineWaitForDaemonExit = func(context.Context, string, time.Duration) error { return exitErr }
+
+	_, err := eng.ApplyUpdateAndRestart(context.Background(), baseUpdateOptions())
+	var updateErr *UpdateAndRestartError
+	if !errors.As(err, &updateErr) {
+		t.Fatalf("error = %v, want UpdateAndRestartError", err)
+	}
+	if updateErr.Phase != UpdatePhaseWaitExit || !errors.Is(updateErr.Err, exitErr) {
+		t.Fatalf("phase/err = %s/%v, want wait_exit/still running", updateErr.Phase, updateErr.Err)
+	}
+	if !updateErr.Result.FallbackShutdown {
+		t.Fatalf("partial result did not record fallback shutdown: %+v", updateErr.Result)
+	}
+}
+
+func TestApplyUpdateAndRestart_GracefulExitTimeoutIsPhaseError(t *testing.T) {
+	restoreUpdateSeams(t)
+	eng := newUpdateTestEngine(t)
+	exitErr := errors.New("old daemon still responding")
+	readyChecks := 0
+
+	engineUpgradeSwap = func(string, string) (string, error) { return "old", nil }
+	engineCleanStale = func(string) int { return 0 }
+	engineIsDaemonRunning = func(string) bool { return true }
+	engineAcquireDaemonLock = func(string) (daemonLock, error) { return &fakeDaemonLock{}, nil }
+	engineControlSendWithTimeout = func(string, control.Request, time.Duration) (*control.Response, error) {
+		return &control.Response{OK: true}, nil
+	}
+	engineWaitForDaemonExit = func(context.Context, string, time.Duration) error { return exitErr }
+	engineWaitForDaemonReady = func(context.Context, string, time.Duration) error {
+		readyChecks++
+		return nil
+	}
+
+	_, err := eng.ApplyUpdateAndRestart(context.Background(), baseUpdateOptions())
+	var updateErr *UpdateAndRestartError
+	if !errors.As(err, &updateErr) {
+		t.Fatalf("error = %v, want UpdateAndRestartError", err)
+	}
+	if updateErr.Phase != UpdatePhaseWaitExit || !errors.Is(updateErr.Err, exitErr) {
+		t.Fatalf("phase/err = %s/%v, want wait_exit/old daemon still responding", updateErr.Phase, updateErr.Err)
+	}
+	if !updateErr.Result.GracefulRestarted {
+		t.Fatalf("partial result did not record graceful restart: %+v", updateErr.Result)
+	}
+	if readyChecks != 0 {
+		t.Fatalf("ready checks = %d, want 0 when old daemon did not exit", readyChecks)
+	}
+}
+
+func TestApplyUpdateAndRestart_ReadyTimeoutIsPhaseError(t *testing.T) {
+	restoreUpdateSeams(t)
+	eng := newUpdateTestEngine(t)
+	readyErr := errors.New("not ready")
+
+	engineUpgradeSwap = func(string, string) (string, error) { return "old", nil }
+	engineCleanStale = func(string) int { return 0 }
+	engineIsDaemonRunning = func(string) bool { return true }
+	engineAcquireDaemonLock = func(string) (daemonLock, error) { return &fakeDaemonLock{}, nil }
+	engineControlSendWithTimeout = func(string, control.Request, time.Duration) (*control.Response, error) {
+		return nil, errors.New("dial failed")
+	}
+	engineControlSend = func(string, control.Request) (*control.Response, error) {
+		return &control.Response{OK: true}, nil
+	}
+	engineWaitForDaemonExit = func(context.Context, string, time.Duration) error { return nil }
+	engineStartDaemonExecutable = func(string, string) error { return nil }
+	engineWaitForDaemonReady = func(context.Context, string, time.Duration) error { return readyErr }
+
+	_, err := eng.ApplyUpdateAndRestart(context.Background(), baseUpdateOptions())
+	var updateErr *UpdateAndRestartError
+	if !errors.As(err, &updateErr) {
+		t.Fatalf("error = %v, want UpdateAndRestartError", err)
+	}
+	if updateErr.Phase != UpdatePhaseReady || !errors.Is(updateErr.Err, readyErr) {
+		t.Fatalf("phase/err = %s/%v, want wait_ready/not ready", updateErr.Phase, updateErr.Err)
+	}
+	if !updateErr.Result.ReplacementStarted {
+		t.Fatalf("partial result did not record replacement start: %+v", updateErr.Result)
+	}
+}
+
+func TestApplyUpdateAndRestart_StartFailureIsPhaseError(t *testing.T) {
+	restoreUpdateSeams(t)
+	eng := newUpdateTestEngine(t)
+	startErr := errors.New("spawn denied")
+
+	engineUpgradeSwap = func(string, string) (string, error) { return "old", nil }
+	engineCleanStale = func(string) int { return 0 }
+	engineIsDaemonRunning = func(string) bool { return true }
+	engineAcquireDaemonLock = func(string) (daemonLock, error) { return &fakeDaemonLock{}, nil }
+	engineControlSendWithTimeout = func(string, control.Request, time.Duration) (*control.Response, error) {
+		return nil, errors.New("dial failed")
+	}
+	engineControlSend = func(string, control.Request) (*control.Response, error) {
+		return &control.Response{OK: true}, nil
+	}
+	engineWaitForDaemonExit = func(context.Context, string, time.Duration) error { return nil }
+	engineStartDaemonExecutable = func(string, string) error { return startErr }
+
+	_, err := eng.ApplyUpdateAndRestart(context.Background(), baseUpdateOptions())
+	var updateErr *UpdateAndRestartError
+	if !errors.As(err, &updateErr) {
+		t.Fatalf("error = %v, want UpdateAndRestartError", err)
+	}
+	if updateErr.Phase != UpdatePhaseStart || !errors.Is(updateErr.Err, startErr) {
+		t.Fatalf("phase/err = %s/%v, want start_replacement/spawn denied", updateErr.Phase, updateErr.Err)
+	}
+	if !updateErr.Result.FallbackShutdown {
+		t.Fatalf("partial result did not record fallback shutdown: %+v", updateErr.Result)
+	}
+}
+
+type updateDummySessionHandler struct{}
+
+func (updateDummySessionHandler) HandleRequest(context.Context, muxcore.ProjectContext, []byte) ([]byte, error) {
+	return []byte(`{"jsonrpc":"2.0","result":null,"id":1}`), nil
+}
+
+func TestApplyUpdateAndRestart_SessionHandlerConsumerUsesEngineNamespace(t *testing.T) {
+	restoreUpdateSeams(t)
+	eng, err := New(Config{
+		Name:           "aimux-like",
+		SessionHandler: updateDummySessionHandler{},
+		Handler:        func(context.Context, io.Reader, io.Writer) error { return nil },
+		BaseDir:        t.TempDir(),
+		DaemonFlag:     "--aimux-daemon",
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	var sawLockPath, sawControlPath, sawDaemonFlag string
+
+	engineUpgradeSwap = func(string, string) (string, error) { return "old", nil }
+	engineCleanStale = func(string) int { return 0 }
+	engineIsDaemonRunning = func(path string) bool {
+		sawControlPath = path
+		return true
+	}
+	engineAcquireDaemonLock = func(path string) (daemonLock, error) {
+		sawLockPath = path
+		return &fakeDaemonLock{}, nil
+	}
+	engineControlSendWithTimeout = func(string, control.Request, time.Duration) (*control.Response, error) {
+		return nil, errors.New("force fallback")
+	}
+	engineControlSend = func(string, control.Request) (*control.Response, error) {
+		return &control.Response{OK: true}, nil
+	}
+	engineWaitForDaemonExit = func(context.Context, string, time.Duration) error { return nil }
+	engineStartDaemonExecutable = func(_, flag string) error {
+		sawDaemonFlag = flag
+		return nil
+	}
+	engineWaitForDaemonReady = func(context.Context, string, time.Duration) error { return nil }
+
+	if _, err := eng.ApplyUpdateAndRestart(context.Background(), baseUpdateOptions()); err != nil {
+		t.Fatalf("ApplyUpdateAndRestart: %v", err)
+	}
+	if sawControlPath == "" || sawLockPath == "" {
+		t.Fatalf("namespace paths not used: control=%q lock=%q", sawControlPath, sawLockPath)
+	}
+	if sawDaemonFlag != "--aimux-daemon" {
+		t.Fatalf("daemon flag = %q, want --aimux-daemon", sawDaemonFlag)
+	}
+}


### PR DESCRIPTION
## Summary
- add engine.ApplyUpdateAndRestart for reusable SessionHandler consumer update flow
- pass successor_exe through graceful-restart so the old daemon launches the intended replacement binary
- document the SessionHandler restart contract and aimux adoption path

## Verification
- go test ./... -count=1 (root)
- go test ./... -count=1 (muxcore)
- go vet ./... (root)
- go vet ./... (muxcore)
- git diff --check

Refs Engram #239 / aimux #208 provider bridge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for graceful restart with custom successor executable configuration during updates.
  * Introduced unified update and restart orchestration with detailed progress tracking and error reporting across multiple phases (validate, swap, lock, restart, wait, start, ready).
  * Added cross-platform file locking mechanism for daemon coordination.

* **Documentation**
  * Updated release notes with migration guidance and new update/restart best practices.
  * Added comprehensive documentation on recommended update workflow and phase descriptions.

* **Tests**
  * Added test coverage for graceful restart with options and successor executable override.
  * Added test suite for update and restart scenarios including success paths, fallback mechanisms, and error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thebtf/mcp-mux/pull/120?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->