### PR TITLE
docs: clarify muxcore v0.25.3 consumer update protocol

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,20 +62,24 @@ CC 4 ──stdio──> mcp-mux ──IPC──┘
 ### Upgrade
 
 ```bash
-go get github.com/thebtf/mcp-mux/muxcore@v0.25.0
+go get github.com/thebtf/mcp-mux/muxcore@v0.25.3
 ```
 
-### v0.24.4 — engine.ApplyUpdateAndRestart for SessionHandler consumers (#239)
+### v0.25.3 - native SessionHandler live update helpers (#239)
 
-**No breaking changes.** The new update helper is additive; existing
+**No breaking changes.** The live-update helpers are additive; existing
 `upgrade.Swap`, control commands, and engine configuration keep their current
-behavior.
+behavior. Use v0.25.3 as the current consumer target; it supersedes the
+v0.25.1/v0.25.2 release candidates and includes the active-control-socket wait
+fix needed for reliable fallback start after graceful restart.
 
 | API | Semantics |
 |-----|-----------|
 | `engine.UpdateAndRestartOptions` | Caller supplies `CurrentExe`, `StagedExe`, drain/restart/shutdown/ready timeouts, stale cleanup preference, and optional lock-failure behavior. |
+| `engine.RestartWithSuccessorOptions` | Caller supplies the explicit successor executable for stable-launcher/versioned-engine topologies without renaming the launcher. |
 | `engine.UpdateAndRestartResult` | Reports partial success: `OldPath`, daemon-running state, lock acquisition, graceful restart, shutdown fallback, replacement start/readiness, stale cleanup count, and warnings. |
 | `(*engine.MuxEngine).ApplyUpdateAndRestart(ctx, opts)` | Runs the reusable provider sequence: `upgrade.Swap`, daemon namespace lock, `graceful-restart`, shutdown fallback, wait-for-exit, replacement daemon start, and ready wait. |
+| `(*engine.MuxEngine).RestartWithSuccessor(ctx, opts)` | Runs the restart sequence with an explicit `SuccessorExe`, but does not rename files. Use after the consumer has updated its active engine pointer. |
 | `control.Request.SuccessorExe` + `control.GracefulRestartOptionsHandler` | Additive control-plane extension so a caller can tell the old daemon which executable should become the successor during graceful restart. Older handlers fall back to the legacy `HandleGracefulRestart(int)` path. |
 
 **Migration for aimux after muxcore release:**
@@ -126,6 +130,13 @@ product executable/version, `daemon_generation` changes,
 `shim_reconnect_fallback_spawned == 0`, and `shim_reconnect_gave_up == 0`.
 
 **Tests landed in this release:**
+- `TestRestartWithSuccessor_ValidationErrors`
+- `TestRestartWithSuccessor_GracefulSuccessUsesExplicitSuccessor`
+- `TestRestartWithSuccessor_GracefulErrorFallbackStartsSuccessor`
+- `TestRestartWithSuccessor_PreparesControlSocketBeforeCleanFallbackStart`
+- `TestRestartWithSuccessor_TreatsAlreadyBoundReplacementAsReady`
+- `TestPrepareControlSocketForReplacement_WaitsOnActiveSocketFalseNegative`
+- `TestPrepareControlSocketForReplacement_ReturnsAfterEndpointUnavailable`
 - `TestApplyUpdateAndRestart_GracefulSuccessUsesSuccessorExe`
 - `TestApplyUpdateAndRestart_DaemonNotRunningOnlySwaps`
 - `TestApplyUpdateAndRestart_SwapFailureStopsBeforeDaemonCalls`
@@ -467,19 +478,20 @@ by itself it does not signal, wait for, or restart a daemon.
 ### For aimux
 
 ```bash
-cd aimux && go get github.com/thebtf/mcp-mux/muxcore@v0.25.0
+cd aimux && go get github.com/thebtf/mcp-mux/muxcore@v0.25.3
 ```
 
 Key changes to adopt:
 1. **SessionHandler** — replace `srv.StdioHandler()` with SessionHandler implementation to get per-CC-session ProjectContext
