### PR TITLE
Fix restart reconnect and launcher upgrade protocol

### DIFF
--- a/cmd/mcp-mux/daemon.go
+++ b/cmd/mcp-mux/daemon.go
@@ -253,8 +253,10 @@ func startDaemonProcess() error {
 	if err != nil {
 		return fmt.Errorf("resolve executable: %w", err)
 	}
+	daemonExe := daemonExecutableForSpawn(exe)
 
-	cmd := exec.Command(exe, "daemon")
+	cmd := exec.Command(daemonExe, "daemon")
+	cmd.Env = setEnv(os.Environ(), envEngineMode, "1")
 	cmd.Stdout = nil
 	cmd.Stderr = nil
 	cmd.Stdin = nil
@@ -272,6 +274,15 @@ func startDaemonProcess() error {
 	}
 
 	return nil
+}
+
+func daemonExecutableForSpawn(currentExe string) string {
+	if pointerPath := os.Getenv(envActiveEngineFile); pointerPath != "" {
+		if activeExe, ok := resolveActiveEnginePointer(pointerPath); ok && !samePath(activeExe, currentExe) {
+			return activeExe
+		}
+	}
+	return currentExe
 }
 
 // spawnViaDaemon sends a spawn request to the daemon and returns the IPC path and handshake token.
@@ -349,6 +360,8 @@ func refreshTokenViaDaemon(prevToken string, logger *log.Logger) (string, error)
 			return "", daemon.ErrOwnerGone
 		case daemon.ErrUnknownToken.Error():
 			return "", daemon.ErrUnknownToken
+		case daemon.ErrDaemonShuttingDown.Error():
+			return "", daemon.ErrDaemonShuttingDown
 		default:
 			return "", fmt.Errorf("daemon refresh failed: %s", resp.Message)
 		}

