### PR TITLE
Fix muxcore active control socket wait

### DIFF
--- a/muxcore/engine/update.go
+++ b/muxcore/engine/update.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/thebtf/mcp-mux/muxcore/control"
+	"github.com/thebtf/mcp-mux/muxcore/ipc"
 	"github.com/thebtf/mcp-mux/muxcore/serverid"
 	"github.com/thebtf/mcp-mux/muxcore/upgrade"
 )
@@ -163,6 +164,7 @@ var (
 	engineWaitForReplacement     = waitForDaemonReplacementOrExit
 	engineDaemonIdentity         = daemonIdentityFromStatus
 	enginePrepareControlSocket   = prepareControlSocketForReplacement
+	engineControlSocketAvailable = ipc.IsAvailable
 	engineAcquireDaemonLock      = acquireDaemonLock
 )
 
@@ -543,7 +545,7 @@ func prepareControlSocketForReplacement(ctx context.Context, ctlPath string, tim
 	ticker := time.NewTicker(daemonPollInterval)
 	defer ticker.Stop()
 	for {
-		if !engineIsDaemonRunning(ctlPath) {
+		if !engineIsDaemonRunning(ctlPath) && !engineControlSocketAvailable(ctlPath) {
 			return nil
 		}
 		select {

--- a/muxcore/engine/update_test.go
+++ b/muxcore/engine/update_test.go
@@ -37,6 +37,7 @@ type updateSeams struct {
 	waitReplacement func(context.Context, string, daemonIdentity, time.Duration) (bool, error)
 	identity        func(string) (daemonIdentity, error)
 	prepareSocket   func(context.Context, string, time.Duration) error
+	available       func(string) bool
 	acquireLock     func(string) (daemonLock, error)
 }
 
@@ -53,6 +54,7 @@ func captureUpdateSeams() updateSeams {
 		waitReplacement: engineWaitForReplacement,
 		identity:        engineDaemonIdentity,
 		prepareSocket:   enginePrepareControlSocket,
+		available:       engineControlSocketAvailable,
 		acquireLock:     engineAcquireDaemonLock,
 	}
 }
@@ -79,6 +81,7 @@ func restoreUpdateSeams(t *testing.T) {
 		engineWaitForReplacement = orig.waitReplacement
 		engineDaemonIdentity = orig.identity
 		enginePrepareControlSocket = orig.prepareSocket
+		engineControlSocketAvailable = orig.available
 		engineAcquireDaemonLock = orig.acquireLock
 	})
 }
@@ -576,7 +579,7 @@ func TestRestartWithSuccessor_TreatsAlreadyBoundReplacementAsReady(t *testing.T)
 	}
 }
 
-func TestPrepareControlSocketForReplacement_DoesNotUnlinkActiveSocketOnFalseNegative(t *testing.T) {
+func TestPrepareControlSocketForReplacement_WaitsOnActiveSocketFalseNegative(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Unix socket pathname unlink race does not apply to Windows named pipes")
 	}
@@ -606,14 +609,32 @@ func TestPrepareControlSocketForReplacement_DoesNotUnlinkActiveSocketOnFalseNega
 
 	engineIsDaemonRunning = func(string) bool { return false }
 
-	if err := prepareControlSocketForReplacement(context.Background(), ctlPath, time.Second); err != nil {
-		t.Fatalf("prepareControlSocketForReplacement: %v", err)
+	err = prepareControlSocketForReplacement(context.Background(), ctlPath, 50*time.Millisecond)
+	if err == nil {
+		t.Fatal("prepareControlSocketForReplacement returned nil while socket listener was still active")
 	}
 	conn, err := net.DialTimeout("unix", ctlPath, 200*time.Millisecond)
 	if err != nil {
 		t.Fatalf("control socket path was unlinked; dial after prepare: %v", err)
 	}
 	_ = conn.Close()
+}
+
+func TestPrepareControlSocketForReplacement_ReturnsAfterEndpointUnavailable(t *testing.T) {
+	restoreUpdateSeams(t)
+	availableCalls := 0
+	engineIsDaemonRunning = func(string) bool { return false }
+	engineControlSocketAvailable = func(string) bool {
+		availableCalls++
+		return availableCalls < 3
+	}
+
+	if err := prepareControlSocketForReplacement(context.Background(), "control.sock", time.Second); err != nil {
+		t.Fatalf("prepareControlSocketForReplacement: %v", err)
+	}
+	if availableCalls < 3 {
+		t.Fatalf("available calls = %d, want polling until unavailable", availableCalls)
+	}
 }
 
 func TestApplyUpdateAndRestart_LockFailureIsPhaseError(t *testing.T) {


### PR DESCRIPTION
## Summary
- make update restart preparation wait until the daemon control endpoint is both not pinging and not connectable
- keep stale cleanup delegated to ipc.Listen so live listeners are never unlinked
- update regressions for false-negative ping while the listener path is still active

## Review Context
Follow-up to the late Codex review finding on merged PR #125: thread PRRT_kwDORq0kOM6Jtc2E / comment PRRC_kwDORq0kOM7LpQsv.

v0.25.2 removed the unsafe unlink but could still treat a false-negative ping as ready-to-bind while a listener remained connectable. This PR closes that remaining bind-refusal/readiness-timeout path.

## Verification
- go test ./engine -run "ControlSocket|Successor|RestartWithSuccessor|PrepareControlSocket" -count=1 -timeout 120s (muxcore)
- go vet ./... (muxcore)
- go test -race -count=1 -timeout 180s ./... (muxcore)
- go test ./... -count=1 -timeout 300s (repo root)
- go vet ./... (repo root)