-2. **ApplyUpdateAndRestart** — for live update flows, stage the new binary and call `eng.ApplyUpdateAndRestart(...)`; use `upgrade.Swap` only for low-level rename-only cases.
-3. **v0.19.3 concurrency fixes** — included automatically, no code changes needed. The CPU-spin-on-failed-background-spawn (BUG-001) and ownerNotifier.Notify RLock hold (BUG-002) are both hidden behind existing aimux code paths and required no consumer-side changes.
-4. **Circuit breaker** — included automatically, protects against upstream crash loops
+2. **Native update topology** — use `eng.RestartWithSuccessor(...)` when aimux keeps a stable launcher plus versioned engine store; use `eng.ApplyUpdateAndRestart(...)` only when `CurrentExe` is the replaceable engine path. Do not call `upgrade.Swap` as the whole update protocol.
+3. **Native process management** — agents should use aimux's own `sessions`, `status`, and `upgrade` surfaces for aimux state. `mcp-mux mux_list` is scoped to mcp-mux unless a future opt-in muxcore registry is implemented.
+4. **v0.19.3 concurrency fixes** — included automatically, no code changes needed. The CPU-spin-on-failed-background-spawn (BUG-001) and ownerNotifier.Notify RLock hold (BUG-002) are both hidden behind existing aimux code paths and required no consumer-side changes.
+5. **Circuit breaker** — included automatically, protects against upstream crash loops
 
 ### For engram
 
 ```bash
-cd engram && go get github.com/thebtf/mcp-mux/muxcore@v0.19.3
+cd engram && go get github.com/thebtf/mcp-mux/muxcore@v0.25.3
 ```
 
 Key changes:

--- a/docs/PRODUCTION-TESTING-PLAYBOOK.md
+++ b/docs/PRODUCTION-TESTING-PLAYBOOK.md
@@ -218,8 +218,9 @@ Required consumer fixture:
   product version, `engine_name`, `daemon_generation`, `owner_generation`,
   `restore_source`, and shim reconnect counters.
 - A consumer update command/tool that exercises the chosen topology from
-  `muxcore/README.md`: stable launcher + versioned engine store, fixed
-  replaceable engine path with `ApplyUpdateAndRestart`, or custom supervisor.
+  `muxcore/README.md`: stable launcher + versioned engine store with
+  `RestartWithSuccessor`, fixed replaceable engine path with
+  `ApplyUpdateAndRestart`, or custom supervisor.
 
 Commands:
 

--- a/muxcore/README.md
+++ b/muxcore/README.md
@@ -14,8 +14,13 @@ Pin the tagged muxcore module. Do not depend on `latest` for production
 consumers; muxcore is a runtime layer and downstream behavior changes matter.
 
 ```bash
-go get github.com/thebtf/mcp-mux/muxcore@v0.25.0
+go get github.com/thebtf/mcp-mux/muxcore@v0.25.3
 ```
+
+Use v0.25.3 for native SessionHandler hot-update work. It is the current
+consumer target for the `RestartWithSuccessor` / `ApplyUpdateAndRestart`
+contract and includes the active-control-socket wait fix required for reliable
+fallback start after graceful restart.
 
 ## Golden Path
 
@@ -271,7 +276,7 @@ operator docs.
 
 | Topology | Use when | Consumer action |
 | --- | --- | --- |
-| Stable launcher + versioned engine store | The executable configured in the MCP host may be held open by live shims or daemons. This is the safest Windows topology. | Keep the configured launcher stable. Install each build as a new engine path such as `versions/<hash>/<product>-engine.exe`, update an `active.txt` pointer, and restart with `MCPMUX_ACTIVE_ENGINE_FILE` or `MCPMUX_SUCCESSOR_EXE` pointing at the intended successor. Do not call `ApplyUpdateAndRestart` against the launcher path. |
+| Stable launcher + versioned engine store | The executable configured in the MCP host may be held open by live shims or daemons. This is the safest Windows topology. | Keep the configured launcher stable. Install each build as a new engine path such as `versions/<hash>/<product>-engine.exe`, update an `active.txt` pointer, then call `RestartWithSuccessor` or restart with `MCPMUX_ACTIVE_ENGINE_FILE` / `MCPMUX_SUCCESSOR_EXE` pointing at the intended successor. Do not call `ApplyUpdateAndRestart` against the launcher path. |
 | Fixed replaceable engine path | The product has a current engine executable path that can be renamed while old processes continue from `*.old.<pid>`. | Build or copy the candidate to an explicit `StagedExe`, commonly `CurrentExe + "~"`, then call `ApplyUpdateAndRestart` with `CurrentExe` set to that replaceable engine path. |
 | Offline / custom supervisor | The product owns daemon lifecycle outside the standard engine helper. | Use `upgrade.Swap` only as the rename primitive. Your updater must still handle daemon namespace locking, graceful restart, shutdown fallback, daemon start, ready wait, and status reporting. |
 


### PR DESCRIPTION
## Summary
- bump muxcore consumer install guidance to v0.25.3
- document RestartWithSuccessor as the stable-launcher/versioned-engine path
- keep ApplyUpdateAndRestart scoped to fixed replaceable engine paths
- tell aimux agents to use aimux native sessions/status/upgrade surfaces instead of mcp-mux mux_list for aimux state

## Verification
- git diff --check
- source-checked API and test names in muxcore/engine/update.go and muxcore/engine/update_test.go

Engram follow-up is queued because Engram is temporarily unavailable.