### PR TITLE
Fix registry descriptor ownership checks

### DIFF
--- a/internal/mcpserver/server_test.go
+++ b/internal/mcpserver/server_test.go
@@ -1033,7 +1033,7 @@ func TestMuxEnginesListsHealthyAndStaleDescriptors(t *testing.T) {
 
 	startFakeDaemonControlServerWithStatus(t, healthyCtl, map[string]any{
 		"engine_name":       "aimux-test",
-		"pid":               4321,
+		"pid":               1234,
 		"daemon_generation": "daemon-aimux",
 		"owner_count":       2,
 	}, control.ListOwnersResponse{})
@@ -1141,6 +1141,7 @@ func TestMuxListDefaultIgnoresRegisteredForeignEngines(t *testing.T) {
 	foreignCtl := filepath.Join(baseDir, "aimux-muxd.ctl.sock")
 	startFakeDaemonControlServerWithStatus(t, foreignCtl, map[string]any{
 		"engine_name": "aimux-test",
+		"pid":         1234,
 		"owner_count": 1,
 	}, control.ListOwnersResponse{Owners: []control.OwnerInfo{{
 		ServerID: "foreign0011223344",
@@ -1186,6 +1187,7 @@ func TestMuxListWithEngineNameQueriesExactRegisteredEngine(t *testing.T) {
 	foreignCtl := filepath.Join(baseDir, "aimux-muxd.ctl.sock")
 	startFakeDaemonControlServerWithStatus(t, foreignCtl, map[string]any{
 		"engine_name": "aimux-test",
+		"pid":         1234,
 		"owner_count": 1,
 	}, control.ListOwnersResponse{Owners: []control.OwnerInfo{{
 		ServerID:   "aimux001122334455",
@@ -1231,6 +1233,7 @@ func TestMuxListWithEngineNameIgnoresStaleDuplicateWhenOneHealthy(t *testing.T) 
 
 	startFakeDaemonControlServerWithStatus(t, healthyCtl, map[string]any{
 		"engine_name": "aimux-test",
+		"pid":         1234,
 		"owner_count": 1,
 	}, control.ListOwnersResponse{Owners: []control.OwnerInfo{{
 		ServerID:   "aimuxlive11223344",

--- a/muxcore/daemon/daemon.go
+++ b/muxcore/daemon/daemon.go
@@ -224,6 +224,7 @@ type Daemon struct {
 	reconnectFallbackSpawned   atomic.Uint64
 	reconnectGaveUp            atomic.Uint64
 	registryDescriptorPath     string
+	registryDescriptor         registry.Descriptor
 	restoredOwnerCount         atomic.Uint64
 	oldOwnerSocketRetiredCount atomic.Uint64
 	ownerRemoval               ownerRemovalStats
@@ -489,6 +490,7 @@ func New(cfg Config) (*Daemon, error) {
 			return nil, fmt.Errorf("daemon: registry descriptor: %w", err)
 		}
 		d.registryDescriptorPath = path
+		d.registryDescriptor = desc
 	}
 
 	// Clean up stale socket files from previous daemon crashes/kills.
@@ -2478,7 +2480,7 @@ func (d *Daemon) shutdown(beforeDone func()) {
 			d.ctlSrv.Close()
 		}
 		if d.registryDescriptorPath != "" {
-			if err := os.Remove(d.registryDescriptorPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			if _, err := registry.RemoveDescriptorIfOwned(d.registryDescriptorPath, d.registryDescriptor); err != nil {
 				d.logger.Printf("registry: remove descriptor %s: %v", d.registryDescriptorPath, err)
 			}
 		}

--- a/muxcore/daemon/daemon_test.go
+++ b/muxcore/daemon/daemon_test.go
@@ -148,6 +148,56 @@ func TestRegistryOptInWritesDescriptorAfterControlBind(t *testing.T) {
 	}
 }
 
+func TestRegistryShutdownDoesNotRemoveSuccessorDescriptor(t *testing.T) {
+	baseDir, err := os.MkdirTemp("", "rd*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(baseDir) })
+
+	ctlPath := filepath.Join(baseDir, "regok.ctl.sock")
+	d, err := New(Config{
+		Name:         "regok",
+		ControlPath:  ctlPath,
+		SkipSnapshot: true,
+		Logger:       testLogger(t),
+		Registry: &registry.Config{
+			ProductName:    "Registry Test Product",
+			MuxcoreVersion: "test-version",
+			Capabilities:   registry.Capabilities{ListOwners: true},
+		},
+	})
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	t.Cleanup(func() { d.Shutdown() })
+
+	records, err := registry.ListDescriptors(baseDir)
+	if err != nil {
+		t.Fatalf("ListDescriptors: %v", err)
+	}
+	if len(records) != 1 || records[0].Err != nil {
+		t.Fatalf("registry descriptors = %+v, want one valid descriptor", records)
+	}
+	path := records[0].Path
+	successor := records[0].Descriptor
+	successor.PID++
+	if successorPath, err := registry.WriteDescriptor(baseDir, successor); err != nil {
+		t.Fatalf("WriteDescriptor successor: %v", err)
+	} else if successorPath != path {
+		t.Fatalf("successor descriptor path = %q, want %q", successorPath, path)
+	}
+
+	d.Shutdown()
+	got, err := registry.ReadDescriptor(path)
+	if err != nil {
+		t.Fatalf("successor descriptor was removed by predecessor shutdown: %v", err)
+	}
+	if got.PID != successor.PID {
+		t.Fatalf("descriptor PID = %d, want successor PID %d", got.PID, successor.PID)
+	}
+}
+
 type noopSessionHandler struct{}
 
 func (noopSessionHandler) HandleRequest(context.Context, muxcore.ProjectContext, []byte) ([]byte, error) {

--- a/muxcore/registry/registry.go
+++ b/muxcore/registry/registry.go
@@ -189,6 +189,33 @@ func WriteDescriptor(baseDir string, d Descriptor) (string, error) {
 	return path, nil
 }
 
+// RemoveDescriptorIfOwned removes path only when the descriptor currently on
+// disk still belongs to the expected daemon process. It intentionally refuses
+// to remove descriptors with a different PID so a predecessor cannot erase a
+// successor advertisement that reused the same deterministic descriptor path.
+func RemoveDescriptorIfOwned(path string, expected Descriptor) (bool, error) {
+	current, err := ReadDescriptor(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+	if current.EngineName != expected.EngineName ||
+		current.DaemonControlPath != expected.DaemonControlPath ||
+		current.PID == 0 ||
+		current.PID != expected.PID {
+		return false, nil
+	}
+	if err := os.Remove(path); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
 // ReadDescriptor reads and validates a descriptor file.
 func ReadDescriptor(path string) (Descriptor, error) {
 	data, err := os.ReadFile(path)
@@ -334,6 +361,11 @@ func VerifyDescriptorWithSender(rec Record, send SendFunc) VerifiedDescriptor {
 	if engineName != rec.Descriptor.EngineName {
 		out.State = StateStale
 		out.Reason = fmt.Sprintf("engine_name_mismatch: descriptor=%q status=%q", rec.Descriptor.EngineName, engineName)
+		return out
+	}
+	if rec.Descriptor.PID != 0 && out.PID != rec.Descriptor.PID {
+		out.State = StateStale
+		out.Reason = fmt.Sprintf("pid_mismatch: descriptor=%d status=%d", rec.Descriptor.PID, out.PID)
 		return out
 	}
 	out.State = StateHealthy

--- a/muxcore/registry/registry_test.go
+++ b/muxcore/registry/registry_test.go
@@ -166,10 +166,10 @@ func TestVerifyDescriptorStatusMismatchAndHealthy(t *testing.T) {
 		Descriptor: testDescriptor("aimux", filepath.Join(base, "aimux.sock")),
 	}
 
-	statusData := func(engineName string) json.RawMessage {
+	statusData := func(engineName string, pid int) json.RawMessage {
 		data, err := json.Marshal(map[string]any{
 			"engine_name":       engineName,
-			"pid":               4321,
+			"pid":               pid,
 			"daemon_generation": "daemon-test",
 			"owner_count":       7,
 		})
@@ -183,20 +183,71 @@ func TestVerifyDescriptorStatusMismatchAndHealthy(t *testing.T) {
 		if path != rec.Descriptor.DaemonControlPath || req.Cmd != "status" {
 			t.Fatalf("unexpected verify request path=%q req=%+v", path, req)
 		}
-		return &control.Response{OK: true, Data: statusData("engram")}, nil
+		return &control.Response{OK: true, Data: statusData("engram", rec.Descriptor.PID)}, nil
 	})
 	if mismatch.State != StateStale || !strings.Contains(mismatch.Reason, "engine_name_mismatch") {
 		t.Fatalf("mismatch verify = %+v, want stale engine mismatch", mismatch)
 	}
 
+	pidMismatch := VerifyDescriptorWithSender(rec, func(string, control.Request) (*control.Response, error) {
+		return &control.Response{OK: true, Data: statusData("aimux", rec.Descriptor.PID+1)}, nil
+	})
+	if pidMismatch.State != StateStale || !strings.Contains(pidMismatch.Reason, "pid_mismatch") {
+		t.Fatalf("pid mismatch verify = %+v, want stale pid mismatch", pidMismatch)
+	}
+
 	healthy := VerifyDescriptorWithSender(rec, func(string, control.Request) (*control.Response, error) {
-		return &control.Response{OK: true, Data: statusData("aimux")}, nil
+		return &control.Response{OK: true, Data: statusData("aimux", rec.Descriptor.PID)}, nil
 	})
 	if healthy.State != StateHealthy || !healthy.Reachable {
 		t.Fatalf("healthy verify = %+v, want healthy reachable", healthy)
 	}
-	if healthy.PID != 4321 || healthy.OwnerCount != 7 || healthy.DaemonGeneration != "daemon-test" {
+	if healthy.PID != rec.Descriptor.PID || healthy.OwnerCount != 7 || healthy.DaemonGeneration != "daemon-test" {
 		t.Fatalf("healthy status fields = %+v", healthy)
+	}
+}
+
+func TestRemoveDescriptorIfOwnedSkipsSuccessorDescriptor(t *testing.T) {
+	base := t.TempDir()
+	oldDesc := testDescriptor("aimux", filepath.Join(base, "aimux.sock"))
+	oldDesc.PID = 1111
+	path, err := WriteDescriptor(base, oldDesc)
+	if err != nil {
+		t.Fatalf("WriteDescriptor old: %v", err)
+	}
+
+	successor := oldDesc
+	successor.PID = 2222
+	if successorPath, err := WriteDescriptor(base, successor); err != nil {
+		t.Fatalf("WriteDescriptor successor: %v", err)
+	} else if successorPath != path {
+		t.Fatalf("successor descriptor path = %q, want %q", successorPath, path)
+	}
+
+	removed, err := RemoveDescriptorIfOwned(path, oldDesc)
+	if err != nil {
+		t.Fatalf("RemoveDescriptorIfOwned old: %v", err)
+	}
+	if removed {
+		t.Fatal("old descriptor cleanup removed successor descriptor")
+	}
+	got, err := ReadDescriptor(path)
+	if err != nil {
+		t.Fatalf("ReadDescriptor after skipped remove: %v", err)
+	}
+	if got.PID != successor.PID {
+		t.Fatalf("descriptor PID = %d, want successor PID %d", got.PID, successor.PID)
+	}
+
+	removed, err = RemoveDescriptorIfOwned(path, successor)
+	if err != nil {
+		t.Fatalf("RemoveDescriptorIfOwned successor: %v", err)
+	}
+	if !removed {
+		t.Fatal("successor descriptor was not removed by matching cleanup")
+	}
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("descriptor still exists after matching cleanup: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Patch-forward for two PR #128 registry findings found after `v0.26.0` publication:

- Treat a registry descriptor as stale when daemon `status.pid` does not match the descriptor PID.
- Remove a daemon registry descriptor during shutdown only when the descriptor still belongs to the same process, so a predecessor cannot delete a successor advertisement on hot restart.
- Update mcpserver fake registry fixtures to satisfy the new PID invariant.

## Verification

- `Push-Location muxcore; go test ./registry -run "VerifyDescriptor|RemoveDescriptor" -count=1; Pop-Location`
- `Push-Location muxcore; go test ./daemon -run "Registry" -count=1; Pop-Location`
- `go test ./internal/mcpserver -run "MuxEngines|MuxListWithEngineName|DefaultIgnoresRegisteredForeign" -count=1`
- `Push-Location muxcore; go test ./... -count=1; Pop-Location`
- `go test ./... -count=1`
- `go vet ./...`
- `git diff --check`

## Release note

If merged, release as `v0.26.1` / `muxcore/v0.26.1` because `v0.26.0` is already published.