--- a/cmd/mcp-mux/daemon.go
+++ b/cmd/mcp-mux/daemon.go
@@ -279,7 +279,9 @@ func startDaemonProcess() error {
 func daemonExecutableForSpawn(currentExe string) string {
 	if pointerPath := os.Getenv(envActiveEngineFile); pointerPath != "" {
 		if activeExe, ok := resolveActiveEnginePointer(pointerPath); ok && !samePath(activeExe, currentExe) {
-			return activeExe
+			if _, err := os.Stat(activeExe); err == nil {
+				return activeExe
+			}
 		}
 	}
 	return currentExe

--- a/cmd/mcp-mux/launcher.go
+++ b/cmd/mcp-mux/launcher.go
@@ -115,7 +115,13 @@ func runLauncherUpgrade(launcherPath string, args []string) int {
 		return 2
 	}
 	if *restartActive != "" {
-		if err := restartDaemonAfterEngineSwitch(launcherPath, filepath.Clean(*restartActive)); err != nil {
+		enginePath, err := filepath.Abs(filepath.Clean(*restartActive))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: daemon restart incomplete: resolve active engine path: %v\n", err)
+			fmt.Fprintln(os.Stderr, "Shims will start the active engine on next reconnect.")
+			return 1
+		}
+		if err := restartDaemonAfterEngineSwitch(launcherPath, enginePath); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: daemon restart incomplete: %v\n", err)
 			fmt.Fprintln(os.Stderr, "Shims will start the active engine on next reconnect.")
 			return 1

--- a/cmd/mcp-mux/launcher.go
+++ b/cmd/mcp-mux/launcher.go
@@ -249,11 +249,9 @@ func removeWithRetry(path string, attempts int, delay time.Duration) error {
 
 func restartDaemonAfterEngineSwitch(launcherPath, enginePath string) error {
 	ctlPath := serverid.DaemonControlPath("", engineName)
-	if !isDaemonRunning(ctlPath) {
-		if err := startDaemonProcessFrom(launcherPath, enginePath); err != nil {
-			return err
-		}
-		return waitForDaemon(ctlPath, 10*time.Second)
+	if !launcherIsDaemonRunning(ctlPath) {
+		fmt.Fprintln(os.Stderr, "No daemon running; active engine will be used by the next shim reconnect.")
+		return nil
 	}
 
 	lockPath := serverid.DaemonLockPath("", engineName)
@@ -298,7 +296,7 @@ func restartDaemonAfterEngineSwitch(launcherPath, enginePath string) error {
 	}
 
 	waitForDaemonExit(ctlPath, "  snapshot written. Waiting for daemon to exit...")
-	if err := waitForDaemon(ctlPath, 10*time.Second); err == nil {
+	if err := launcherWaitForDaemon(ctlPath, 10*time.Second); err == nil {
 		fmt.Fprintln(os.Stderr, "  New daemon ready. Releasing lock — shims will reconnect.")
 		return nil
 	}
@@ -307,10 +305,10 @@ func restartDaemonAfterEngineSwitch(launcherPath, enginePath string) error {
 }
 
 func startDaemonAndWait(launcherPath, enginePath, ctlPath string) error {
-	if err := startDaemonProcessFrom(launcherPath, enginePath); err != nil {
+	if err := launcherStartDaemonProcessFrom(launcherPath, enginePath); err != nil {
 		return err
 	}
-	return waitForDaemon(ctlPath, 10*time.Second)
+	return launcherWaitForDaemon(ctlPath, 10*time.Second)
 }
 
 func startDaemonProcessFrom(launcherPath, enginePath string) error {
@@ -328,6 +326,12 @@ func startDaemonProcessFrom(launcherPath, enginePath string) error {
 	}
 	return nil
 }
+
+var (
+	launcherIsDaemonRunning        = isDaemonRunning
+	launcherWaitForDaemon          = waitForDaemon
+	launcherStartDaemonProcessFrom = startDaemonProcessFrom
+)
 
 func resolveActiveEngine(launcherPath string) (string, bool) {
 	data, err := os.ReadFile(activeEngineFile(launcherPath))

--- a/cmd/mcp-mux/launcher.go
+++ b/cmd/mcp-mux/launcher.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/thebtf/mcp-mux/muxcore/control"
 	"github.com/thebtf/mcp-mux/muxcore/serverid"
+	"github.com/thebtf/mcp-mux/muxcore/upgrade"
 )
 
 const (
@@ -109,12 +110,21 @@ func runLauncherUpgrade(launcherPath string, args []string) int {
 	upgradeFlags := flag.NewFlagSet("upgrade", flag.ContinueOnError)
 	upgradeFlags.SetOutput(os.Stderr)
 	restart := upgradeFlags.Bool("restart", false, "Restart daemon after active engine switch")
+	restartActive := upgradeFlags.String("restart-active", "", "internal: restart daemon after active engine switch")
 	if err := upgradeFlags.Parse(args); err != nil {
 		return 2
 	}
+	if *restartActive != "" {
+		if err := restartDaemonAfterEngineSwitch(launcherPath, filepath.Clean(*restartActive)); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: daemon restart incomplete: %v\n", err)
+			fmt.Fprintln(os.Stderr, "Shims will start the active engine on next reconnect.")
+			return 1
+		}
+		return 0
+	}
 
 	pendingPath := launcherPath + "~"
-	enginePath, installed, err := installVersionedEngine(launcherPath, pendingPath)
+	enginePath, installed, launcherUpdated, err := installVersionedEngine(launcherPath, pendingPath)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		fmt.Fprintln(os.Stderr, "")
@@ -128,9 +138,17 @@ func runLauncherUpgrade(launcherPath string, args []string) int {
 	} else {
 		fmt.Fprintf(os.Stderr, "Engine already installed: %s\n", enginePath)
 	}
+	if launcherUpdated {
+		fmt.Fprintf(os.Stderr, "Updated launcher: %s\n", launcherPath)
+	} else {
+		fmt.Fprintf(os.Stderr, "Launcher already current: %s\n", launcherPath)
+	}
 	fmt.Fprintf(os.Stderr, "Active engine: %s\n", enginePath)
 
 	if *restart {
+		if launcherUpdated {
+			return launcherRunRestartActive(launcherPath, enginePath)
+		}
 		if err := restartDaemonAfterEngineSwitch(launcherPath, enginePath); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: daemon restart incomplete: %v\n", err)
 			fmt.Fprintln(os.Stderr, "Shims will start the active engine on next reconnect.")
@@ -140,17 +158,35 @@ func runLauncherUpgrade(launcherPath string, args []string) int {
 	return 0
 }
 
-func installVersionedEngine(launcherPath, pendingPath string) (enginePath string, installed bool, err error) {
+func runLauncherRestartActive(launcherPath, enginePath string) int {
+	fmt.Fprintln(os.Stderr, "Re-executing updated launcher for daemon restart...")
+	cmd := exec.Command(launcherPath, "upgrade", "--restart-active", enginePath)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return exitErr.ExitCode()
+		}
+		fmt.Fprintf(os.Stderr, "warning: updated launcher restart failed: %v\n", err)
+		fmt.Fprintln(os.Stderr, "Shims will start the active engine on next reconnect.")
+		return 1
+	}
+	return 0
+}
+
+func installVersionedEngine(launcherPath, pendingPath string) (enginePath string, installed bool, launcherUpdated bool, err error) {
 	if _, err := os.Stat(pendingPath); err != nil {
 		if os.IsNotExist(err) {
-			return "", false, fmt.Errorf("no pending update found at %s", pendingPath)
+			return "", false, false, fmt.Errorf("no pending update found at %s", pendingPath)
 		}
-		return "", false, fmt.Errorf("stat pending update: %w", err)
+		return "", false, false, fmt.Errorf("stat pending update: %w", err)
 	}
 
 	hash, err := fileHash(pendingPath)
 	if err != nil {
-		return "", false, fmt.Errorf("hash pending update: %w", err)
+		return "", false, false, fmt.Errorf("hash pending update: %w", err)
 	}
 	versionID := hash
 	if len(versionID) > 12 {
@@ -158,51 +194,40 @@ func installVersionedEngine(launcherPath, pendingPath string) (enginePath string
 	}
 	enginePath = filepath.Join(versionStoreDir(launcherPath), versionID, engineFileName())
 
-	if current, ok := resolveActiveEngine(launcherPath); ok && samePath(current, enginePath) {
-		if sameFile(current, pendingPath) {
-			_ = removeWithRetry(pendingPath, 10, 50*time.Millisecond)
-			return enginePath, false, nil
-		}
-	}
-
 	if err := os.MkdirAll(filepath.Dir(enginePath), 0755); err != nil {
-		return "", false, fmt.Errorf("create version dir: %w", err)
+		return "", false, false, fmt.Errorf("create version dir: %w", err)
 	}
 
 	if _, statErr := os.Stat(enginePath); statErr == nil {
 		if !sameFile(enginePath, pendingPath) {
-			return "", false, fmt.Errorf("version path exists with different content: %s", enginePath)
+			return "", false, false, fmt.Errorf("version path exists with different content: %s", enginePath)
 		}
-		_ = removeWithRetry(pendingPath, 10, 50*time.Millisecond)
 		installed = false
 	} else if os.IsNotExist(statErr) {
-		if err := movePendingEngine(pendingPath, enginePath); err != nil {
-			return "", false, fmt.Errorf("move pending update into version store: %w", err)
+		if err := copyFile(pendingPath, enginePath, 0755); err != nil {
+			return "", false, false, fmt.Errorf("copy pending update into version store: %w", err)
 		}
 		installed = true
 	} else {
-		return "", false, fmt.Errorf("stat version path: %w", statErr)
+		return "", false, false, fmt.Errorf("stat version path: %w", statErr)
+	}
+
+	if sameFile(launcherPath, pendingPath) {
+		_ = removeWithRetry(pendingPath, 10, 50*time.Millisecond)
+	} else {
+		oldPath, swapErr := upgrade.Swap(launcherPath, pendingPath)
+		if swapErr != nil {
+			return "", installed, false, fmt.Errorf("update launcher binary: %w", swapErr)
+		}
+		_ = os.Remove(oldPath)
+		upgrade.CleanStale(launcherPath)
+		launcherUpdated = true
 	}
 
 	if err := writeActiveEngine(launcherPath, enginePath); err != nil {
-		return "", installed, err
+		return "", installed, launcherUpdated, err
 	}
-	return enginePath, installed, nil
-}
-
-func movePendingEngine(src, dst string) error {
-	if err := os.Rename(src, dst); err == nil {
-		return nil
-	}
-	if err := copyFile(src, dst, 0755); err != nil {
-		return err
-	}
-	if !sameFile(src, dst) {
-		_ = os.Remove(dst)
-		return fmt.Errorf("copied engine hash mismatch")
-	}
-	_ = removeWithRetry(src, 10, 50*time.Millisecond)
-	return nil
+	return enginePath, installed, launcherUpdated, nil
 }
 
 func copyFile(src, dst string, perm os.FileMode) error {
@@ -278,30 +303,35 @@ func restartDaemonAfterEngineSwitch(launcherPath, enginePath string) error {
 	}
 
 	fmt.Fprintln(os.Stderr, "Graceful restart: serializing state...")
-	resp, err := control.SendWithTimeout(ctlPath, control.Request{
+	resp, err := launcherControlSendWithTimeout(ctlPath, control.Request{
 		Cmd:            "graceful-restart",
 		DrainTimeoutMs: 30000,
+		SuccessorExe:   enginePath,
 	}, 60*time.Second)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "  graceful-restart not available: %v, falling back to shutdown\n", err)
 		_, _ = control.Send(ctlPath, control.Request{Cmd: "shutdown"})
-		waitForDaemonExit(ctlPath, "  Waiting for old daemon to exit...")
+		launcherWaitForDaemonExit(ctlPath, "  Waiting for old daemon to exit...")
 		return startDaemonAndWait(launcherPath, enginePath, ctlPath)
 	}
 	if !resp.OK {
 		fmt.Fprintf(os.Stderr, "  graceful-restart failed: %s, falling back to shutdown\n", resp.Message)
 		_, _ = control.Send(ctlPath, control.Request{Cmd: "shutdown"})
-		waitForDaemonExit(ctlPath, "  Waiting for old daemon to exit...")
+		launcherWaitForDaemonExit(ctlPath, "  Waiting for old daemon to exit...")
 		return startDaemonAndWait(launcherPath, enginePath, ctlPath)
 	}
 
-	waitForDaemonExit(ctlPath, "  snapshot written. Waiting for daemon to exit...")
+	launcherWaitForDaemonExit(ctlPath, "  snapshot written. Waiting for daemon to exit...")
 	if err := launcherWaitForDaemon(ctlPath, 10*time.Second); err == nil {
 		fmt.Fprintln(os.Stderr, "  New daemon ready. Releasing lock — shims will reconnect.")
 		return nil
 	}
 	fmt.Fprintln(os.Stderr, "  Successor daemon not ready; starting active engine daemon...")
-	return startDaemonAndWait(launcherPath, enginePath, ctlPath)
+	if err := startDaemonAndWait(launcherPath, enginePath, ctlPath); err != nil {
+		return err
+	}
+	fmt.Fprintln(os.Stderr, "  New daemon ready. Releasing lock — shims will reconnect.")
+	return nil
 }
 
 func startDaemonAndWait(launcherPath, enginePath, ctlPath string) error {
@@ -330,11 +360,18 @@ func startDaemonProcessFrom(launcherPath, enginePath string) error {
 var (
 	launcherIsDaemonRunning        = isDaemonRunning
 	launcherWaitForDaemon          = waitForDaemon
+	launcherWaitForDaemonExit      = waitForDaemonExit
 	launcherStartDaemonProcessFrom = startDaemonProcessFrom
+	launcherControlSendWithTimeout = control.SendWithTimeout
+	launcherRunRestartActive       = runLauncherRestartActive
 )
 
 func resolveActiveEngine(launcherPath string) (string, bool) {
-	data, err := os.ReadFile(activeEngineFile(launcherPath))
+	return resolveActiveEnginePointer(activeEngineFile(launcherPath))
+}
+
+func resolveActiveEnginePointer(pointerPath string) (string, bool) {
+	data, err := os.ReadFile(pointerPath)
 	if err != nil {
 		return "", false
 	}
@@ -345,7 +382,7 @@ func resolveActiveEngine(launcherPath string) (string, bool) {
 	if filepath.IsAbs(raw) {
 		return filepath.Clean(raw), true
 	}
-	return filepath.Clean(filepath.Join(versionStoreDir(launcherPath), raw)), true
+	return filepath.Clean(filepath.Join(filepath.Dir(pointerPath), raw)), true
 }
 
 func writeActiveEngine(launcherPath, enginePath string) error {

--- a/cmd/mcp-mux/launcher_test.go
+++ b/cmd/mcp-mux/launcher_test.go
@@ -473,7 +473,7 @@ func TestRunLauncherUpgradeRestartActiveCanonicalizesEnginePath(t *testing.T) {
 	if code := runLauncherUpgrade(launcherPath, []string{"--restart-active", filepath.Join("relative-engine", engineFileName())}); code != 0 {
 		t.Fatalf("runLauncherUpgrade(--restart-active) code = %d, want 0", code)
 	}
-	if gotEnginePath != enginePath {
+	if !samePath(gotEnginePath, enginePath) {
 		t.Fatalf("SuccessorExe = %q, want absolute path %q", gotEnginePath, enginePath)
 	}
 }

--- a/cmd/mcp-mux/launcher_test.go
+++ b/cmd/mcp-mux/launcher_test.go
@@ -7,6 +7,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/thebtf/mcp-mux/muxcore/control"
+	"github.com/thebtf/mcp-mux/muxcore/serverid"
 )
 
 func writeTestFile(t *testing.T, path, content string) {
@@ -19,27 +22,30 @@ func writeTestFile(t *testing.T, path, content string) {
 	}
 }
 
-func TestInstallVersionedEngineDoesNotRenameLauncher(t *testing.T) {
+func TestInstallVersionedEngineUpdatesLauncher(t *testing.T) {
 	dir := t.TempDir()
 	launcherPath := filepath.Join(dir, "mcp-mux.exe")
 	pendingPath := launcherPath + "~"
 	writeTestFile(t, launcherPath, "stable launcher")
 	writeTestFile(t, pendingPath, "engine v1")
 
-	enginePath, installed, err := installVersionedEngine(launcherPath, pendingPath)
+	enginePath, installed, launcherUpdated, err := installVersionedEngine(launcherPath, pendingPath)
 	if err != nil {
 		t.Fatalf("installVersionedEngine() error = %v", err)
 	}
 	if !installed {
 		t.Fatal("installVersionedEngine() installed = false, want true")
 	}
+	if !launcherUpdated {
+		t.Fatal("installVersionedEngine() launcherUpdated = false, want true")
+	}
 
 	launcherBytes, err := os.ReadFile(launcherPath)
 	if err != nil {
 		t.Fatalf("read launcher: %v", err)
 	}
-	if string(launcherBytes) != "stable launcher" {
-		t.Fatalf("launcher content changed to %q", launcherBytes)
+	if string(launcherBytes) != "engine v1" {
+		t.Fatalf("launcher content = %q, want engine v1", launcherBytes)
 	}
 	if _, err := os.Stat(pendingPath); !os.IsNotExist(err) {
 		t.Fatalf("pending path still exists after install: %v", err)
@@ -65,16 +71,16 @@ func TestInstallVersionedEngineSwitchesPointerAndKeepsOldVersion(t *testing.T) {
 	dir := t.TempDir()
 	launcherPath := filepath.Join(dir, "mcp-mux.exe")
 	pendingPath := launcherPath + "~"
-	writeTestFile(t, launcherPath, "stable launcher")
+	writeTestFile(t, launcherPath, "engine v1")
 	writeTestFile(t, pendingPath, "engine v1")
 
-	firstPath, _, err := installVersionedEngine(launcherPath, pendingPath)
+	firstPath, _, _, err := installVersionedEngine(launcherPath, pendingPath)
 	if err != nil {
 		t.Fatalf("first install: %v", err)
 	}
 
 	writeTestFile(t, pendingPath, "engine v2")
-	secondPath, installed, err := installVersionedEngine(launcherPath, pendingPath)
+	secondPath, installed, _, err := installVersionedEngine(launcherPath, pendingPath)
 	if err != nil {
 		t.Fatalf("second install: %v", err)
 	}
@@ -114,6 +120,24 @@ func TestWriteActiveEngineStoresRelativePointer(t *testing.T) {
 	resolved, ok := resolveActiveEngine(launcherPath)
 	if !ok || !samePath(resolved, enginePath) {
 		t.Fatalf("resolved active engine = %q ok=%v, want %q", resolved, ok, enginePath)
+	}
+}
+
+func TestDaemonExecutableForSpawnUsesActiveEnginePointer(t *testing.T) {
+	dir := t.TempDir()
+	launcherPath := filepath.Join(dir, "mcp-mux.exe")
+	oldEnginePath := filepath.Join(versionStoreDir(launcherPath), "old123", engineFileName())
+	activeEnginePath := filepath.Join(versionStoreDir(launcherPath), "new456", engineFileName())
+	writeTestFile(t, oldEnginePath, "old engine")
+	writeTestFile(t, activeEnginePath, "new engine")
+	if err := writeActiveEngine(launcherPath, activeEnginePath); err != nil {
+		t.Fatalf("writeActiveEngine() error = %v", err)
+	}
+	t.Setenv(envActiveEngineFile, activeEngineFile(launcherPath))
+
+	got := daemonExecutableForSpawn(oldEnginePath)
+	if !samePath(got, activeEnginePath) {
+		t.Fatalf("daemonExecutableForSpawn() = %q, want active engine %q", got, activeEnginePath)
 	}
 }
 
@@ -185,11 +209,91 @@ func TestRestartDaemonAfterEngineSwitchNoDaemonIsNoop(t *testing.T) {
 	}
 }
 
+func TestRestartDaemonAfterEngineSwitchSendsSuccessorExe(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("TEMP", dir)
+	t.Setenv("TMP", dir)
+	launcherPath := filepath.Join(dir, "mcp-mux.exe")
+	enginePath := filepath.Join(versionStoreDir(launcherPath), "abc123", engineFileName())
+
+	oldIsDaemonRunning := launcherIsDaemonRunning
+	oldStartDaemonProcessFrom := launcherStartDaemonProcessFrom
+	oldWaitForDaemon := launcherWaitForDaemon
+	oldWaitForDaemonExit := launcherWaitForDaemonExit
+	oldControlSendWithTimeout := launcherControlSendWithTimeout
+	t.Cleanup(func() {
+		launcherIsDaemonRunning = oldIsDaemonRunning
+		launcherStartDaemonProcessFrom = oldStartDaemonProcessFrom
+		launcherWaitForDaemon = oldWaitForDaemon
+		launcherWaitForDaemonExit = oldWaitForDaemonExit
+		launcherControlSendWithTimeout = oldControlSendWithTimeout
+	})
+
+	var gotReq control.Request
+	sendCalled := false
+	exitCalled := false
+	waitCalled := false
+	startCalled := false
+	launcherIsDaemonRunning = func(path string) bool {
+		return path == serverid.DaemonControlPath("", engineName)
+	}
+	launcherControlSendWithTimeout = func(path string, req control.Request, timeout time.Duration) (*control.Response, error) {
+		sendCalled = true
+		gotReq = req
+		if path != serverid.DaemonControlPath("", engineName) {
+			t.Fatalf("control path = %q, want daemon control path", path)
+		}
+		if timeout != 60*time.Second {
+			t.Fatalf("timeout = %s, want 60s", timeout)
+		}
+		return &control.Response{OK: true}, nil
+	}
+	launcherWaitForDaemonExit = func(path, prefix string) {
+		exitCalled = true
+		if path != serverid.DaemonControlPath("", engineName) {
+			t.Fatalf("exit wait path = %q, want daemon control path", path)
+		}
+	}
+	launcherWaitForDaemon = func(path string, timeout time.Duration) error {
+		waitCalled = true
+		return nil
+	}
+	launcherStartDaemonProcessFrom = func(string, string) error {
+		startCalled = true
+		return nil
+	}
+
+	if err := restartDaemonAfterEngineSwitch(launcherPath, enginePath); err != nil {
+		t.Fatalf("restartDaemonAfterEngineSwitch() error = %v, want nil", err)
+	}
+	if !sendCalled {
+		t.Fatal("graceful-restart request was not sent")
+	}
+	if gotReq.Cmd != "graceful-restart" {
+		t.Fatalf("Cmd = %q, want graceful-restart", gotReq.Cmd)
+	}
+	if gotReq.DrainTimeoutMs != 30000 {
+		t.Fatalf("DrainTimeoutMs = %d, want 30000", gotReq.DrainTimeoutMs)
+	}
+	if gotReq.SuccessorExe != enginePath {
+		t.Fatalf("SuccessorExe = %q, want %q", gotReq.SuccessorExe, enginePath)
+	}
+	if !exitCalled {
+		t.Fatal("daemon-exit wait was not called")
+	}
+	if !waitCalled {
+		t.Fatal("successor readiness wait was not called")
+	}
+	if startCalled {
+		t.Fatal("restartDaemonAfterEngineSwitch started fallback daemon despite ready successor")
+	}
+}
+
 func TestRunLauncherUpgradeRestartNoDaemonSucceeds(t *testing.T) {
 	dir := t.TempDir()
 	launcherPath := filepath.Join(dir, "mcp-mux.exe")
 	pendingPath := launcherPath + "~"
-	writeTestFile(t, launcherPath, "stable launcher")
+	writeTestFile(t, launcherPath, "engine v1")
 	writeTestFile(t, pendingPath, "engine v1")
 
 	oldIsDaemonRunning := launcherIsDaemonRunning
@@ -219,5 +323,122 @@ func TestRunLauncherUpgradeRestartNoDaemonSucceeds(t *testing.T) {
 	}
 	if _, ok := resolveActiveEngine(launcherPath); !ok {
 		t.Fatal("active engine pointer was not written")
+	}
+	gotLauncher, err := os.ReadFile(launcherPath)
+	if err != nil {
+		t.Fatalf("read launcher: %v", err)
+	}
+	if string(gotLauncher) != "engine v1" {
+		t.Fatalf("launcher content = %q, want staged binary", gotLauncher)
+	}
+}
+
+func TestRunLauncherUpgradeRestartReexecsUpdatedLauncher(t *testing.T) {
+	dir := t.TempDir()
+	launcherPath := filepath.Join(dir, "mcp-mux.exe")
+	pendingPath := launcherPath + "~"
+	writeTestFile(t, launcherPath, "old launcher")
+	writeTestFile(t, pendingPath, "new launcher and engine")
+
+	oldIsDaemonRunning := launcherIsDaemonRunning
+	oldRunRestartActive := launcherRunRestartActive
+	t.Cleanup(func() {
+		launcherIsDaemonRunning = oldIsDaemonRunning
+		launcherRunRestartActive = oldRunRestartActive
+	})
+
+	reexecCalled := false
+	launcherIsDaemonRunning = func(string) bool {
+		t.Fatal("restart should be delegated to the updated launcher, not run inline")
+		return false
+	}
+	launcherRunRestartActive = func(gotLauncherPath, gotEnginePath string) int {
+		reexecCalled = true
+		if gotLauncherPath != launcherPath {
+			t.Fatalf("launcherPath = %q, want %q", gotLauncherPath, launcherPath)
+		}
+		if !strings.Contains(gotEnginePath, versionStoreDir(launcherPath)) {
+			t.Fatalf("enginePath = %q, want version store path", gotEnginePath)
+		}
+		return 0
+	}
+
+	if code := runLauncherUpgrade(launcherPath, []string{"--restart"}); code != 0 {
+		t.Fatalf("runLauncherUpgrade(--restart) code = %d, want 0", code)
+	}
+	if !reexecCalled {
+		t.Fatal("updated launcher restart was not re-executed")
+	}
+}
+
+func TestRunLauncherUpgradeRestartActiveDoesNotRequirePendingUpdate(t *testing.T) {
+	dir := t.TempDir()
+	launcherPath := filepath.Join(dir, "mcp-mux.exe")
+	enginePath := filepath.Join(versionStoreDir(launcherPath), "abc123", engineFileName())
+	writeTestFile(t, launcherPath, "launcher")
+	writeTestFile(t, enginePath, "engine")
+
+	oldIsDaemonRunning := launcherIsDaemonRunning
+	oldStartDaemonProcessFrom := launcherStartDaemonProcessFrom
+	oldWaitForDaemon := launcherWaitForDaemon
+	t.Cleanup(func() {
+		launcherIsDaemonRunning = oldIsDaemonRunning
+		launcherStartDaemonProcessFrom = oldStartDaemonProcessFrom
+		launcherWaitForDaemon = oldWaitForDaemon
+	})
+
+	launcherIsDaemonRunning = func(string) bool { return false }
+	launcherStartDaemonProcessFrom = func(string, string) error {
+		t.Fatal("--restart-active should not start a daemon when no daemon is running")
+		return nil
+	}
+	launcherWaitForDaemon = func(string, time.Duration) error {
+		t.Fatal("--restart-active should not wait when no daemon is running")
+		return nil
+	}
+
+	if code := runLauncherUpgrade(launcherPath, []string{"--restart-active", enginePath}); code != 0 {
+		t.Fatalf("runLauncherUpgrade(--restart-active) code = %d, want 0", code)
+	}
+}
+
+func TestInstallVersionedEngineUpdatesStaleLauncherWhenEngineAlreadyInstalled(t *testing.T) {
+	dir := t.TempDir()
+	launcherPath := filepath.Join(dir, "mcp-mux.exe")
+	pendingPath := launcherPath + "~"
+	writeTestFile(t, launcherPath, "old launcher")
+	writeTestFile(t, pendingPath, "new engine")
+	hash, err := fileHash(pendingPath)
+	if err != nil {
+		t.Fatalf("fileHash() error = %v", err)
+	}
+	enginePath := filepath.Join(versionStoreDir(launcherPath), hash[:12], engineFileName())
+	writeTestFile(t, enginePath, "new engine")
+	if err := writeActiveEngine(launcherPath, enginePath); err != nil {
+		t.Fatalf("writeActiveEngine() error = %v", err)
+	}
+
+	gotEnginePath, installed, launcherUpdated, err := installVersionedEngine(launcherPath, pendingPath)
+	if err != nil {
+		t.Fatalf("installVersionedEngine() error = %v", err)
+	}
+	if gotEnginePath != enginePath {
+		t.Fatalf("enginePath = %q, want %q", gotEnginePath, enginePath)
+	}
+	if installed {
+		t.Fatal("installed = true, want false for already-installed engine")
+	}
+	if !launcherUpdated {
+		t.Fatal("launcherUpdated = false, want true")
+	}
+	if _, err := os.Stat(pendingPath); !os.IsNotExist(err) {
+		t.Fatalf("pending path still exists after launcher update: %v", err)
+	}
+	gotLauncher, err := os.ReadFile(launcherPath)
+	if err != nil {
+		t.Fatalf("read launcher: %v", err)
+	}
+	if string(gotLauncher) != "new engine" {
+		t.Fatalf("launcher content = %q, want staged binary", gotLauncher)
 	}
 }

--- a/cmd/mcp-mux/launcher_test.go
+++ b/cmd/mcp-mux/launcher_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func writeTestFile(t *testing.T, path, content string) {
@@ -144,5 +145,79 @@ func TestDaemonStartReportsActiveAndFallbackStartFailures(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "start stable launcher fallback") {
 		t.Fatalf("error = %q, want stable launcher fallback context", err)
+	}
+}
+
+func TestRestartDaemonAfterEngineSwitchNoDaemonIsNoop(t *testing.T) {
+	dir := t.TempDir()
+	launcherPath := filepath.Join(dir, "mcp-mux.exe")
+	enginePath := filepath.Join(versionStoreDir(launcherPath), "abc123", engineFileName())
+
+	oldIsDaemonRunning := launcherIsDaemonRunning
+	oldStartDaemonProcessFrom := launcherStartDaemonProcessFrom
+	oldWaitForDaemon := launcherWaitForDaemon
+	t.Cleanup(func() {
+		launcherIsDaemonRunning = oldIsDaemonRunning
+		launcherStartDaemonProcessFrom = oldStartDaemonProcessFrom
+		launcherWaitForDaemon = oldWaitForDaemon
+	})
+
+	startCalled := false
+	waitCalled := false
+	launcherIsDaemonRunning = func(string) bool { return false }
+	launcherStartDaemonProcessFrom = func(string, string) error {
+		startCalled = true
+		return nil
+	}
+	launcherWaitForDaemon = func(string, time.Duration) error {
+		waitCalled = true
+		return nil
+	}
+
+	if err := restartDaemonAfterEngineSwitch(launcherPath, enginePath); err != nil {
+		t.Fatalf("restartDaemonAfterEngineSwitch() error = %v, want nil", err)
+	}
+	if startCalled {
+		t.Fatal("restartDaemonAfterEngineSwitch started a daemon when none was running")
+	}
+	if waitCalled {
+		t.Fatal("restartDaemonAfterEngineSwitch waited for daemon readiness when none was running")
+	}
+}
+
+func TestRunLauncherUpgradeRestartNoDaemonSucceeds(t *testing.T) {
+	dir := t.TempDir()
+	launcherPath := filepath.Join(dir, "mcp-mux.exe")
+	pendingPath := launcherPath + "~"
+	writeTestFile(t, launcherPath, "stable launcher")
+	writeTestFile(t, pendingPath, "engine v1")
+
+	oldIsDaemonRunning := launcherIsDaemonRunning
+	oldStartDaemonProcessFrom := launcherStartDaemonProcessFrom
+	oldWaitForDaemon := launcherWaitForDaemon
+	t.Cleanup(func() {
+		launcherIsDaemonRunning = oldIsDaemonRunning
+		launcherStartDaemonProcessFrom = oldStartDaemonProcessFrom
+		launcherWaitForDaemon = oldWaitForDaemon
+	})
+
+	launcherIsDaemonRunning = func(string) bool { return false }
+	launcherStartDaemonProcessFrom = func(string, string) error {
+		t.Fatal("runLauncherUpgrade started a daemon when none was running")
+		return nil
+	}
+	launcherWaitForDaemon = func(string, time.Duration) error {
+		t.Fatal("runLauncherUpgrade waited for daemon readiness when none was running")
+		return nil
+	}
+
+	if code := runLauncherUpgrade(launcherPath, []string{"--restart"}); code != 0 {
+		t.Fatalf("runLauncherUpgrade(--restart) code = %d, want 0", code)
+	}
+	if _, err := os.Stat(pendingPath); !os.IsNotExist(err) {
+		t.Fatalf("pending path still exists after install: %v", err)
+	}
+	if _, ok := resolveActiveEngine(launcherPath); !ok {
+		t.Fatal("active engine pointer was not written")
 	}
 }

--- a/cmd/mcp-mux/launcher_test.go
+++ b/cmd/mcp-mux/launcher_test.go
@@ -141,6 +141,23 @@ func TestDaemonExecutableForSpawnUsesActiveEnginePointer(t *testing.T) {
 	}
 }
 
+func TestDaemonExecutableForSpawnIgnoresMissingActiveEnginePointer(t *testing.T) {
+	dir := t.TempDir()
+	launcherPath := filepath.Join(dir, "mcp-mux.exe")
+	currentEnginePath := filepath.Join(versionStoreDir(launcherPath), "old123", engineFileName())
+	missingActiveEnginePath := filepath.Join(versionStoreDir(launcherPath), "missing", engineFileName())
+	writeTestFile(t, currentEnginePath, "old engine")
+	if err := writeActiveEngine(launcherPath, missingActiveEnginePath); err != nil {
+		t.Fatalf("writeActiveEngine() error = %v", err)
+	}
+	t.Setenv(envActiveEngineFile, activeEngineFile(launcherPath))
+
+	got := daemonExecutableForSpawn(currentEnginePath)
+	if !samePath(got, currentEnginePath) {
+		t.Fatalf("daemonExecutableForSpawn() = %q, want current engine %q", got, currentEnginePath)
+	}
+}
+
 func TestRunEngineProcessStartFailureFallsBackToLauncher(t *testing.T) {
 	dir := t.TempDir()
 	launcherPath := filepath.Join(dir, "mcp-mux.exe")
@@ -399,6 +416,65 @@ func TestRunLauncherUpgradeRestartActiveDoesNotRequirePendingUpdate(t *testing.T
 
 	if code := runLauncherUpgrade(launcherPath, []string{"--restart-active", enginePath}); code != 0 {
 		t.Fatalf("runLauncherUpgrade(--restart-active) code = %d, want 0", code)
+	}
+}
+
+func TestRunLauncherUpgradeRestartActiveCanonicalizesEnginePath(t *testing.T) {
+	dir := t.TempDir()
+	launcherPath := filepath.Join(dir, "mcp-mux.exe")
+	enginePath := filepath.Join(dir, "relative-engine", engineFileName())
+	writeTestFile(t, launcherPath, "launcher")
+	writeTestFile(t, enginePath, "engine")
+
+	oldRestart := launcherRunRestartActive
+	oldWd, wdErr := os.Getwd()
+	if wdErr != nil {
+		t.Fatalf("Getwd(): %v", wdErr)
+	}
+	t.Cleanup(func() {
+		launcherRunRestartActive = oldRestart
+		if err := os.Chdir(oldWd); err != nil {
+			t.Fatalf("restore cwd: %v", err)
+		}
+	})
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("Chdir(%s): %v", dir, err)
+	}
+
+	var gotEnginePath string
+	launcherRunRestartActive = func(string, string) int {
+		t.Fatal("--restart-active should restart inline, not re-exec")
+		return 1
+	}
+	oldIsDaemonRunning := launcherIsDaemonRunning
+	oldControlSendWithTimeout := launcherControlSendWithTimeout
+	oldWaitForDaemonExit := launcherWaitForDaemonExit
+	oldWaitForDaemon := launcherWaitForDaemon
+	oldStartDaemonProcessFrom := launcherStartDaemonProcessFrom
+	t.Cleanup(func() {
+		launcherIsDaemonRunning = oldIsDaemonRunning
+		launcherControlSendWithTimeout = oldControlSendWithTimeout
+		launcherWaitForDaemonExit = oldWaitForDaemonExit
+		launcherWaitForDaemon = oldWaitForDaemon
+		launcherStartDaemonProcessFrom = oldStartDaemonProcessFrom
+	})
+	launcherIsDaemonRunning = func(string) bool { return true }
+	launcherControlSendWithTimeout = func(_ string, req control.Request, _ time.Duration) (*control.Response, error) {
+		gotEnginePath = req.SuccessorExe
+		return &control.Response{OK: true}, nil
+	}
+	launcherWaitForDaemonExit = func(string, string) {}
+	launcherWaitForDaemon = func(string, time.Duration) error { return nil }
+	launcherStartDaemonProcessFrom = func(string, string) error {
+		t.Fatal("--restart-active should not fallback-start when successor is ready")
+		return nil
+	}
+
+	if code := runLauncherUpgrade(launcherPath, []string{"--restart-active", filepath.Join("relative-engine", engineFileName())}); code != 0 {
+		t.Fatalf("runLauncherUpgrade(--restart-active) code = %d, want 0", code)
+	}
+	if gotEnginePath != enginePath {
+		t.Fatalf("SuccessorExe = %q, want absolute path %q", gotEnginePath, enginePath)
 	}
 }
 

--- a/cmd/mcp-mux/launcher_test.go
+++ b/cmd/mcp-mux/launcher_test.go
@@ -473,7 +473,15 @@ func TestRunLauncherUpgradeRestartActiveCanonicalizesEnginePath(t *testing.T) {
 	if code := runLauncherUpgrade(launcherPath, []string{"--restart-active", filepath.Join("relative-engine", engineFileName())}); code != 0 {
 		t.Fatalf("runLauncherUpgrade(--restart-active) code = %d, want 0", code)
 	}
-	if !samePath(gotEnginePath, enginePath) {
+	gotReal, gotRealErr := filepath.EvalSymlinks(gotEnginePath)
+	if gotRealErr != nil {
+		t.Fatalf("EvalSymlinks(%q): %v", gotEnginePath, gotRealErr)
+	}
+	wantReal, wantRealErr := filepath.EvalSymlinks(enginePath)
+	if wantRealErr != nil {
+		t.Fatalf("EvalSymlinks(%q): %v", enginePath, wantRealErr)
+	}
+	if gotReal != wantReal {
 		t.Fatalf("SuccessorExe = %q, want absolute path %q", gotEnginePath, enginePath)
 	}
 }

--- a/muxcore/daemon/daemon.go
+++ b/muxcore/daemon/daemon.go
@@ -1745,6 +1745,10 @@ func (d *Daemon) afterSnapshotOnlyRestart(successorExe string) func() {
 
 // HandleRefreshSessionToken implements control.DaemonHandler.
 func (d *Daemon) HandleRefreshSessionToken(prevToken string) (string, error) {
+	if d.shuttingDown.Load() {
+		d.logger.Printf("shim.reconnect.refresh_fail reason=daemon_shutting_down")
+		return "", ErrDaemonShuttingDown
+	}
 	if prevToken == "" {
 		d.logger.Printf("shim.reconnect.refresh_fail reason=unknown_token")
 		return "", ErrUnknownToken

--- a/muxcore/daemon/daemon_test.go
+++ b/muxcore/daemon/daemon_test.go
@@ -631,6 +631,16 @@ func TestHandleRefreshSessionToken_UnknownToken(t *testing.T) {
 	}
 }
 
+func TestHandleRefreshSessionToken_ShuttingDownIsTransient(t *testing.T) {
+	d := testDaemon(t)
+	d.shuttingDown.Store(true)
+
+	_, err := d.HandleRefreshSessionToken("missing-token")
+	if !errors.Is(err, ErrDaemonShuttingDown) {
+		t.Fatalf("HandleRefreshSessionToken() error = %v, want ErrDaemonShuttingDown", err)
+	}
+}
+
 func TestHandleRefreshSessionToken_OwnerGone(t *testing.T) {
 	d := testDaemon(t)
 	sid := "owner-refresh-gone"

--- a/muxcore/engine/engine.go
+++ b/muxcore/engine/engine.go
@@ -662,6 +662,8 @@ func refreshTokenViaDaemon(ctlPath, prevToken string, logger *log.Logger) (strin
 			return "", daemon.ErrOwnerGone
 		case daemon.ErrUnknownToken.Error():
 			return "", daemon.ErrUnknownToken
+		case daemon.ErrDaemonShuttingDown.Error():
+			return "", daemon.ErrDaemonShuttingDown
 		default:
 			return "", fmt.Errorf("daemon refresh failed: %s", resp.Message)
 		}

--- a/muxcore/owner/resilient_client.go
+++ b/muxcore/owner/resilient_client.go
@@ -589,6 +589,9 @@ func refreshFailureReason(err error) string {
 	if isUnknownTokenError(err) {
 		return "unknown_token"
 	}
+	if isDaemonShuttingDownError(err) {
+		return "daemon_shutting_down"
+	}
 	return "other"
 }
 
@@ -598,6 +601,10 @@ func isOwnerGoneError(err error) bool {
 
 func isUnknownTokenError(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "unknown token")
+}
+
+func isDaemonShuttingDownError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "daemon shutting down")
 }
 
 // terminalRefreshErrorReason returns a non-empty fallback reason if err is

--- a/muxcore/owner/resilient_client_reconnect_test.go
+++ b/muxcore/owner/resilient_client_reconnect_test.go
@@ -317,6 +317,55 @@ func TestReconnect_ImmediateSpawnOnUnknownToken(t *testing.T) {
 	}
 }
 
+func TestReconnect_RetriesRefreshDuringDaemonShutdown(t *testing.T) {
+	var logs bytes.Buffer
+	logger := log.New(&logs, "", 0)
+	rc := newReconnectClient(t, io.Discard, logger)
+	rc.token = "prev-token"
+
+	refreshPath := tempReconnectSocketPath(t, "aabbccddeeff")
+	srv, _ := startEchoIPCServer(t, refreshPath)
+	defer srv.closeAll()
+
+	stdinDone := make(chan error)
+	refreshCalls := 0
+	reconnectCalls := 0
+	rc.cfg.RefreshToken = func() (string, string, error) {
+		refreshCalls++
+		if refreshCalls == 1 {
+			return "", "", errors.New("daemon shutting down")
+		}
+		return refreshPath, "fresh-token", nil
+	}
+	rc.cfg.Reconnect = func() (string, string, error) {
+		reconnectCalls++
+		return "", "", errors.New("unexpected fallback spawn")
+	}
+
+	conn, err := rc.reconnect(&sync.Mutex{}, stdinDone)
+	if err != nil {
+		t.Fatalf("reconnect() error = %v", err)
+	}
+	defer closeReconnectConn(t, conn)
+
+	if refreshCalls != 2 {
+		t.Fatalf("refreshCalls = %d, want 2", refreshCalls)
+	}
+	if reconnectCalls != 0 {
+		t.Fatalf("reconnectCalls = %d, want 0", reconnectCalls)
+	}
+	if rc.token != "fresh-token" {
+		t.Fatalf("rc.token = %q, want fresh-token", rc.token)
+	}
+	logText := logs.String()
+	if !strings.Contains(logText, "shim.reconnect.refresh_fail reason=daemon_shutting_down") {
+		t.Fatalf("missing transient refresh_fail log, got %q", logText)
+	}
+	if strings.Contains(logText, "shim.reconnect.fallback_spawn") {
+		t.Fatalf("unexpected fallback spawn log, got %q", logText)
+	}
+}
+
 func startGenerationIPCServer(t *testing.T, path, generation string) *echoServer {
 	t.Helper()
 	received := make(chan string, 100)


### PR DESCRIPTION
## Summary
- Treat daemon shutdown token-refresh failures as transient so resilient shims retry against the successor instead of falling back immediately.
- Start daemon replacements from the active engine pointer instead of the stale shim executable.
- Update the stable launcher during versioned-engine upgrades and re-exec the updated launcher for restart-active handling.
- Pass SuccessorExe in launcher-driven graceful restart and report ready after fallback start.

## Verification
- go test ./...
- cd muxcore; go test ./...
- .\\mcp-mux.exe upgrade --restart
- Fresh stdio smoke for pr, time, and socraticode: initialize/tools-list all returned ok.