### PR TITLE
Fix muxcore control socket replacement race

### DIFF
--- a/muxcore/engine/update.go
+++ b/muxcore/engine/update.go
@@ -542,22 +542,14 @@ func prepareControlSocketForReplacement(ctx context.Context, ctlPath string, tim
 	defer timer.Stop()
 	ticker := time.NewTicker(daemonPollInterval)
 	defer ticker.Stop()
-	var lastErr error
 	for {
 		if !engineIsDaemonRunning(ctlPath) {
-			err := os.Remove(ctlPath)
-			if err == nil || os.IsNotExist(err) {
-				return nil
-			}
-			lastErr = err
+			return nil
 		}
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-timer.C:
-			if lastErr != nil {
-				return fmt.Errorf("control socket %s was not released: %w", ctlPath, lastErr)
-			}
 			return fmt.Errorf("control socket %s was still active", ctlPath)
 		case <-ticker.C:
 		}

--- a/muxcore/engine/update_test.go
+++ b/muxcore/engine/update_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"errors"
 	"io"
+	"net"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -570,6 +573,41 @@ func TestRestartWithSuccessor_TreatsAlreadyBoundReplacementAsReady(t *testing.T)
 	if identityCalls < 2 {
 		t.Fatalf("identity calls = %d, want pre-restart and replacement checks", identityCalls)
 	}
+}
+
+func TestPrepareControlSocketForReplacement_DoesNotUnlinkActiveSocketOnFalseNegative(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix socket pathname unlink race does not apply to Windows named pipes")
+	}
+	restoreUpdateSeams(t)
+	ctlPath := filepath.Join(t.TempDir(), "control.sock")
+	ln, err := net.Listen("unix", ctlPath)
+	if err != nil {
+		t.Fatalf("listen unix socket: %v", err)
+	}
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			_ = conn.Close()
+		}
+	}()
+	t.Cleanup(func() {
+		_ = ln.Close()
+	})
+
+	engineIsDaemonRunning = func(string) bool { return false }
+
+	if err := prepareControlSocketForReplacement(context.Background(), ctlPath, time.Second); err != nil {
+		t.Fatalf("prepareControlSocketForReplacement: %v", err)
+	}
+	conn, err := net.DialTimeout("unix", ctlPath, 200*time.Millisecond)
+	if err != nil {
+		t.Fatalf("control socket path was unlinked; dial after prepare: %v", err)
+	}
+	_ = conn.Close()
 }
 
 func TestApplyUpdateAndRestart_LockFailureIsPhaseError(t *testing.T) {

--- a/muxcore/engine/update_test.go
+++ b/muxcore/engine/update_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"net"
+	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -580,7 +581,12 @@ func TestPrepareControlSocketForReplacement_DoesNotUnlinkActiveSocketOnFalseNega
 		t.Skip("Unix socket pathname unlink race does not apply to Windows named pipes")
 	}
 	restoreUpdateSeams(t)
-	ctlPath := filepath.Join(t.TempDir(), "control.sock")
+	baseDir, err := os.MkdirTemp("", "ctl*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(baseDir) })
+	ctlPath := filepath.Join(baseDir, "control.sock")
 	ln, err := net.Listen("unix", ctlPath)
 	if err != nil {
 		t.Fatalf("listen unix socket: %v", err)

--- a/muxcore/owner/accept_loop_test.go
+++ b/muxcore/owner/accept_loop_test.go
@@ -84,12 +84,12 @@ func TestAcceptLoop_RejectEmptyToken(t *testing.T) {
 	o, socketPath := newTokenHandshakeOwner(t, logger)
 
 	conn := connectWithToken(t, socketPath, "")
-	conn.Close()
+	defer conn.Close()
 
 	// Positive evidence of rejection: the rejection log entry appears. Plain
 	// `sessionCount == 0` is true from t=0 and cannot distinguish "rejected"
 	// from "acceptLoop hasn't run yet" (CodeRabbit concern).
-	waitForCondition(t, 200*time.Millisecond, func() bool {
+	waitForCondition(t, 500*time.Millisecond, func() bool {
 		return strings.Contains(logBuffer.String(), "accept: rejected connection")
 	}, "empty-token connection should produce a rejection log entry")
 	if got := sessionCount(o); got != 0 {
@@ -117,9 +117,9 @@ func TestAcceptLoop_RejectUnknownToken(t *testing.T) {
 	o, socketPath := newTokenHandshakeOwner(t, logger)
 
 	conn := connectWithToken(t, socketPath, "cafebabe")
-	conn.Close()
+	defer conn.Close()
 
-	waitForCondition(t, 200*time.Millisecond, func() bool {
+	waitForCondition(t, 500*time.Millisecond, func() bool {
 		return strings.Contains(logBuffer.String(), "accept: rejected connection")
 	}, "unknown-token connection should produce a rejection log entry")
 	if got := sessionCount(o); got != 0 {
@@ -182,11 +182,8 @@ func TestAcceptLoop_ConcurrentTokenMix(t *testing.T) {
 		}(i)
 	}
 	wg.Wait()
-	for _, conn := range conns[n:] {
-		conn.Close()
-	}
 	t.Cleanup(func() {
-		for _, conn := range conns[:n] {
+		for _, conn := range conns {
 			if conn != nil {
 				conn.Close()
 			}


### PR DESCRIPTION
## Summary
- stop pre-start update preparation from unlinking daemon control socket paths
- rely on ipc.Listen stale cleanup guard to remove stale sockets only at bind time
- add Unix regression proving a false no-daemon gap does not unlink a live listener path

## Review Context
Fixes the delayed Codex review finding on merged PR #124: comment 3416465933 / thread PRRT_kwDORq0kOM6JtGJI (avoid unlinking a concurrently bound control socket).

## Verification
- go test ./engine -run "ControlSocket|Successor|RestartWithSuccessor" -count=1 -timeout 120s (from muxcore)
- go test ./... -count=1 -timeout 300s (from muxcore)
- go vet ./... (from muxcore)
- go test ./... -count=1 -timeout 300s (from repo root)
- go vet ./... (from repo root)
