### PR TITLE
Add opt-in muxcore daemon registry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -484,7 +484,7 @@ cd aimux && go get github.com/thebtf/mcp-mux/muxcore@v0.25.3
 Key changes to adopt:
 1. **SessionHandler** — replace `srv.StdioHandler()` with SessionHandler implementation to get per-CC-session ProjectContext
 2. **Native update topology** — use `eng.RestartWithSuccessor(...)` when aimux keeps a stable launcher plus versioned engine store; use `eng.ApplyUpdateAndRestart(...)` only when `CurrentExe` is the replaceable engine path. Do not call `upgrade.Swap` as the whole update protocol.
-3. **Native process management** — agents should use aimux's own `sessions`, `status`, and `upgrade` surfaces for aimux state. `mcp-mux mux_list` is scoped to mcp-mux unless a future opt-in muxcore registry is implemented.
+3. **Native process management** — agents should use aimux's own `sessions`, `status`, and `upgrade` surfaces for aimux state. Default `mcp-mux mux_list` is scoped to the `mcp-mux` daemon namespace. When aimux consumes a muxcore version with opt-in daemon registry support, it may advertise via `engine.Config.Registry`; then `mux_engines` can show aimux and `mux_list(engine_name="aimux")` can list aimux owners read-only after status verification. This does not imply cross-engine stop/restart/update.
 4. **v0.19.3 concurrency fixes** — included automatically, no code changes needed. The CPU-spin-on-failed-background-spawn (BUG-001) and ownerNotifier.Notify RLock hold (BUG-002) are both hidden behind existing aimux code paths and required no consumer-side changes.
 5. **Circuit breaker** — included automatically, protects against upstream crash loops
 
@@ -498,6 +498,7 @@ Key changes:
 1. **DaemonControlPath** — if you call it directly, add name parameter: `DaemonControlPath(baseDir, "engram")`
 2. **v0.19.3 concurrency fixes** — included automatically
 3. **SessionHandler** — optional. engram can stay on legacy `Handler` until multi-session support is needed
+4. **Opt-in daemon registry** — optional read-only visibility. If engram adopts `engine.Config.Registry`, `mcp-mux serve` can show it through `mux_engines` and scoped `mux_list(engine_name="engram")`; default `mux_list` remains the `mcp-mux` namespace and engram's own management surface remains authoritative.
 
 ### v0.21.10 — Flush conn before afterFn (#99)
 

--- a/README.md
+++ b/README.md
@@ -548,9 +548,10 @@ any other server:
 
 | Tool | Description |
 |------|-------------|
-| `mux_list` | Returns running instances for the **current project** inside this `mcp-mux` daemon namespace (filtered by caller's cwd). Pass `all: true` to list this daemon's instances across all projects. Includes server ID, engine name, PID, session count, pending requests, classification, and cache status. With `verbose: true`, includes classification source/reason and inflight request details when present. |
-| `mux_stop` | Gracefully drains and stops an instance by `server_id`. Use `force: true` for immediate kill. |
-| `mux_restart` | Stops an instance and spawns a fresh daemon owner with the same command. When called without arguments, resolves to the instance belonging to the caller's session (e.g. `mux_restart(name: "aimux")` restarts this project's aimux, not another project's). Connected sessions reconnect automatically on their next tool call. |
+| `mux_engines` | Lists opted-in native muxcore daemon engines registered on this host. Each descriptor is advisory and is verified by daemon `status` before being marked healthy. Stale or mismatched descriptors are labeled instead of mixed into owner lists. |
+| `mux_list` | Returns running instances for the **current project** inside this `mcp-mux` daemon namespace (filtered by caller's cwd). Pass `all: true` to list this daemon's instances across all projects. Pass exact `engine_name` from `mux_engines` to query one verified native muxcore engine explicitly. Includes server ID, engine name, PID, session count, pending requests, classification, and cache status. With `verbose: true`, includes classification source/reason and inflight request details when present. |
+| `mux_stop` | Gracefully drains and stops an instance by `server_id`. Use `force: true` for immediate kill. CR-001 scope is current `mcp-mux` daemon namespace only; it does not stop native registered engines. |
+| `mux_restart` | Stops an instance and spawns a fresh daemon owner with the same command. When called without arguments, resolves to the instance belonging to the caller's session (e.g. `mux_restart(name: "aimux")` restarts this project's aimux if it was launched through this `mcp-mux` daemon, not a native `aimux` engine). CR-001 scope is current namespace only; cross-engine restart is a future opt-in management feature. |
 
 **Session-scoped control plane:**
 
@@ -560,6 +561,11 @@ session's working directory:
 - `mux_list` — shows only servers owned by the current project by default.
   Use `mux_list(all: true)` for a full view across all projects in this
   `mcp-mux` daemon.
+- `mux_engines` — shows native muxcore products only when they explicitly opt
+  into daemon registry advertisement.
+- `mux_list(engine_name: "aimux")` — queries exactly one registered engine after
+  verifying that the descriptor's control socket returns matching
+  `engine_name` from daemon `status`.
 - `mux_restart(name: "aimux")` — resolves to the aimux instance started from this project's
   directory, not a same-named server from a different project.
 
@@ -567,10 +573,13 @@ This prevents accidental cross-project interference when multiple projects use t
 name.
 
 Native muxcore products such as `aimux` or `engram` run under their own engine
-namespaces when they embed muxcore directly. They do not appear in
-`mcp-mux serve` unless they were launched through the `mcp-mux` product daemon.
-Inspect or update those products through their own MCP/CLI health and update
-surfaces, or through a future explicit cross-engine registry.
+namespaces when they embed muxcore directly. They do not appear in default
+`mux_list` unless they were launched through the `mcp-mux` product daemon. If a
+native product opts into muxcore daemon registry advertisement, `mux_engines`
+can discover it and `mux_list(engine_name: "...")` can list that one engine's
+owners. Product-native health, sessions, upgrade, and restart surfaces remain
+authoritative unless that product later opts into explicit cross-engine
+management capabilities.
 
 **Prompts:**
 

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -488,8 +488,7 @@ func (s *Server) toolMuxList(id json.RawMessage, args json.RawMessage) {
 
 	servers := s.formatOwnerList(listResp.Owners, params.Verbose, params.All, myCwd)
 
-	result, _ := json.MarshalIndent(servers, "", "  ")
-	s.sendToolResult(id, string(result))
+	s.sendJSONToolResult(id, servers)
 }
 
 func (s *Server) toolMuxEngines(id json.RawMessage, _ json.RawMessage) {
@@ -542,11 +541,10 @@ func (s *Server) toolMuxEngines(id json.RawMessage, _ json.RawMessage) {
 		engines = append(engines, row)
 	}
 
-	result, _ := json.MarshalIndent(map[string]any{
+	s.sendJSONToolResult(id, map[string]any{
 		"engines":    engines,
 		"duplicates": duplicates,
-	}, "", "  ")
-	s.sendToolResult(id, string(result))
+	})
 }
 
 func (s *Server) toolMuxListForEngine(id json.RawMessage, engineName string, verbose, all bool) {
@@ -591,20 +589,21 @@ func (s *Server) toolMuxListForEngine(id json.RawMessage, engineName string, ver
 		s.sendToolError(id, fmt.Sprintf("registered muxcore engine returned invalid list_owners response: %v", err))
 		return
 	}
+	for _, owner := range listResp.Owners {
+		if owner.EngineName != "" && owner.EngineName != engineName {
+			s.sendToolError(id, fmt.Sprintf("registered muxcore engine owner mismatch: requested %q, owner %q reports %q", engineName, owner.ServerID, owner.EngineName))
+			return
+		}
+	}
 	for i := range listResp.Owners {
 		if listResp.Owners[i].EngineName == "" {
 			listResp.Owners[i].EngineName = engineName
-		}
-		if listResp.Owners[i].EngineName != engineName {
-			s.sendToolError(id, fmt.Sprintf("registered muxcore engine owner mismatch: requested %q, owner %q reports %q", engineName, listResp.Owners[i].ServerID, listResp.Owners[i].EngineName))
-			return
 		}
 	}
 	myCwd, _ := os.Getwd()
 	myCwd = normalizeCwd(myCwd)
 	servers := s.formatOwnerList(listResp.Owners, verbose, all, myCwd)
-	result, _ := json.MarshalIndent(servers, "", "  ")
-	s.sendToolResult(id, string(result))
+	s.sendJSONToolResult(id, servers)
 }
 
 func (s *Server) formatOwnerList(owners []control.OwnerInfo, verbose, all bool, myCwd string) []map[string]any {
@@ -931,6 +930,15 @@ func (s *Server) sendToolResult(id json.RawMessage, text string) {
 			{"type": "text", "text": text},
 		},
 	})
+}
+
+func (s *Server) sendJSONToolResult(id json.RawMessage, payload any) {
+	result, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		s.sendToolError(id, fmt.Sprintf("internal: marshal tool result: %v", err))
+		return
+	}
+	s.sendToolResult(id, string(result))
 }
 
 func (s *Server) sendToolError(id json.RawMessage, text string) {

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -8,6 +8,7 @@ package mcpserver
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -20,6 +21,7 @@ import (
 
 	"github.com/thebtf/mcp-mux/muxcore/control"
 	"github.com/thebtf/mcp-mux/muxcore/ipc"
+	"github.com/thebtf/mcp-mux/muxcore/registry"
 	"github.com/thebtf/mcp-mux/muxcore/serverid"
 )
 
@@ -323,9 +325,20 @@ Stop + re-spawn as daemon. Existing CC clients reconnect on next tool call:
 func (s *Server) handleToolsList(id json.RawMessage) {
 	tools := []map[string]any{
 		{
+			"name": "mux_engines",
+			"description": "List opted-in native muxcore daemon engines registered on this host. " +
+				"Descriptors are advisory and are verified by daemon status before being marked healthy. " +
+				"Default mux_list remains scoped to this mcp-mux daemon namespace; use mux_list(engine_name=...) to list one registered engine explicitly.",
+			"inputSchema": map[string]any{
+				"type":       "object",
+				"properties": map[string]any{},
+			},
+		},
+		{
 			"name": "mux_list",
 			"description": "List all running mcp-mux managed MCP server instances. " +
 				"This is this mcp-mux daemon's engine namespace, not a global registry for native muxcore products. " +
+				"Use mux_engines to discover opted-in native muxcore engines, then pass engine_name to query exactly one registered engine. " +
 				"Returns compact summary by default: server name, sessions, classification, version. " +
 				"Set verbose=true for full details (PID, IPC path, cache status, classification reason). " +
 				"By default shows only servers belonging to this CC session's project. " +
@@ -343,6 +356,10 @@ func (s *Server) handleToolsList(id json.RawMessage) {
 						"type":        "boolean",
 						"description": "Show servers from all projects/sessions, not just this one (default: false).",
 						"default":     false,
+					},
+					"engine_name": map[string]any{
+						"type":        "string",
+						"description": "Exact opted-in muxcore engine name to query. Empty/default queries only this mcp-mux daemon namespace.",
 					},
 				},
 			},
@@ -416,6 +433,8 @@ func (s *Server) handleToolsCall(id json.RawMessage, params json.RawMessage) {
 	}
 
 	switch call.Name {
+	case "mux_engines":
+		s.toolMuxEngines(id, call.Arguments)
 	case "mux_list":
 		s.toolMuxList(id, call.Arguments)
 	case "mux_stop":
@@ -432,11 +451,16 @@ func (s *Server) handleToolsCall(id json.RawMessage, params json.RawMessage) {
 // Set all=true to see all servers across all projects.
 func (s *Server) toolMuxList(id json.RawMessage, args json.RawMessage) {
 	var params struct {
-		Verbose bool `json:"verbose"`
-		All     bool `json:"all"`
+		Verbose    bool   `json:"verbose"`
+		All        bool   `json:"all"`
+		EngineName string `json:"engine_name"`
 	}
 	if args != nil {
 		_ = json.Unmarshal(args, &params)
+	}
+	if strings.TrimSpace(params.EngineName) != "" {
+		s.toolMuxListForEngine(id, params.EngineName, params.Verbose, params.All)
+		return
 	}
 
 	myCwd, _ := os.Getwd()
@@ -462,14 +486,136 @@ func (s *Server) toolMuxList(id json.RawMessage, args json.RawMessage) {
 		return
 	}
 
+	servers := s.formatOwnerList(listResp.Owners, params.Verbose, params.All, myCwd)
+
+	result, _ := json.MarshalIndent(servers, "", "  ")
+	s.sendToolResult(id, string(result))
+}
+
+func (s *Server) toolMuxEngines(id json.RawMessage, _ json.RawMessage) {
+	records, err := registry.ListDescriptors(s.socketDir())
+	if err != nil {
+		s.sendToolError(id, fmt.Sprintf("list muxcore engine registry: %v", err))
+		return
+	}
+	duplicates := registry.DuplicateEngineNames(records)
+
+	engines := make([]map[string]any, 0, len(records))
+	for _, rec := range records {
+		verified := registry.VerifyDescriptor(rec)
+		state := verified.State
+		reason := verified.Reason
+		if rec.Err == nil {
+			if count, ok := duplicates[rec.Descriptor.EngineName]; ok {
+				state = registry.StateDuplicate
+				if reason == "" {
+					reason = fmt.Sprintf("duplicate_engine_name: %d descriptors", count)
+				}
+			}
+		}
+
+		row := map[string]any{
+			"descriptor_path": rec.Path,
+			"state":           state,
+			"reachable":       verified.Reachable,
+		}
+		if reason != "" {
+			row["reason"] = reason
+		}
+		if rec.Err == nil {
+			row["engine_name"] = rec.Descriptor.EngineName
+			row["product_name"] = rec.Descriptor.ProductName
+			row["pid"] = rec.Descriptor.PID
+			if verified.PID != 0 {
+				row["status_pid"] = verified.PID
+			}
+			row["base_dir"] = rec.Descriptor.BaseDir
+			row["daemon_control_path"] = rec.Descriptor.DaemonControlPath
+			row["started_at"] = rec.Descriptor.StartedAt.Format(time.RFC3339)
+			row["muxcore_version"] = rec.Descriptor.MuxcoreVersion
+			row["capabilities"] = rec.Descriptor.Capabilities
+			row["owner_count"] = verified.OwnerCount
+			if verified.DaemonGeneration != "" {
+				row["daemon_generation"] = verified.DaemonGeneration
+			}
+		}
+		engines = append(engines, row)
+	}
+
+	result, _ := json.MarshalIndent(map[string]any{
+		"engines":    engines,
+		"duplicates": duplicates,
+	}, "", "  ")
+	s.sendToolResult(id, string(result))
+}
+
+func (s *Server) toolMuxListForEngine(id json.RawMessage, engineName string, verbose, all bool) {
+	engineName = strings.TrimSpace(engineName)
+	records, err := registry.ListDescriptors(s.socketDir())
+	if err != nil {
+		s.sendToolError(id, fmt.Sprintf("list muxcore engine registry: %v", err))
+		return
+	}
+	rec, err := registry.ResolveEngine(records, engineName)
+	if err != nil {
+		switch {
+		case errors.Is(err, registry.ErrEngineNotFound):
+			s.sendToolError(id, fmt.Sprintf("registered muxcore engine not found: %s", engineName))
+		case errors.Is(err, registry.ErrDuplicateEngine):
+			s.sendToolError(id, fmt.Sprintf("registered muxcore engine is ambiguous: %s", engineName))
+		default:
+			s.sendToolError(id, fmt.Sprintf("resolve registered muxcore engine %q: %v", engineName, err))
+		}
+		return
+	}
+	verified := registry.VerifyDescriptor(rec)
+	if verified.State != registry.StateHealthy {
+		s.sendToolError(id, fmt.Sprintf("registered muxcore engine is not healthy: %s (%s)", engineName, verified.Reason))
+		return
+	}
+	resp, err := control.Send(rec.Descriptor.DaemonControlPath, control.Request{Cmd: "list_owners"})
+	if err != nil {
+		s.sendToolError(id, fmt.Sprintf("registered muxcore engine list_owners failed: %v", err))
+		return
+	}
+	if !resp.OK {
+		s.sendToolError(id, fmt.Sprintf("registered muxcore engine list_owners error: %s", resp.Message))
+		return
+	}
+	if resp.Data == nil {
+		s.sendToolError(id, "registered muxcore engine returned empty list_owners response")
+		return
+	}
+	var listResp control.ListOwnersResponse
+	if err := json.Unmarshal(resp.Data, &listResp); err != nil {
+		s.sendToolError(id, fmt.Sprintf("registered muxcore engine returned invalid list_owners response: %v", err))
+		return
+	}
+	for i := range listResp.Owners {
+		if listResp.Owners[i].EngineName == "" {
+			listResp.Owners[i].EngineName = engineName
+		}
+		if listResp.Owners[i].EngineName != engineName {
+			s.sendToolError(id, fmt.Sprintf("registered muxcore engine owner mismatch: requested %q, owner %q reports %q", engineName, listResp.Owners[i].ServerID, listResp.Owners[i].EngineName))
+			return
+		}
+	}
+	myCwd, _ := os.Getwd()
+	myCwd = normalizeCwd(myCwd)
+	servers := s.formatOwnerList(listResp.Owners, verbose, all, myCwd)
+	result, _ := json.MarshalIndent(servers, "", "  ")
+	s.sendToolResult(id, string(result))
+}
+
+func (s *Server) formatOwnerList(owners []control.OwnerInfo, verbose, all bool, myCwd string) []map[string]any {
 	var servers []map[string]any
-	for _, owner := range listResp.Owners {
-		if !params.All && myCwd != "" {
+	for _, owner := range owners {
+		if !all && myCwd != "" {
 			if !s.ownerInfoHasCwd(owner, myCwd) {
 				continue
 			}
 		}
-		if params.Verbose {
+		if verbose {
 			servers = append(servers, map[string]any{
 				"server_id":             owner.ServerID,
 				"engine_name":           owner.EngineName,
@@ -503,9 +649,10 @@ func (s *Server) toolMuxList(id json.RawMessage, args json.RawMessage) {
 			})
 		}
 	}
-
-	result, _ := json.MarshalIndent(servers, "", "  ")
-	s.sendToolResult(id, string(result))
+	if servers == nil {
+		return []map[string]any{}
+	}
+	return servers
 }
 
 // normalizeCwd cleans a path and lowercases only on Windows. Linux/macOS

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -8,7 +8,6 @@ package mcpserver
 import (
 	"bufio"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -554,23 +553,32 @@ func (s *Server) toolMuxListForEngine(id json.RawMessage, engineName string, ver
 		s.sendToolError(id, fmt.Sprintf("list muxcore engine registry: %v", err))
 		return
 	}
-	rec, err := registry.ResolveEngine(records, engineName)
-	if err != nil {
-		switch {
-		case errors.Is(err, registry.ErrEngineNotFound):
-			s.sendToolError(id, fmt.Sprintf("registered muxcore engine not found: %s", engineName))
-		case errors.Is(err, registry.ErrDuplicateEngine):
-			s.sendToolError(id, fmt.Sprintf("registered muxcore engine is ambiguous: %s", engineName))
-		default:
-			s.sendToolError(id, fmt.Sprintf("resolve registered muxcore engine %q: %v", engineName, err))
+	var matches []registry.VerifiedDescriptor
+	for _, rec := range records {
+		if rec.Err != nil || rec.Descriptor.EngineName != engineName {
+			continue
 		}
+		matches = append(matches, registry.VerifyDescriptor(rec))
+	}
+	if len(matches) == 0 {
+		s.sendToolError(id, fmt.Sprintf("registered muxcore engine not found: %s", engineName))
 		return
 	}
-	verified := registry.VerifyDescriptor(rec)
-	if verified.State != registry.StateHealthy {
-		s.sendToolError(id, fmt.Sprintf("registered muxcore engine is not healthy: %s (%s)", engineName, verified.Reason))
+	var healthy []registry.VerifiedDescriptor
+	for _, match := range matches {
+		if match.State == registry.StateHealthy {
+			healthy = append(healthy, match)
+		}
+	}
+	if len(healthy) == 0 {
+		s.sendToolError(id, fmt.Sprintf("registered muxcore engine is not healthy: %s (%s)", engineName, registrySummary(matches)))
 		return
 	}
+	if len(healthy) > 1 {
+		s.sendToolError(id, fmt.Sprintf("registered muxcore engine is ambiguous: %s (%d healthy descriptors)", engineName, len(healthy)))
+		return
+	}
+	rec := healthy[0].Record
 	resp, err := control.Send(rec.Descriptor.DaemonControlPath, control.Request{Cmd: "list_owners"})
 	if err != nil {
 		s.sendToolError(id, fmt.Sprintf("registered muxcore engine list_owners failed: %v", err))
@@ -652,6 +660,18 @@ func (s *Server) formatOwnerList(owners []control.OwnerInfo, verbose, all bool, 
 		return []map[string]any{}
 	}
 	return servers
+}
+
+func registrySummary(matches []registry.VerifiedDescriptor) string {
+	parts := make([]string, 0, len(matches))
+	for _, match := range matches {
+		reason := match.Reason
+		if reason == "" {
+			reason = match.State
+		}
+		parts = append(parts, fmt.Sprintf("%s: %s", match.State, reason))
+	}
+	return strings.Join(parts, "; ")
 }
 
 // normalizeCwd cleans a path and lowercases only on Windows. Linux/macOS

--- a/internal/mcpserver/server_test.go
+++ b/internal/mcpserver/server_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/thebtf/mcp-mux/muxcore/control"
+	"github.com/thebtf/mcp-mux/muxcore/registry"
 )
 
 // shortBaseDir returns a fresh temp directory whose path is short enough to host
@@ -208,8 +209,8 @@ func TestToolsList(t *testing.T) {
 	}
 	unmarshalResult(t, resp, &result)
 
-	if len(result.Tools) != 3 {
-		t.Fatalf("tools count = %d, want 3", len(result.Tools))
+	if len(result.Tools) != 4 {
+		t.Fatalf("tools count = %d, want 4", len(result.Tools))
 	}
 
 	names := make(map[string]bool)
@@ -217,7 +218,7 @@ func TestToolsList(t *testing.T) {
 		names[tool.Name] = true
 	}
 
-	for _, expected := range []string{"mux_list", "mux_stop", "mux_restart"} {
+	for _, expected := range []string{"mux_engines", "mux_list", "mux_stop", "mux_restart"} {
 		if !names[expected] {
 			t.Errorf("tool %q not found in list", expected)
 		}
@@ -899,9 +900,14 @@ func (h *fakeDaemonHandler) HandleListOwners(_ control.Request) (control.ListOwn
 // startFakeDaemonControlServer creates a daemon control server at socketPath responding to list_owners.
 func startFakeDaemonControlServer(t *testing.T, socketPath string, resp control.ListOwnersResponse) *control.Server {
 	t.Helper()
+	return startFakeDaemonControlServerWithStatus(t, socketPath, map[string]any{}, resp)
+}
+
+func startFakeDaemonControlServerWithStatus(t *testing.T, socketPath string, status map[string]any, resp control.ListOwnersResponse) *control.Server {
+	t.Helper()
 	t.Cleanup(func() { os.Remove(socketPath) })
 	handler := &fakeDaemonHandler{
-		fakeHandler:    fakeHandler{status: map[string]any{}, shutdownMsg: "ok"},
+		fakeHandler:    fakeHandler{status: status, shutdownMsg: "ok"},
 		listOwnersResp: resp,
 	}
 	srv, err := control.NewServer(socketPath, handler, log.New(io.Discard, "", 0))
@@ -910,6 +916,24 @@ func startFakeDaemonControlServer(t *testing.T, socketPath string, resp control.
 	}
 	t.Cleanup(func() { srv.Close() })
 	return srv
+}
+
+func writeTestEngineDescriptor(t *testing.T, baseDir, engineName, productName, ctlPath string) {
+	t.Helper()
+	_, err := registry.WriteDescriptor(baseDir, registry.Descriptor{
+		SchemaVersion:     registry.SchemaVersion,
+		EngineName:        engineName,
+		ProductName:       productName,
+		PID:               1234,
+		BaseDir:           baseDir,
+		DaemonControlPath: ctlPath,
+		StartedAt:         time.Unix(1700000000, 0).UTC(),
+		MuxcoreVersion:    "test",
+		Capabilities:      registry.Capabilities{ListOwners: true},
+	})
+	if err != nil {
+		t.Fatalf("WriteDescriptor(%s): %v", engineName, err)
+	}
 }
 
 // newTestServerFull creates a Server with both DaemonCtlPath and BaseDir set.
@@ -998,6 +1022,248 @@ func TestMuxListWithFakeServer(t *testing.T) {
 	}
 	if !strings.Contains(text, "test-server") {
 		t.Errorf("mux_list output should contain args, got: %s", text)
+	}
+}
+
+func TestMuxEnginesListsHealthyAndStaleDescriptors(t *testing.T) {
+	baseDir := shortBaseDir(t, "mcpmux-engines-")
+	healthyCtl := filepath.Join(baseDir, "aimux-muxd.ctl.sock")
+	mismatchCtl := filepath.Join(baseDir, "mismatch-muxd.ctl.sock")
+	missingCtl := filepath.Join(baseDir, "missing-muxd.ctl.sock")
+
+	startFakeDaemonControlServerWithStatus(t, healthyCtl, map[string]any{
+		"engine_name":       "aimux-test",
+		"pid":               4321,
+		"daemon_generation": "daemon-aimux",
+		"owner_count":       2,
+	}, control.ListOwnersResponse{})
+	startFakeDaemonControlServerWithStatus(t, mismatchCtl, map[string]any{
+		"engine_name": "engram-test",
+		"pid":         9999,
+		"owner_count": 0,
+	}, control.ListOwnersResponse{})
+	writeTestEngineDescriptor(t, baseDir, "aimux-test", "Aimux Test", healthyCtl)
+	writeTestEngineDescriptor(t, baseDir, "mismatch-test", "Mismatch Test", mismatchCtl)
+	writeTestEngineDescriptor(t, baseDir, "missing-test", "Missing Test", missingCtl)
+
+	daemonCtlPath := filepath.Join(baseDir, "mcp-mux-muxd.ctl.sock")
+	startFakeDaemonControlServer(t, daemonCtlPath, control.ListOwnersResponse{})
+	clientW, clientR, _ := newTestServerFull(t, daemonCtlPath, baseDir)
+	defer clientW.Close()
+
+	sendLine(t, clientW, `{"jsonrpc":"2.0","id":60,"method":"tools/call","params":{"name":"mux_engines","arguments":{}}}`)
+	line := readLine(t, clientR)
+	resp := parseResponse(t, line)
+	assertID(t, resp, 60)
+	assertNoError(t, resp)
+
+	var result struct {
+		Content []struct {
+			Text string `json:"text"`
+		} `json:"content"`
+	}
+	unmarshalResult(t, resp, &result)
+	if len(result.Content) == 0 {
+		t.Fatal("expected mux_engines content")
+	}
+	var decoded struct {
+		Engines []struct {
+			EngineName  string `json:"engine_name"`
+			ProductName string `json:"product_name"`
+			State       string `json:"state"`
+			Reachable   bool   `json:"reachable"`
+			Reason      string `json:"reason"`
+			OwnerCount  int    `json:"owner_count"`
+		} `json:"engines"`
+	}
+	if err := json.Unmarshal([]byte(result.Content[0].Text), &decoded); err != nil {
+		t.Fatalf("mux_engines content is not valid JSON: %v\n%s", err, result.Content[0].Text)
+	}
+	seen := map[string]struct {
+		state     string
+		reachable bool
+		reason    string
+		owners    int
+	}{}
+	for _, engine := range decoded.Engines {
+		seen[engine.EngineName] = struct {
+			state     string
+			reachable bool
+			reason    string
+			owners    int
+		}{engine.State, engine.Reachable, engine.Reason, engine.OwnerCount}
+	}
+	if got := seen["aimux-test"]; got.state != registry.StateHealthy || !got.reachable || got.owners != 2 {
+		t.Fatalf("aimux-test = %+v, want healthy reachable owner_count=2", got)
+	}
+	if got := seen["mismatch-test"]; got.state != registry.StateStale || !strings.Contains(got.reason, "engine_name_mismatch") {
+		t.Fatalf("mismatch-test = %+v, want stale mismatch", got)
+	}
+	if got := seen["missing-test"]; got.state != registry.StateStale || !strings.Contains(got.reason, "control_unreachable") {
+		t.Fatalf("missing-test = %+v, want stale unreachable", got)
+	}
+}
+
+func TestMuxEnginesEmptyRegistry(t *testing.T) {
+	baseDir := shortBaseDir(t, "mcpmux-emptyengines-")
+	daemonCtlPath := filepath.Join(baseDir, "mcp-mux-muxd.ctl.sock")
+	startFakeDaemonControlServer(t, daemonCtlPath, control.ListOwnersResponse{})
+	clientW, clientR, _ := newTestServerFull(t, daemonCtlPath, baseDir)
+	defer clientW.Close()
+
+	sendLine(t, clientW, `{"jsonrpc":"2.0","id":61,"method":"tools/call","params":{"name":"mux_engines","arguments":{}}}`)
+	line := readLine(t, clientR)
+	resp := parseResponse(t, line)
+	assertID(t, resp, 61)
+	assertNoError(t, resp)
+
+	var result struct {
+		Content []struct {
+			Text string `json:"text"`
+		} `json:"content"`
+	}
+	unmarshalResult(t, resp, &result)
+	var decoded struct {
+		Engines []any `json:"engines"`
+	}
+	if err := json.Unmarshal([]byte(result.Content[0].Text), &decoded); err != nil {
+		t.Fatalf("mux_engines content is not valid JSON: %v\n%s", err, result.Content[0].Text)
+	}
+	if len(decoded.Engines) != 0 {
+		t.Fatalf("engines = %d, want 0", len(decoded.Engines))
+	}
+}
+
+func TestMuxListDefaultIgnoresRegisteredForeignEngines(t *testing.T) {
+	myCwd, _ := os.Getwd()
+	baseDir := shortBaseDir(t, "mcpmux-defaultforeign-")
+
+	foreignCtl := filepath.Join(baseDir, "aimux-muxd.ctl.sock")
+	startFakeDaemonControlServerWithStatus(t, foreignCtl, map[string]any{
+		"engine_name": "aimux-test",
+		"owner_count": 1,
+	}, control.ListOwnersResponse{Owners: []control.OwnerInfo{{
+		ServerID: "foreign0011223344",
+		Command:  "aimux",
+		Args:     []string{"native"},
+		Cwd:      myCwd,
+	}}})
+	writeTestEngineDescriptor(t, baseDir, "aimux-test", "Aimux Test", foreignCtl)
+
+	daemonCtlPath := filepath.Join(baseDir, "mcp-mux-muxd.ctl.sock")
+	startFakeDaemonControlServer(t, daemonCtlPath, control.ListOwnersResponse{Owners: []control.OwnerInfo{{
+		ServerID: "local001122334455",
+		Command:  "uvx",
+		Args:     []string{"local-server"},
+		Cwd:      myCwd,
+	}}})
+	clientW, clientR, _ := newTestServerFull(t, daemonCtlPath, baseDir)
+	defer clientW.Close()
+
+	sendLine(t, clientW, `{"jsonrpc":"2.0","id":62,"method":"tools/call","params":{"name":"mux_list","arguments":{}}}`)
+	line := readLine(t, clientR)
+	resp := parseResponse(t, line)
+	assertID(t, resp, 62)
+	assertNoError(t, resp)
+
+	var result struct {
+		Content []struct {
+			Text string `json:"text"`
+		} `json:"content"`
+	}
+	unmarshalResult(t, resp, &result)
+	text := result.Content[0].Text
+	if !strings.Contains(text, "local-server") {
+		t.Fatalf("default mux_list should include local current daemon owner, got: %s", text)
+	}
+	if strings.Contains(text, "aimux") || strings.Contains(text, "foreign0011223344") {
+		t.Fatalf("default mux_list leaked registered foreign engine owner: %s", text)
+	}
+}
+
+func TestMuxListWithEngineNameQueriesExactRegisteredEngine(t *testing.T) {
+	baseDir := shortBaseDir(t, "mcpmux-scopedlist-")
+	foreignCtl := filepath.Join(baseDir, "aimux-muxd.ctl.sock")
+	startFakeDaemonControlServerWithStatus(t, foreignCtl, map[string]any{
+		"engine_name": "aimux-test",
+		"owner_count": 1,
+	}, control.ListOwnersResponse{Owners: []control.OwnerInfo{{
+		ServerID:   "aimux001122334455",
+		EngineName: "aimux-test",
+		Command:    "aimux",
+		Args:       []string{"native"},
+		Sessions:   4,
+		Cwd:        filepath.Join(baseDir, "foreign-project"),
+	}}})
+	writeTestEngineDescriptor(t, baseDir, "aimux-test", "Aimux Test", foreignCtl)
+
+	daemonCtlPath := filepath.Join(baseDir, "mcp-mux-muxd.ctl.sock")
+	startFakeDaemonControlServer(t, daemonCtlPath, control.ListOwnersResponse{})
+	clientW, clientR, _ := newTestServerFull(t, daemonCtlPath, baseDir)
+	defer clientW.Close()
+
+	sendLine(t, clientW, `{"jsonrpc":"2.0","id":63,"method":"tools/call","params":{"name":"mux_list","arguments":{"engine_name":"aimux-test","all":true}}}`)
+	line := readLine(t, clientR)
+	resp := parseResponse(t, line)
+	assertID(t, resp, 63)
+	assertNoError(t, resp)
+
+	var result struct {
+		IsError bool `json:"isError"`
+		Content []struct {
+			Text string `json:"text"`
+		} `json:"content"`
+	}
+	unmarshalResult(t, resp, &result)
+	if result.IsError {
+		t.Fatalf("scoped mux_list returned tool error: %+v", result.Content)
+	}
+	text := result.Content[0].Text
+	if !strings.Contains(text, "aimux001122334455") || !strings.Contains(text, "aimux-test") {
+		t.Fatalf("scoped mux_list missing aimux owner: %s", text)
+	}
+}
+
+func TestMuxListWithEngineNameRejectsUnknownAndStale(t *testing.T) {
+	baseDir := shortBaseDir(t, "mcpmux-scopederr-")
+	missingCtl := filepath.Join(baseDir, "missing-muxd.ctl.sock")
+	writeTestEngineDescriptor(t, baseDir, "missing-test", "Missing Test", missingCtl)
+
+	daemonCtlPath := filepath.Join(baseDir, "mcp-mux-muxd.ctl.sock")
+	startFakeDaemonControlServer(t, daemonCtlPath, control.ListOwnersResponse{})
+	clientW, clientR, _ := newTestServerFull(t, daemonCtlPath, baseDir)
+	defer clientW.Close()
+
+	sendLine(t, clientW, `{"jsonrpc":"2.0","id":64,"method":"tools/call","params":{"name":"mux_list","arguments":{"engine_name":"unknown-test"}}}`)
+	line := readLine(t, clientR)
+	resp := parseResponse(t, line)
+	assertID(t, resp, 64)
+	assertNoError(t, resp)
+	var unknown struct {
+		IsError bool `json:"isError"`
+		Content []struct {
+			Text string `json:"text"`
+		} `json:"content"`
+	}
+	unmarshalResult(t, resp, &unknown)
+	if !unknown.IsError || !strings.Contains(unknown.Content[0].Text, "registered muxcore engine not found") {
+		t.Fatalf("unknown engine response = %+v", unknown)
+	}
+
+	sendLine(t, clientW, `{"jsonrpc":"2.0","id":65,"method":"tools/call","params":{"name":"mux_list","arguments":{"engine_name":"missing-test"}}}`)
+	line = readLine(t, clientR)
+	resp = parseResponse(t, line)
+	assertID(t, resp, 65)
+	assertNoError(t, resp)
+	var stale struct {
+		IsError bool `json:"isError"`
+		Content []struct {
+			Text string `json:"text"`
+		} `json:"content"`
+	}
+	unmarshalResult(t, resp, &stale)
+	if !stale.IsError || !strings.Contains(stale.Content[0].Text, "registered muxcore engine is not healthy") {
+		t.Fatalf("stale engine response = %+v", stale)
 	}
 }
 

--- a/internal/mcpserver/server_test.go
+++ b/internal/mcpserver/server_test.go
@@ -1224,6 +1224,49 @@ func TestMuxListWithEngineNameQueriesExactRegisteredEngine(t *testing.T) {
 	}
 }
 
+func TestMuxListWithEngineNameIgnoresStaleDuplicateWhenOneHealthy(t *testing.T) {
+	baseDir := shortBaseDir(t, "mcpmux-scopeddupe-")
+	healthyCtl := filepath.Join(baseDir, "aimux-live-muxd.ctl.sock")
+	staleCtl := filepath.Join(baseDir, "aimux-stale-muxd.ctl.sock")
+
+	startFakeDaemonControlServerWithStatus(t, healthyCtl, map[string]any{
+		"engine_name": "aimux-test",
+		"owner_count": 1,
+	}, control.ListOwnersResponse{Owners: []control.OwnerInfo{{
+		ServerID:   "aimuxlive11223344",
+		EngineName: "aimux-test",
+		Command:    "aimux",
+		Args:       []string{"native"},
+	}}})
+	writeTestEngineDescriptor(t, baseDir, "aimux-test", "Aimux Live", healthyCtl)
+	writeTestEngineDescriptor(t, baseDir, "aimux-test", "Aimux Stale", staleCtl)
+
+	daemonCtlPath := filepath.Join(baseDir, "mcp-mux-muxd.ctl.sock")
+	startFakeDaemonControlServer(t, daemonCtlPath, control.ListOwnersResponse{})
+	clientW, clientR, _ := newTestServerFull(t, daemonCtlPath, baseDir)
+	defer clientW.Close()
+
+	sendLine(t, clientW, `{"jsonrpc":"2.0","id":66,"method":"tools/call","params":{"name":"mux_list","arguments":{"engine_name":"aimux-test","all":true}}}`)
+	line := readLine(t, clientR)
+	resp := parseResponse(t, line)
+	assertID(t, resp, 66)
+	assertNoError(t, resp)
+
+	var result struct {
+		IsError bool `json:"isError"`
+		Content []struct {
+			Text string `json:"text"`
+		} `json:"content"`
+	}
+	unmarshalResult(t, resp, &result)
+	if result.IsError {
+		t.Fatalf("scoped mux_list should ignore stale duplicate when one healthy descriptor remains: %+v", result.Content)
+	}
+	if text := result.Content[0].Text; !strings.Contains(text, "aimuxlive11223344") {
+		t.Fatalf("scoped mux_list missing live owner: %s", text)
+	}
+}
+
 func TestMuxListWithEngineNameRejectsUnknownAndStale(t *testing.T) {
 	baseDir := shortBaseDir(t, "mcpmux-scopederr-")
 	missingCtl := filepath.Join(baseDir, "missing-muxd.ctl.sock")

--- a/muxcore/README.md
+++ b/muxcore/README.md
@@ -136,7 +136,33 @@ Every muxcore consumer should satisfy this checklist before shipping.
    your own control socket unless you are in client/proxy mode or an external
    operator process.
 
-10. **Provide a real update strategy.**
+10. **Opt into daemon registry advertisement only when wanted.**
+    `engine.Config.Registry` is nil by default, so non-adopting consumers do
+    not publish descriptors and remain invisible to `mcp-mux serve`
+    cross-engine discovery. If you want central read-only visibility, pass a
+    `registry.Config`:
+
+    ```go
+    import "github.com/thebtf/mcp-mux/muxcore/registry"
+
+    eng, err := engine.New(engine.Config{
+        Name:           "aimux",
+        SessionHandler: handler,
+        Registry: &registry.Config{
+            ProductName:    "aimux",
+            MuxcoreVersion: "vX.Y.Z",
+            Capabilities:   registry.Capabilities{ListOwners: true},
+        },
+    })
+    ```
+
+    The daemon writes a descriptor after its control socket is bound. Descriptor
+    fields include `engine_name`, `product_name`, `pid`, `base_dir`,
+    `daemon_control_path`, `started_at`, `muxcore_version`, and
+    `capabilities`. The descriptor is advisory: readers must call daemon
+    `status` and verify the returned `engine_name` before trusting it.
+
+11. **Provide a real update strategy.**
     Muxcore can restart daemons and reattach owners, but your product must
     choose how new executable bytes become the next daemon. On Windows the
     configured executable is exactly the file most likely to be held by live
@@ -439,6 +465,13 @@ Avoid these integration patterns:
   successor is selected by an active-engine pointer.
 - Reporting update success without checking `UpdateAndRestartResult` or the
   `UpdateAndRestartError.Phase` and partial `Result`.
+- Scanning temp sockets such as `*-muxd.ctl.sock` as a fake global registry.
+  Use opt-in descriptors and verify them with daemon `status`.
+- Treating default `mcp-mux serve` / `mux_list` as a global view of native
+  muxcore products. Default `mux_list` is the current `mcp-mux` namespace.
+- Exposing cross-engine stop/restart/update in CR-001. The registry's first
+  management capability is read-only `list_owners`; mutating management needs a
+  later explicit capability policy.
 
 ## Integration Verification
 
@@ -463,10 +496,11 @@ Then run a customer-mode smoke through the same entrypoint your MCP host uses:
    reconnect counters. SessionHandler hot updates should show refresh-based
    reconnect (`shim_reconnect_refreshed > 0`) without fallback spawn or give-up.
 6. Verify native muxcore products through their own MCP/CLI health and update
-   surfaces. `mcp-mux serve` / `mux_list` observes the `mcp-mux` daemon
-   namespace; it is not a generic registry for `aimux`, `engram`, or other
-   native muxcore daemons unless those products explicitly opt into such a
-   registry.
+   surfaces. Non-adopters remain invisible to cross-engine discovery. Opt-in
+   consumers should additionally verify `mux_engines` shows a healthy row and
+   `mux_list(engine_name="...")` lists only that engine after status
+   verification. Default `mux_list` still observes the current `mcp-mux` daemon
+   namespace.
 
 ## Stable Operator Status Contract
 

--- a/muxcore/README.md
+++ b/muxcore/README.md
@@ -160,7 +160,10 @@ Every muxcore consumer should satisfy this checklist before shipping.
     fields include `engine_name`, `product_name`, `pid`, `base_dir`,
     `daemon_control_path`, `started_at`, `muxcore_version`, and
     `capabilities`. The descriptor is advisory: readers must call daemon
-    `status` and verify the returned `engine_name` before trusting it.
+    `status` and verify the returned `engine_name` before trusting it. The
+    native daemon and the operator tool reading descriptors must use the same
+    `BaseDir` or both rely on the default temp dir; otherwise discovery is
+    intentionally empty.
 
 11. **Provide a real update strategy.**
     Muxcore can restart daemons and reattach owners, but your product must

--- a/muxcore/daemon/daemon.go
+++ b/muxcore/daemon/daemon.go
@@ -25,6 +25,7 @@ import (
 	muxcore "github.com/thebtf/mcp-mux/muxcore"
 	"github.com/thebtf/mcp-mux/muxcore/control"
 	"github.com/thebtf/mcp-mux/muxcore/owner"
+	"github.com/thebtf/mcp-mux/muxcore/registry"
 	"github.com/thebtf/mcp-mux/muxcore/serverid"
 	"github.com/thebtf/mcp-mux/muxcore/session"
 	mcpsnapshot "github.com/thebtf/mcp-mux/muxcore/snapshot"
@@ -326,6 +327,10 @@ type Config struct {
 	// managed by this daemon are treated as persistent (not evicted on idle).
 	Persistent bool
 
+	// Registry enables opt-in daemon advertisement for cross-engine discovery.
+	// Nil is the zero-value opt-out and preserves pre-registry behavior.
+	Registry *registry.Config
+
 	// AuthorizeSession, when non-nil, is forwarded to every Owner created by
 	// this daemon. Owners invoke the callback in acceptLoop after IPC
 	// handshake / peer-credential extraction and before AddSession.
@@ -468,6 +473,18 @@ func New(cfg Config) (*Daemon, error) {
 			if restored := d.loadSnapshot(); restored > 0 {
 				logger.Printf("startup: restored %d owners from snapshot", restored)
 			}
+		}
+	}
+
+	if cfg.Registry != nil {
+		baseDir := filepath.Dir(cfg.ControlPath)
+		desc := cfg.Registry.Descriptor(d.name, baseDir, cfg.ControlPath, os.Getpid(), time.Now())
+		if _, err := registry.WriteDescriptor(baseDir, desc); err != nil {
+			if d.ctlSrv != nil {
+				d.ctlSrv.Close()
+			}
+			supCancel()
+			return nil, fmt.Errorf("daemon: registry descriptor: %w", err)
 		}
 	}
 

--- a/muxcore/daemon/daemon.go
+++ b/muxcore/daemon/daemon.go
@@ -223,6 +223,7 @@ type Daemon struct {
 	reconnectRefreshed         atomic.Uint64
 	reconnectFallbackSpawned   atomic.Uint64
 	reconnectGaveUp            atomic.Uint64
+	registryDescriptorPath     string
 	restoredOwnerCount         atomic.Uint64
 	oldOwnerSocketRetiredCount atomic.Uint64
 	ownerRemoval               ownerRemovalStats
@@ -478,14 +479,16 @@ func New(cfg Config) (*Daemon, error) {
 
 	if cfg.Registry != nil {
 		baseDir := filepath.Dir(cfg.ControlPath)
-		desc := cfg.Registry.Descriptor(d.name, baseDir, cfg.ControlPath, os.Getpid(), time.Now())
-		if _, err := registry.WriteDescriptor(baseDir, desc); err != nil {
+		desc := cfg.Registry.BuildDescriptor(d.name, baseDir, cfg.ControlPath, os.Getpid(), time.Now())
+		path, err := registry.WriteDescriptor(baseDir, desc)
+		if err != nil {
 			if d.ctlSrv != nil {
 				d.ctlSrv.Close()
 			}
 			supCancel()
 			return nil, fmt.Errorf("daemon: registry descriptor: %w", err)
 		}
+		d.registryDescriptorPath = path
 	}
 
 	// Clean up stale socket files from previous daemon crashes/kills.
@@ -2473,6 +2476,11 @@ func (d *Daemon) shutdown(beforeDone func()) {
 		// Close control server
 		if d.ctlSrv != nil {
 			d.ctlSrv.Close()
+		}
+		if d.registryDescriptorPath != "" {
+			if err := os.Remove(d.registryDescriptorPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+				d.logger.Printf("registry: remove descriptor %s: %v", d.registryDescriptorPath, err)
+			}
 		}
 
 		// Shutdown all owners

--- a/muxcore/daemon/daemon_test.go
+++ b/muxcore/daemon/daemon_test.go
@@ -137,6 +137,15 @@ func TestRegistryOptInWritesDescriptorAfterControlBind(t *testing.T) {
 	if verified.State != registry.StateHealthy || !verified.Reachable {
 		t.Fatalf("VerifyDescriptor = %+v, want healthy reachable", verified)
 	}
+
+	d.Shutdown()
+	records, err = registry.ListDescriptors(baseDir)
+	if err != nil {
+		t.Fatalf("ListDescriptors after Shutdown: %v", err)
+	}
+	if len(records) != 0 {
+		t.Fatalf("clean Shutdown left registry descriptors: %+v", records)
+	}
 }
 
 type noopSessionHandler struct{}

--- a/muxcore/daemon/daemon_test.go
+++ b/muxcore/daemon/daemon_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/thebtf/mcp-mux/muxcore/control"
 	"github.com/thebtf/mcp-mux/muxcore/ipc"
 	"github.com/thebtf/mcp-mux/muxcore/owner"
+	"github.com/thebtf/mcp-mux/muxcore/registry"
 	"github.com/thebtf/mcp-mux/muxcore/serverid"
 )
 
@@ -58,6 +59,84 @@ func testDaemon(t *testing.T) *Daemon {
 	}
 	t.Cleanup(func() { d.Shutdown() })
 	return d
+}
+
+func TestRegistryNilConfigWritesNoDescriptor(t *testing.T) {
+	baseDir, err := os.MkdirTemp("", "rd*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(baseDir) })
+
+	d, err := New(Config{
+		Name:         "regnil",
+		ControlPath:  filepath.Join(baseDir, "regnil.ctl.sock"),
+		SkipSnapshot: true,
+		Logger:       testLogger(t),
+	})
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	t.Cleanup(func() { d.Shutdown() })
+
+	records, err := registry.ListDescriptors(baseDir)
+	if err != nil {
+		t.Fatalf("ListDescriptors: %v", err)
+	}
+	if len(records) != 0 {
+		t.Fatalf("nil Registry wrote descriptors: %+v", records)
+	}
+}
+
+func TestRegistryOptInWritesDescriptorAfterControlBind(t *testing.T) {
+	baseDir, err := os.MkdirTemp("", "rd*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(baseDir) })
+
+	ctlPath := filepath.Join(baseDir, "regok.ctl.sock")
+	d, err := New(Config{
+		Name:         "regok",
+		ControlPath:  ctlPath,
+		SkipSnapshot: true,
+		Logger:       testLogger(t),
+		Registry: &registry.Config{
+			ProductName:    "Registry Test Product",
+			MuxcoreVersion: "test-version",
+			Capabilities:   registry.Capabilities{ListOwners: true},
+		},
+	})
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	t.Cleanup(func() { d.Shutdown() })
+
+	records, err := registry.ListDescriptors(baseDir)
+	if err != nil {
+		t.Fatalf("ListDescriptors: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("registry descriptors = %d, want 1: %+v", len(records), records)
+	}
+	rec := records[0]
+	if rec.Err != nil {
+		t.Fatalf("descriptor parse error: %v", rec.Err)
+	}
+	if rec.Descriptor.EngineName != "regok" {
+		t.Fatalf("engine_name = %q, want regok", rec.Descriptor.EngineName)
+	}
+	if rec.Descriptor.ProductName != "Registry Test Product" {
+		t.Fatalf("product_name = %q", rec.Descriptor.ProductName)
+	}
+	if rec.Descriptor.DaemonControlPath != ctlPath {
+		t.Fatalf("control path = %q, want %q", rec.Descriptor.DaemonControlPath, ctlPath)
+	}
+
+	verified := registry.VerifyDescriptor(rec)
+	if verified.State != registry.StateHealthy || !verified.Reachable {
+		t.Fatalf("VerifyDescriptor = %+v, want healthy reachable", verified)
+	}
 }
 
 type noopSessionHandler struct{}

--- a/muxcore/engine/engine.go
+++ b/muxcore/engine/engine.go
@@ -18,6 +18,7 @@ import (
 	"github.com/thebtf/mcp-mux/muxcore/control"
 	"github.com/thebtf/mcp-mux/muxcore/daemon"
 	"github.com/thebtf/mcp-mux/muxcore/owner"
+	"github.com/thebtf/mcp-mux/muxcore/registry"
 	"github.com/thebtf/mcp-mux/muxcore/serverid"
 )
 
@@ -127,6 +128,10 @@ type Config struct {
 	// Persistent means the daemon stays alive even with zero sessions.
 	// Useful for servers that maintain long-running state (like aimux).
 	Persistent bool
+
+	// Registry enables opt-in daemon advertisement for cross-engine discovery.
+	// Nil is the zero-value opt-out and preserves pre-registry behavior.
+	Registry *registry.Config
 
 	// BaseDir overrides os.TempDir() for socket file locations.
 	// Empty string = use system temp dir.
@@ -361,6 +366,7 @@ func (e *MuxEngine) runDaemon(ctx context.Context) error {
 		DaemonFlag:       e.cfg.DaemonFlag,
 		Name:             e.cfg.Name,
 		Persistent:       e.cfg.Persistent,
+		Registry:         e.cfg.Registry,
 		AuthorizeSession: e.cfg.AuthorizeSession,
 		OnFrameReceived:  e.cfg.OnFrameReceived,
 	})

--- a/muxcore/engine/engine_test.go
+++ b/muxcore/engine/engine_test.go
@@ -15,6 +15,7 @@ import (
 	muxcore "github.com/thebtf/mcp-mux/muxcore"
 	"github.com/thebtf/mcp-mux/muxcore/control"
 	"github.com/thebtf/mcp-mux/muxcore/owner"
+	"github.com/thebtf/mcp-mux/muxcore/registry"
 	"github.com/thebtf/mcp-mux/muxcore/serverid"
 )
 
@@ -943,6 +944,80 @@ func TestEngine_DaemonModeExposesDaemon(t *testing.T) {
 	// After shutdown, Daemon() must be nil (deferred reset in runDaemon).
 	if d := eng.Daemon(); d != nil {
 		t.Error("Daemon() != nil after Run() returned — deferred reset failed")
+	}
+}
+
+func TestEngineRegistryConfigPropagatesToDaemon(t *testing.T) {
+	const testFlag = "--test-daemon-registry-propagation"
+
+	baseDir, err := os.MkdirTemp("", "er*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(baseDir) })
+
+	eng, err := New(Config{
+		Name:           "er",
+		SessionHandler: noopSessionHandler{},
+		BaseDir:        baseDir,
+		DaemonFlag:     testFlag,
+		IdleTimeout:    2 * time.Second,
+		SkipSnapshot:   true,
+		Registry: &registry.Config{
+			ProductName:    "Engine Registry Test",
+			MuxcoreVersion: "test-version",
+			Capabilities:   registry.Capabilities{ListOwners: true},
+		},
+	})
+	if err != nil {
+		t.Fatalf("New() unexpected error: %v", err)
+	}
+
+	origArgs := os.Args
+	os.Args = append(os.Args, testFlag)
+	defer func() { os.Args = origArgs }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runErr := make(chan error, 1)
+	go func() { runErr <- eng.Run(ctx) }()
+
+	select {
+	case <-eng.Ready():
+	case err := <-runErr:
+		t.Fatalf("Run() returned before Ready(): %v", err)
+	case <-time.After(5 * time.Second):
+		cancel()
+		t.Fatal("Ready() did not fire within 5s")
+	}
+
+	records, err := registry.ListDescriptors(baseDir)
+	if err != nil {
+		cancel()
+		t.Fatalf("ListDescriptors: %v", err)
+	}
+	if len(records) != 1 {
+		cancel()
+		t.Fatalf("registry descriptors = %d, want 1: %+v", len(records), records)
+	}
+	rec := records[0]
+	if rec.Err != nil {
+		cancel()
+		t.Fatalf("descriptor parse error: %v", rec.Err)
+	}
+	if rec.Descriptor.EngineName != "er" {
+		cancel()
+		t.Fatalf("engine_name = %q, want er", rec.Descriptor.EngineName)
+	}
+	if rec.Descriptor.DaemonControlPath != serverid.DaemonControlPath(baseDir, "er") {
+		cancel()
+		t.Fatalf("control path = %q, want %q", rec.Descriptor.DaemonControlPath, serverid.DaemonControlPath(baseDir, "er"))
+	}
+
+	cancel()
+	select {
+	case <-runErr:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run() did not return within 5s after cancel")
 	}
 }
 

--- a/muxcore/registry/registry.go
+++ b/muxcore/registry/registry.go
@@ -1,0 +1,368 @@
+// Package registry provides an opt-in descriptor registry for native muxcore
+// daemons. Descriptors are advisory: callers must verify the advertised daemon
+// over its control socket before trusting owner or lifecycle state.
+package registry
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/thebtf/mcp-mux/muxcore/control"
+)
+
+const (
+	SchemaVersion = 1
+
+	StateHealthy   = "healthy"
+	StateStale     = "stale"
+	StateInvalid   = "invalid"
+	StateDuplicate = "duplicate"
+
+	registryDirName = "muxcore-daemon-registry"
+)
+
+var (
+	ErrInvalidDescriptor = errors.New("registry: invalid descriptor")
+	ErrEngineNotFound    = errors.New("registry: engine not found")
+	ErrDuplicateEngine   = errors.New("registry: duplicate engine name")
+)
+
+// Capabilities advertises read-only and future management capabilities exposed
+// by a daemon. CR-001 uses ListOwners only; mutating fields are reserved for
+// later opt-in CRs.
+type Capabilities struct {
+	ListOwners bool `json:"list_owners"`
+	Stop       bool `json:"stop,omitempty"`
+	Restart    bool `json:"restart,omitempty"`
+	Update     bool `json:"update,omitempty"`
+}
+
+// Config enables daemon advertisement when passed through engine.Config or
+// daemon.Config. A nil *Config is the opt-out zero value.
+type Config struct {
+	ProductName    string
+	MuxcoreVersion string
+	Capabilities   Capabilities
+}
+
+// Descriptor is a single daemon advertisement. It is intentionally small and
+// stable JSON so agent-facing tools can render it without product-specific code.
+type Descriptor struct {
+	SchemaVersion     int          `json:"schema_version"`
+	EngineName        string       `json:"engine_name"`
+	ProductName       string       `json:"product_name,omitempty"`
+	PID               int          `json:"pid"`
+	BaseDir           string       `json:"base_dir,omitempty"`
+	DaemonControlPath string       `json:"daemon_control_path"`
+	StartedAt         time.Time    `json:"started_at"`
+	MuxcoreVersion    string       `json:"muxcore_version,omitempty"`
+	Capabilities      Capabilities `json:"capabilities"`
+}
+
+// Descriptor builds the runtime descriptor for one daemon process.
+func (cfg Config) Descriptor(engineName, baseDir, controlPath string, pid int, startedAt time.Time) Descriptor {
+	caps := cfg.Capabilities
+	if !caps.ListOwners && !caps.Stop && !caps.Restart && !caps.Update {
+		caps.ListOwners = true
+	}
+	return Descriptor{
+		SchemaVersion:     SchemaVersion,
+		EngineName:        engineName,
+		ProductName:       cfg.ProductName,
+		PID:               pid,
+		BaseDir:           baseDir,
+		DaemonControlPath: controlPath,
+		StartedAt:         startedAt.UTC(),
+		MuxcoreVersion:    cfg.MuxcoreVersion,
+		Capabilities:      caps,
+	}
+}
+
+// Record is a registry file plus the parsed descriptor when parsing succeeded.
+// Invalid records are returned so operator tools can label stale/malformed
+// entries instead of silently pretending the registry is clean.
+type Record struct {
+	Path       string
+	Descriptor Descriptor
+	Err        error
+}
+
+// VerifiedDescriptor is the result of checking a descriptor through the
+// daemon's status control RPC.
+type VerifiedDescriptor struct {
+	Record           Record
+	State            string
+	Reachable        bool
+	Reason           string
+	StatusEngineName string
+	PID              int
+	DaemonGeneration string
+	OwnerCount       int
+}
+
+type SendFunc func(socketPath string, req control.Request) (*control.Response, error)
+
+// Dir returns the registry directory under the muxcore base dir. Empty baseDir
+// follows the same convention as sockets: os.TempDir().
+func Dir(baseDir string) string {
+	if baseDir == "" {
+		baseDir = os.TempDir()
+	}
+	return filepath.Join(baseDir, registryDirName)
+}
+
+// DescriptorPath returns the deterministic file path for a descriptor. The
+// engine name is human-readable in the file name; the hash keeps entries unique
+// when two descriptors claim the same engine name but point at different
+// control sockets.
+func DescriptorPath(baseDir string, d Descriptor) (string, error) {
+	if err := validateDescriptor(d); err != nil {
+		return "", err
+	}
+	hash := sha256.Sum256([]byte(d.EngineName + "\x00" + d.DaemonControlPath))
+	suffix := hex.EncodeToString(hash[:])[:12]
+	return filepath.Join(Dir(baseDir), fmt.Sprintf("%s-%s.json", safeName(d.EngineName), suffix)), nil
+}
+
+// WriteDescriptor writes or replaces this daemon's descriptor. The replacement
+// is best-effort atomic through a temp file and rename; descriptors are
+// advisory and are re-verified by readers.
+func WriteDescriptor(baseDir string, d Descriptor) (string, error) {
+	if d.SchemaVersion == 0 {
+		d.SchemaVersion = SchemaVersion
+	}
+	if err := validateDescriptor(d); err != nil {
+		return "", err
+	}
+	path, err := DescriptorPath(baseDir, d)
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return "", fmt.Errorf("registry: create dir: %w", err)
+	}
+	data, err := json.MarshalIndent(d, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("registry: marshal descriptor: %w", err)
+	}
+	data = append(data, '\n')
+
+	tmp := fmt.Sprintf("%s.tmp.%d", path, os.Getpid())
+	defer os.Remove(tmp)
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return "", fmt.Errorf("registry: write temp descriptor: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		// Some platforms are stricter about replacing an existing file. This is
+		// this daemon's own deterministic descriptor path, not a foreign cleanup.
+		if removeErr := os.Remove(path); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+			return "", fmt.Errorf("registry: replace descriptor: %w", err)
+		}
+		if retryErr := os.Rename(tmp, path); retryErr != nil {
+			return "", fmt.Errorf("registry: replace descriptor: %w", retryErr)
+		}
+	}
+	return path, nil
+}
+
+// ReadDescriptor reads and validates a descriptor file.
+func ReadDescriptor(path string) (Descriptor, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Descriptor{}, fmt.Errorf("registry: read descriptor: %w", err)
+	}
+	var d Descriptor
+	if err := json.Unmarshal(data, &d); err != nil {
+		return Descriptor{}, fmt.Errorf("%w: parse %s: %v", ErrInvalidDescriptor, path, err)
+	}
+	if err := validateDescriptor(d); err != nil {
+		return Descriptor{}, err
+	}
+	return d, nil
+}
+
+// ListDescriptors reads every registry descriptor file. A missing registry dir
+// is an empty registry, not an error.
+func ListDescriptors(baseDir string) ([]Record, error) {
+	dir := Dir(baseDir)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("registry: list descriptors: %w", err)
+	}
+	records := make([]Record, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		d, err := ReadDescriptor(path)
+		records = append(records, Record{Path: path, Descriptor: d, Err: err})
+	}
+	sort.Slice(records, func(i, j int) bool {
+		return records[i].Path < records[j].Path
+	})
+	return records, nil
+}
+
+// DuplicateEngineNames returns exact engine names claimed by more than one
+// valid descriptor record.
+func DuplicateEngineNames(records []Record) map[string]int {
+	counts := make(map[string]int)
+	for _, rec := range records {
+		if rec.Err != nil {
+			continue
+		}
+		name := rec.Descriptor.EngineName
+		if name != "" {
+			counts[name]++
+		}
+	}
+	dups := make(map[string]int)
+	for name, count := range counts {
+		if count > 1 {
+			dups[name] = count
+		}
+	}
+	return dups
+}
+
+// ResolveEngine returns exactly one valid descriptor for engineName.
+func ResolveEngine(records []Record, engineName string) (Record, error) {
+	var matches []Record
+	for _, rec := range records {
+		if rec.Err != nil {
+			continue
+		}
+		if rec.Descriptor.EngineName == engineName {
+			matches = append(matches, rec)
+		}
+	}
+	switch len(matches) {
+	case 0:
+		return Record{}, ErrEngineNotFound
+	case 1:
+		return matches[0], nil
+	default:
+		return Record{}, ErrDuplicateEngine
+	}
+}
+
+// VerifyDescriptor verifies a descriptor with the default control client.
+func VerifyDescriptor(rec Record) VerifiedDescriptor {
+	return VerifyDescriptorWithSender(rec, control.Send)
+}
+
+// VerifyDescriptorWithSender verifies a descriptor by calling status on its
+// advertised control path and checking that status.engine_name matches.
+func VerifyDescriptorWithSender(rec Record, send SendFunc) VerifiedDescriptor {
+	out := VerifiedDescriptor{Record: rec}
+	if rec.Err != nil {
+		out.State = StateInvalid
+		out.Reason = rec.Err.Error()
+		return out
+	}
+	if err := validateDescriptor(rec.Descriptor); err != nil {
+		out.State = StateInvalid
+		out.Reason = err.Error()
+		return out
+	}
+	resp, err := send(rec.Descriptor.DaemonControlPath, control.Request{Cmd: "status"})
+	if err != nil {
+		out.State = StateStale
+		out.Reason = fmt.Sprintf("control_unreachable: %v", err)
+		return out
+	}
+	if resp == nil {
+		out.State = StateStale
+		out.Reason = "status_nil_response"
+		return out
+	}
+	if !resp.OK {
+		out.State = StateStale
+		if resp.Message != "" {
+			out.Reason = "status_not_ok: " + resp.Message
+		} else {
+			out.Reason = "status_not_ok"
+		}
+		return out
+	}
+	var status map[string]any
+	if err := json.Unmarshal(resp.Data, &status); err != nil {
+		out.State = StateStale
+		out.Reason = fmt.Sprintf("status_parse_error: %v", err)
+		return out
+	}
+	engineName, _ := status["engine_name"].(string)
+	out.StatusEngineName = engineName
+	out.PID = intFromStatus(status["pid"])
+	out.OwnerCount = intFromStatus(status["owner_count"])
+	if generation, _ := status["daemon_generation"].(string); generation != "" {
+		out.DaemonGeneration = generation
+	}
+	if engineName != rec.Descriptor.EngineName {
+		out.State = StateStale
+		out.Reason = fmt.Sprintf("engine_name_mismatch: descriptor=%q status=%q", rec.Descriptor.EngineName, engineName)
+		return out
+	}
+	out.State = StateHealthy
+	out.Reachable = true
+	return out
+}
+
+func validateDescriptor(d Descriptor) error {
+	if d.SchemaVersion != 0 && d.SchemaVersion != SchemaVersion {
+		return fmt.Errorf("%w: unsupported schema_version %d", ErrInvalidDescriptor, d.SchemaVersion)
+	}
+	if strings.TrimSpace(d.EngineName) == "" {
+		return fmt.Errorf("%w: engine_name is required", ErrInvalidDescriptor)
+	}
+	if strings.TrimSpace(d.DaemonControlPath) == "" {
+		return fmt.Errorf("%w: daemon_control_path is required", ErrInvalidDescriptor)
+	}
+	return nil
+}
+
+func safeName(name string) string {
+	var b strings.Builder
+	for _, r := range strings.TrimSpace(name) {
+		switch {
+		case unicode.IsLetter(r), unicode.IsDigit(r), r == '.', r == '_', r == '-':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('-')
+		}
+	}
+	out := strings.Trim(b.String(), "-.")
+	if out == "" {
+		return "engine"
+	}
+	return out
+}
+
+func intFromStatus(v any) int {
+	switch n := v.(type) {
+	case int:
+		return n
+	case int64:
+		return int(n)
+	case float64:
+		return int(n)
+	case json.Number:
+		i, _ := n.Int64()
+		return int(i)
+	default:
+		return 0
+	}
+}

--- a/muxcore/registry/registry.go
+++ b/muxcore/registry/registry.go
@@ -47,11 +47,15 @@ type Capabilities struct {
 }
 
 // Config enables daemon advertisement when passed through engine.Config or
-// daemon.Config. A nil *Config is the opt-out zero value.
+// daemon.Config. A nil *Config is the opt-out zero value. Readers discover
+// descriptors only in their muxcore base dir, so native products and operator
+// tools must share BaseDir (or both use the default os.TempDir()).
 type Config struct {
 	ProductName    string
 	MuxcoreVersion string
-	Capabilities   Capabilities
+	// Capabilities defaults to ListOwners when left empty so an advertised
+	// daemon is useful for CR-001 read-only discovery.
+	Capabilities Capabilities
 }
 
 // Descriptor is a single daemon advertisement. It is intentionally small and
@@ -68,8 +72,8 @@ type Descriptor struct {
 	Capabilities      Capabilities `json:"capabilities"`
 }
 
-// Descriptor builds the runtime descriptor for one daemon process.
-func (cfg Config) Descriptor(engineName, baseDir, controlPath string, pid int, startedAt time.Time) Descriptor {
+// BuildDescriptor builds the runtime descriptor for one daemon process.
+func (cfg Config) BuildDescriptor(engineName, baseDir, controlPath string, pid int, startedAt time.Time) Descriptor {
 	caps := cfg.Capabilities
 	if !caps.ListOwners && !caps.Stop && !caps.Restart && !caps.Update {
 		caps.ListOwners = true
@@ -125,6 +129,9 @@ func Dir(baseDir string) string {
 // when two descriptors claim the same engine name but point at different
 // control sockets.
 func DescriptorPath(baseDir string, d Descriptor) (string, error) {
+	if d.SchemaVersion == 0 {
+		d.SchemaVersion = SchemaVersion
+	}
 	if err := validateDescriptor(d); err != nil {
 		return "", err
 	}
@@ -156,16 +163,24 @@ func WriteDescriptor(baseDir string, d Descriptor) (string, error) {
 	}
 	data = append(data, '\n')
 
-	tmp := fmt.Sprintf("%s.tmp.%d", path, os.Getpid())
+	tmpFile, err := os.CreateTemp(filepath.Dir(path), safeName(d.EngineName)+"-*.tmp")
+	if err != nil {
+		return "", fmt.Errorf("registry: create temp descriptor: %w", err)
+	}
+	tmp := tmpFile.Name()
 	defer os.Remove(tmp)
-	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+	if _, err := tmpFile.Write(data); err != nil {
+		_ = tmpFile.Close()
 		return "", fmt.Errorf("registry: write temp descriptor: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		return "", fmt.Errorf("registry: close temp descriptor: %w", err)
 	}
 	if err := os.Rename(tmp, path); err != nil {
 		// Some platforms are stricter about replacing an existing file. This is
 		// this daemon's own deterministic descriptor path, not a foreign cleanup.
 		if removeErr := os.Remove(path); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
-			return "", fmt.Errorf("registry: replace descriptor: %w", err)
+			return "", fmt.Errorf("registry: replace descriptor: remove existing: %w (original rename: %v)", removeErr, err)
 		}
 		if retryErr := os.Rename(tmp, path); retryErr != nil {
 			return "", fmt.Errorf("registry: replace descriptor: %w", retryErr)
@@ -298,6 +313,11 @@ func VerifyDescriptorWithSender(rec Record, send SendFunc) VerifiedDescriptor {
 		}
 		return out
 	}
+	if len(resp.Data) == 0 {
+		out.State = StateStale
+		out.Reason = "status_empty_response_data"
+		return out
+	}
 	var status map[string]any
 	if err := json.Unmarshal(resp.Data, &status); err != nil {
 		out.State = StateStale
@@ -322,7 +342,7 @@ func VerifyDescriptorWithSender(rec Record, send SendFunc) VerifiedDescriptor {
 }
 
 func validateDescriptor(d Descriptor) error {
-	if d.SchemaVersion != 0 && d.SchemaVersion != SchemaVersion {
+	if d.SchemaVersion != SchemaVersion {
 		return fmt.Errorf("%w: unsupported schema_version %d", ErrInvalidDescriptor, d.SchemaVersion)
 	}
 	if strings.TrimSpace(d.EngineName) == "" {

--- a/muxcore/registry/registry_test.go
+++ b/muxcore/registry/registry_test.go
@@ -1,0 +1,196 @@
+package registry
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/thebtf/mcp-mux/muxcore/control"
+)
+
+func testDescriptor(name, controlPath string) Descriptor {
+	return Descriptor{
+		SchemaVersion:     SchemaVersion,
+		EngineName:        name,
+		ProductName:       name + " product",
+		PID:               1234,
+		BaseDir:           filepath.Dir(controlPath),
+		DaemonControlPath: controlPath,
+		StartedAt:         time.Unix(1700000000, 0).UTC(),
+		MuxcoreVersion:    "test",
+		Capabilities:      Capabilities{ListOwners: true},
+	}
+}
+
+func TestDescriptorPathStableSafeAndUniqueByControlPath(t *testing.T) {
+	base := t.TempDir()
+	d1 := testDescriptor("aimux/native", filepath.Join(base, "aimux-one.sock"))
+	d2 := testDescriptor("aimux/native", filepath.Join(base, "aimux-two.sock"))
+
+	p1, err := DescriptorPath(base, d1)
+	if err != nil {
+		t.Fatalf("DescriptorPath d1: %v", err)
+	}
+	p1Again, err := DescriptorPath(base, d1)
+	if err != nil {
+		t.Fatalf("DescriptorPath d1 again: %v", err)
+	}
+	p2, err := DescriptorPath(base, d2)
+	if err != nil {
+		t.Fatalf("DescriptorPath d2: %v", err)
+	}
+
+	if p1 != p1Again {
+		t.Fatalf("path is not stable: %q != %q", p1, p1Again)
+	}
+	if p1 == p2 {
+		t.Fatalf("different control paths produced same descriptor path: %q", p1)
+	}
+	if filepath.Dir(p1) != Dir(base) {
+		t.Fatalf("descriptor dir = %q, want %q", filepath.Dir(p1), Dir(base))
+	}
+	if strings.Contains(filepath.Base(p1), "/") || strings.Contains(filepath.Base(p1), "\\") {
+		t.Fatalf("descriptor filename contains path separator: %q", filepath.Base(p1))
+	}
+}
+
+func TestWriteReadListDescriptorsRoundTrip(t *testing.T) {
+	base := t.TempDir()
+	want := testDescriptor("aimux", filepath.Join(base, "aimux.sock"))
+
+	path, err := WriteDescriptor(base, want)
+	if err != nil {
+		t.Fatalf("WriteDescriptor: %v", err)
+	}
+	got, err := ReadDescriptor(path)
+	if err != nil {
+		t.Fatalf("ReadDescriptor: %v", err)
+	}
+	if got.EngineName != want.EngineName || got.DaemonControlPath != want.DaemonControlPath || !got.Capabilities.ListOwners {
+		t.Fatalf("descriptor roundtrip mismatch: got %+v want %+v", got, want)
+	}
+
+	records, err := ListDescriptors(base)
+	if err != nil {
+		t.Fatalf("ListDescriptors: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("ListDescriptors returned %d records, want 1: %+v", len(records), records)
+	}
+	if records[0].Err != nil {
+		t.Fatalf("record has unexpected parse error: %v", records[0].Err)
+	}
+	if records[0].Path != path {
+		t.Fatalf("record path = %q, want %q", records[0].Path, path)
+	}
+}
+
+func TestListDescriptorsReturnsMalformedRecords(t *testing.T) {
+	base := t.TempDir()
+	if err := os.MkdirAll(Dir(base), 0o700); err != nil {
+		t.Fatalf("mkdir registry dir: %v", err)
+	}
+	badPath := filepath.Join(Dir(base), "bad.json")
+	if err := os.WriteFile(badPath, []byte("{not-json"), 0o600); err != nil {
+		t.Fatalf("write malformed descriptor: %v", err)
+	}
+
+	records, err := ListDescriptors(base)
+	if err != nil {
+		t.Fatalf("ListDescriptors: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("records = %d, want 1", len(records))
+	}
+	if records[0].Err == nil {
+		t.Fatalf("malformed descriptor did not return an error record")
+	}
+	verified := VerifyDescriptorWithSender(records[0], func(string, control.Request) (*control.Response, error) {
+		t.Fatal("sender should not be called for malformed descriptor")
+		return nil, nil
+	})
+	if verified.State != StateInvalid {
+		t.Fatalf("state = %q, want %q", verified.State, StateInvalid)
+	}
+}
+
+func TestDuplicateEngineNamesAndResolveEngine(t *testing.T) {
+	base := t.TempDir()
+	d1 := testDescriptor("aimux", filepath.Join(base, "one.sock"))
+	d2 := testDescriptor("aimux", filepath.Join(base, "two.sock"))
+	if _, err := WriteDescriptor(base, d1); err != nil {
+		t.Fatalf("WriteDescriptor d1: %v", err)
+	}
+	if _, err := WriteDescriptor(base, d2); err != nil {
+		t.Fatalf("WriteDescriptor d2: %v", err)
+	}
+	records, err := ListDescriptors(base)
+	if err != nil {
+		t.Fatalf("ListDescriptors: %v", err)
+	}
+	dups := DuplicateEngineNames(records)
+	if dups["aimux"] != 2 {
+		t.Fatalf("duplicate count = %v, want aimux=2", dups)
+	}
+	if _, err := ResolveEngine(records, "aimux"); !errors.Is(err, ErrDuplicateEngine) {
+		t.Fatalf("ResolveEngine duplicate err = %v, want ErrDuplicateEngine", err)
+	}
+	if _, err := ResolveEngine(records, "engram"); !errors.Is(err, ErrEngineNotFound) {
+		t.Fatalf("ResolveEngine missing err = %v, want ErrEngineNotFound", err)
+	}
+}
+
+func TestVerifyDescriptorStatusMismatchAndHealthy(t *testing.T) {
+	base := t.TempDir()
+	rec := Record{
+		Path:       "aimux.json",
+		Descriptor: testDescriptor("aimux", filepath.Join(base, "aimux.sock")),
+	}
+
+	statusData := func(engineName string) json.RawMessage {
+		data, err := json.Marshal(map[string]any{
+			"engine_name":       engineName,
+			"pid":               4321,
+			"daemon_generation": "daemon-test",
+			"owner_count":       7,
+		})
+		if err != nil {
+			t.Fatalf("marshal status: %v", err)
+		}
+		return data
+	}
+
+	mismatch := VerifyDescriptorWithSender(rec, func(path string, req control.Request) (*control.Response, error) {
+		if path != rec.Descriptor.DaemonControlPath || req.Cmd != "status" {
+			t.Fatalf("unexpected verify request path=%q req=%+v", path, req)
+		}
+		return &control.Response{OK: true, Data: statusData("engram")}, nil
+	})
+	if mismatch.State != StateStale || !strings.Contains(mismatch.Reason, "engine_name_mismatch") {
+		t.Fatalf("mismatch verify = %+v, want stale engine mismatch", mismatch)
+	}
+
+	healthy := VerifyDescriptorWithSender(rec, func(string, control.Request) (*control.Response, error) {
+		return &control.Response{OK: true, Data: statusData("aimux")}, nil
+	})
+	if healthy.State != StateHealthy || !healthy.Reachable {
+		t.Fatalf("healthy verify = %+v, want healthy reachable", healthy)
+	}
+	if healthy.PID != 4321 || healthy.OwnerCount != 7 || healthy.DaemonGeneration != "daemon-test" {
+		t.Fatalf("healthy status fields = %+v", healthy)
+	}
+}
+
+func TestVerifyDescriptorUnreachableIsStale(t *testing.T) {
+	rec := Record{Descriptor: testDescriptor("aimux", "missing.sock")}
+	verified := VerifyDescriptorWithSender(rec, func(string, control.Request) (*control.Response, error) {
+		return nil, errors.New("dial failed")
+	})
+	if verified.State != StateStale || !strings.Contains(verified.Reason, "control_unreachable") {
+		t.Fatalf("verify = %+v, want stale unreachable", verified)
+	}
+}

--- a/muxcore/registry/registry_test.go
+++ b/muxcore/registry/registry_test.go
@@ -118,6 +118,21 @@ func TestListDescriptorsReturnsMalformedRecords(t *testing.T) {
 	}
 }
 
+func TestReadDescriptorRejectsSchemaVersionZero(t *testing.T) {
+	base := t.TempDir()
+	if err := os.MkdirAll(Dir(base), 0o700); err != nil {
+		t.Fatalf("mkdir registry dir: %v", err)
+	}
+	path := filepath.Join(Dir(base), "schema-zero.json")
+	if err := os.WriteFile(path, []byte(`{"schema_version":0,"engine_name":"aimux","daemon_control_path":"aimux.sock"}`), 0o600); err != nil {
+		t.Fatalf("write schema-zero descriptor: %v", err)
+	}
+
+	if _, err := ReadDescriptor(path); !errors.Is(err, ErrInvalidDescriptor) {
+		t.Fatalf("ReadDescriptor error = %v, want ErrInvalidDescriptor", err)
+	}
+}
+
 func TestDuplicateEngineNamesAndResolveEngine(t *testing.T) {
 	base := t.TempDir()
 	d1 := testDescriptor("aimux", filepath.Join(base, "one.sock"))
@@ -192,5 +207,15 @@ func TestVerifyDescriptorUnreachableIsStale(t *testing.T) {
 	})
 	if verified.State != StateStale || !strings.Contains(verified.Reason, "control_unreachable") {
 		t.Fatalf("verify = %+v, want stale unreachable", verified)
+	}
+}
+
+func TestVerifyDescriptorEmptyStatusDataIsStale(t *testing.T) {
+	rec := Record{Descriptor: testDescriptor("aimux", "empty-status.sock")}
+	verified := VerifyDescriptorWithSender(rec, func(string, control.Request) (*control.Response, error) {
+		return &control.Response{OK: true}, nil
+	})
+	if verified.State != StateStale || verified.Reason != "status_empty_response_data" {
+		t.Fatalf("verify = %+v, want stale empty response data", verified)
 	}
 }


### PR DESCRIPTION
## Summary
- add `muxcore/registry` opt-in descriptor package with advisory descriptor read/write/list/verify helpers
- add additive `engine.Config.Registry` / `daemon.Config.Registry` advertisement wiring
- expose `mux_engines` and explicit `mux_list(engine_name=...)` while preserving default `mux_list` namespace isolation
- document CR-001 read-only boundary and native consumer adoption protocol

## Non-scope
- no cross-engine stop/restart/update
- no aimux or engram repo edits

## Verification
- `Push-Location muxcore; go test ./registry -count=1; Pop-Location`
- `Push-Location muxcore; go test ./engine ./daemon -run "Registry|Advertise|Descriptor" -count=1; Pop-Location`
- `go test ./internal/mcpserver -run "MuxEngines|MuxList|CrossEngine" -count=1`
- `Push-Location muxcore; go test ./... -count=1; Pop-Location`
- `go test ./... -count=1`
- `git diff --check`