### PR TITLE
Retry transient Windows named-pipe bind failures

### DIFF
--- a/cmd/mcp-mux/daemon.go
+++ b/cmd/mcp-mux/daemon.go
@@ -13,9 +13,14 @@ import (
 
 	"github.com/thebtf/mcp-mux/muxcore/control"
 	"github.com/thebtf/mcp-mux/muxcore/daemon"
+	"github.com/thebtf/mcp-mux/muxcore/ipc"
 	"github.com/thebtf/mcp-mux/muxcore/rotlog"
 	"github.com/thebtf/mcp-mux/muxcore/serverid"
 )
+
+var daemonStarter = startDaemonProcess
+
+const daemonPingTimeout = 500 * time.Millisecond
 
 // runGlobalDaemon starts the global daemon process. This is invoked via
 // `mcp-mux daemon` subcommand. The daemon manages all upstream MCP servers,
@@ -137,9 +142,21 @@ func ensureDaemonWithin(logger *log.Logger, budget time.Duration) error {
 	// Log lines use key=value with no trailing prose so post-mortem grep/awk
 	// can parse them without surprises.
 	pingStart := time.Now()
-	if isDaemonRunning(ctlPath) {
+	if ok, err := pingDaemon(ctlPath); ok {
 		logger.Printf("ensure_daemon substep=fast_ping status=ok duration=%v",
 			time.Since(pingStart))
+		return nil
+	} else if isOccupiedControlEndpoint(err) {
+		logger.Printf("ensure_daemon substep=fast_ping status=occupied_unresponsive duration=%v err=%q",
+			time.Since(pingStart), err.Error())
+		waitStart := time.Now()
+		if waitErr := waitForDaemon(ctlPath, remainingBudget(deadline, 10*time.Second)); waitErr != nil {
+			logger.Printf("ensure_daemon substep=wait_for_occupied_control status=error duration=%v err=%q",
+				time.Since(waitStart), waitErr.Error())
+			return fmt.Errorf("daemon control endpoint occupied but unresponsive: %w", waitErr)
+		}
+		logger.Printf("ensure_daemon substep=wait_for_occupied_control status=ok duration=%v",
+			time.Since(waitStart))
 		return nil
 	}
 	logger.Printf("ensure_daemon substep=fast_ping status=miss duration=%v",
@@ -177,9 +194,21 @@ func ensureDaemonWithin(logger *log.Logger, budget time.Duration) error {
 
 	// Re-check after acquiring lock (another shim may have started it)
 	recheckStart := time.Now()
-	if isDaemonRunning(ctlPath) {
+	if ok, err := pingDaemon(ctlPath); ok {
 		logger.Printf("ensure_daemon substep=lock_recheck status=already_running duration=%v",
 			time.Since(recheckStart))
+		return nil
+	} else if isOccupiedControlEndpoint(err) {
+		logger.Printf("ensure_daemon substep=lock_recheck status=occupied_unresponsive duration=%v err=%q",
+			time.Since(recheckStart), err.Error())
+		waitStart := time.Now()
+		if waitErr := waitForDaemon(ctlPath, remainingBudget(deadline, 10*time.Second)); waitErr != nil {
+			logger.Printf("ensure_daemon substep=wait_for_occupied_control status=error duration=%v err=%q",
+				time.Since(waitStart), waitErr.Error())
+			return fmt.Errorf("daemon control endpoint occupied but unresponsive: %w", waitErr)
+		}
+		logger.Printf("ensure_daemon substep=wait_for_occupied_control status=ok duration=%v",
+			time.Since(waitStart))
 		return nil
 	}
 	logger.Printf("ensure_daemon substep=lock_recheck status=still_missing duration=%v",
@@ -187,7 +216,7 @@ func ensureDaemonWithin(logger *log.Logger, budget time.Duration) error {
 
 	// Start daemon as detached process
 	spawnStart := time.Now()
-	if err := startDaemonProcess(); err != nil {
+	if err := daemonStarter(); err != nil {
 		logger.Printf("ensure_daemon substep=spawn_process status=error duration=%v err=%q",
 			time.Since(spawnStart), err.Error())
 		return fmt.Errorf("start daemon: %w", err)
@@ -240,11 +269,23 @@ func waitForDaemon(ctlPath string, timeout time.Duration) error {
 
 // isDaemonRunning checks if the daemon control socket responds to ping.
 func isDaemonRunning(ctlPath string) bool {
-	resp, err := control.Send(ctlPath, control.Request{Cmd: "ping"})
+	ok, _ := pingDaemon(ctlPath)
+	return ok
+}
+
+func pingDaemon(ctlPath string) (bool, error) {
+	resp, err := control.SendWithTimeout(ctlPath, control.Request{Cmd: "ping"}, daemonPingTimeout)
 	if err != nil {
+		return false, err
+	}
+	return resp.OK, nil
+}
+
+func isOccupiedControlEndpoint(err error) bool {
+	if err == nil {
 		return false
 	}
-	return resp.OK
+	return ipc.IsEndpointOccupiedError(err)
 }
 
 // startDaemonProcess spawns `mcp-mux daemon` as a detached background process.

--- a/cmd/mcp-mux/daemon_test.go
+++ b/cmd/mcp-mux/daemon_test.go
@@ -6,11 +6,14 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/thebtf/mcp-mux/muxcore/control"
 	"github.com/thebtf/mcp-mux/muxcore/daemon"
+	"github.com/thebtf/mcp-mux/muxcore/ipc"
 	"github.com/thebtf/mcp-mux/muxcore/serverid"
 )
 
@@ -184,5 +187,44 @@ func TestMainIsolatedModeStillUsesDaemon(t *testing.T) {
 	}
 	if strings.Contains(output, "becoming owner") {
 		t.Fatalf("isolated daemon failure started a legacy owner; stderr:\n%s", output)
+	}
+}
+
+func TestEnsureDaemonDoesNotSpawnWhenControlEndpointOccupied(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows named-pipe occupied endpoint behavior")
+	}
+	tempDir := shortTempDir(t, "occ")
+	t.Setenv("TEMP", tempDir)
+	t.Setenv("TMP", tempDir)
+
+	ctlPath := serverid.DaemonControlPath("", engineName)
+	ln, err := ipc.Listen(ctlPath)
+	if err != nil {
+		t.Fatalf("ipc.Listen() error = %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	oldStarter := daemonStarter
+	startCalled := false
+	daemonStarter = func() error {
+		startCalled = true
+		return nil
+	}
+	t.Cleanup(func() { daemonStarter = oldStarter })
+
+	var logs bytes.Buffer
+	err = ensureDaemonWithin(log.New(&logs, "[cmd-test] ", 0), 150*time.Millisecond)
+	if err == nil {
+		t.Fatalf("ensureDaemonWithin() error = nil, want occupied endpoint error; logs:\n%s", logs.String())
+	}
+	if startCalled {
+		t.Fatalf("ensureDaemonWithin started a competing daemon for occupied control endpoint; logs:\n%s", logs.String())
+	}
+	if !strings.Contains(err.Error(), "daemon control endpoint occupied but unresponsive") {
+		t.Fatalf("ensureDaemonWithin() error = %v, want occupied endpoint message; logs:\n%s", err, logs.String())
+	}
+	if !strings.Contains(logs.String(), "status=occupied_unresponsive") {
+		t.Fatalf("logs missing occupied_unresponsive status; logs:\n%s", logs.String())
 	}
 }

--- a/muxcore/ipc/transport.go
+++ b/muxcore/ipc/transport.go
@@ -111,6 +111,13 @@ func IsAvailable(path string) bool {
 	return true
 }
 
+// IsEndpointOccupiedError reports errors that mean an endpoint exists but did
+// not complete a usable client connection. Unix callers rely on socket-file
+// cleanup instead, so no dial error is treated as occupied here.
+func IsEndpointOccupiedError(error) bool {
+	return false
+}
+
 // Cleanup removes the socket file. Called by owner on shutdown.
 func Cleanup(path string) {
 	if IsAvailable(path) {

--- a/muxcore/ipc/transport_windows.go
+++ b/muxcore/ipc/transport_windows.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -21,10 +22,14 @@ const pipeBufferSize = 64 * 1024
 var (
 	staleSocketRemoveAttempts = 40
 	staleSocketRemoveDelay    = 25 * time.Millisecond
+	pipeListenRetryAttempts   = 40
+	pipeListenRetryDelay      = 25 * time.Millisecond
 	pipeListenerCloseTimeout  = 2 * time.Second
 	removeSocketFile          = os.Remove
 	renameSocketFile          = os.Rename
 	sleepBeforeRemoveRetry    = time.Sleep
+	sleepBeforeListenRetry    = time.Sleep
+	listenNamedPipe           = winio.ListenPipe
 )
 
 // Listen creates an IPC listener for path.
@@ -40,11 +45,39 @@ func Listen(path string) (net.Listener, error) {
 	if err != nil {
 		return nil, fmt.Errorf("ipc: build pipe security %s: %w", path, err)
 	}
-	ln, err := winio.ListenPipe(pipeName(path), cfg)
+	ln, err := listenPipeWithRetry(path, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("ipc: listen %s: %w", path, err)
 	}
 	return &pipeListener{Listener: ln, path: path}, nil
+}
+
+func listenPipeWithRetry(path string, cfg *winio.PipeConfig) (net.Listener, error) {
+	attempts := pipeListenRetryAttempts
+	if attempts < 1 {
+		attempts = 1
+	}
+
+	var lastErr error
+	for attempt := 0; attempt < attempts; attempt++ {
+		ln, err := listenNamedPipe(pipeName(path), cfg)
+		if err == nil {
+			return ln, nil
+		}
+		lastErr = err
+		if !isRetryablePipeListenError(err) {
+			return nil, err
+		}
+		if attempt+1 < attempts && pipeListenRetryDelay > 0 {
+			sleepBeforeListenRetry(pipeListenRetryDelay)
+		}
+	}
+	return nil, lastErr
+}
+
+func isRetryablePipeListenError(err error) bool {
+	return errors.Is(err, windows.ERROR_ACCESS_DENIED) ||
+		errors.Is(err, windows.ERROR_PIPE_BUSY)
 }
 
 func pipeConfig() (*winio.PipeConfig, error) {

--- a/muxcore/ipc/transport_windows.go
+++ b/muxcore/ipc/transport_windows.go
@@ -166,6 +166,15 @@ func IsAvailable(path string) bool {
 	return true
 }
 
+// IsEndpointOccupiedError reports errors that mean the named-pipe object
+// exists but did not complete a usable client connection. In that state a
+// caller must not assume the endpoint is free for a competing listener.
+func IsEndpointOccupiedError(err error) bool {
+	return errors.Is(err, syscall.ERROR_ACCESS_DENIED) ||
+		errors.Is(err, windows.ERROR_PIPE_BUSY) ||
+		errors.Is(err, context.DeadlineExceeded)
+}
+
 func Cleanup(path string) {
 	_ = removeSocketFile(path)
 }

--- a/muxcore/ipc/transport_windows.go
+++ b/muxcore/ipc/transport_windows.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/Microsoft/go-winio"
@@ -76,7 +77,7 @@ func listenPipeWithRetry(path string, cfg *winio.PipeConfig) (net.Listener, erro
 }
 
 func isRetryablePipeListenError(err error) bool {
-	return errors.Is(err, windows.ERROR_ACCESS_DENIED) ||
+	return errors.Is(err, syscall.ERROR_ACCESS_DENIED) ||
 		errors.Is(err, windows.ERROR_PIPE_BUSY)
 }
 

--- a/muxcore/ipc/transport_windows_test.go
+++ b/muxcore/ipc/transport_windows_test.go
@@ -3,6 +3,7 @@
 package ipc
 
 import (
+	"context"
 	"net"
 	"os"
 	"os/exec"
@@ -187,7 +188,7 @@ func TestListenRetriesTransientPipeAccessDenied(t *testing.T) {
 			return nil, &os.PathError{
 				Op:   "open",
 				Path: `\\.\pipe\mcp-mux-test`,
-				Err:  windows.ERROR_ACCESS_DENIED,
+				Err:  syscall.ERROR_ACCESS_DENIED,
 			}
 		}
 		return stubListener{}, nil
@@ -204,6 +205,29 @@ func TestListenRetriesTransientPipeAccessDenied(t *testing.T) {
 
 	if calls != 3 {
 		t.Fatalf("listen calls = %d, want 3", calls)
+	}
+}
+
+func TestMissingPipeIsNotOccupiedEndpoint(t *testing.T) {
+	path := socketPath(t)
+	_, err := DialTimeout(path, 25*time.Millisecond)
+	if err == nil {
+		t.Fatal("DialTimeout() error = nil, want missing pipe error")
+	}
+	if IsEndpointOccupiedError(err) {
+		t.Fatalf("IsEndpointOccupiedError(%v) = true, want false for missing pipe", err)
+	}
+}
+
+func TestEndpointOccupiedErrorClassification(t *testing.T) {
+	for name, err := range map[string]error{
+		"access denied":     syscall.ERROR_ACCESS_DENIED,
+		"pipe busy":         windows.ERROR_PIPE_BUSY,
+		"deadline exceeded": context.DeadlineExceeded,
+	} {
+		if !IsEndpointOccupiedError(err) {
+			t.Fatalf("%s: IsEndpointOccupiedError(%v) = false, want true", name, err)
+		}
 	}
 }
 

--- a/muxcore/ipc/transport_windows_test.go
+++ b/muxcore/ipc/transport_windows_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Microsoft/go-winio"
 	"golang.org/x/sys/windows"
 )
 
@@ -167,6 +168,45 @@ func TestPipeListenerCloseTimesOutWhenUnderlyingCloseBlocks(t *testing.T) {
 	}
 }
 
+func TestListenRetriesTransientPipeAccessDenied(t *testing.T) {
+	oldListen := listenNamedPipe
+	oldSleep := sleepBeforeListenRetry
+	oldAttempts := pipeListenRetryAttempts
+	oldDelay := pipeListenRetryDelay
+	t.Cleanup(func() {
+		listenNamedPipe = oldListen
+		sleepBeforeListenRetry = oldSleep
+		pipeListenRetryAttempts = oldAttempts
+		pipeListenRetryDelay = oldDelay
+	})
+
+	calls := 0
+	listenNamedPipe = func(string, *winio.PipeConfig) (net.Listener, error) {
+		calls++
+		if calls < 3 {
+			return nil, &os.PathError{
+				Op:   "open",
+				Path: `\\.\pipe\mcp-mux-test`,
+				Err:  windows.ERROR_ACCESS_DENIED,
+			}
+		}
+		return stubListener{}, nil
+	}
+	sleepBeforeListenRetry = func(time.Duration) {}
+	pipeListenRetryAttempts = 5
+	pipeListenRetryDelay = time.Millisecond
+
+	ln, err := Listen(socketPath(t))
+	if err != nil {
+		t.Fatalf("Listen() error = %v, want retry success", err)
+	}
+	ln.Close()
+
+	if calls != 3 {
+		t.Fatalf("listen calls = %d, want 3", calls)
+	}
+}
+
 func TestDetachedProcessListenerHelper(t *testing.T) {
 	if os.Getenv("MUXCORE_IPC_TEST_HELPER") != "1" {
 		return
@@ -223,6 +263,12 @@ type testAddr string
 
 func (a testAddr) Network() string { return "test" }
 func (a testAddr) String() string  { return string(a) }
+
+type stubListener struct{}
+
+func (stubListener) Accept() (net.Conn, error) { return nil, net.ErrClosed }
+func (stubListener) Close() error              { return nil }
+func (stubListener) Addr() net.Addr            { return testAddr("stub-listener") }
 
 func waitForFile(t *testing.T, path string, timeout time.Duration) {
 	t.Helper()


### PR DESCRIPTION
## Summary
- retry Windows `winio.ListenPipe` bind when a just-closed or competing named pipe reports transient `ERROR_ACCESS_DENIED` / `ERROR_PIPE_BUSY`
- keep non-retryable listen errors immediate
- add a Windows regression test for transient access-denied bind recovery

## Evidence
- `go test ./ipc -run "TestListenRetriesTransientPipeAccessDenied|TestListen_RefusesWhenAlreadyActive|TestDialMayStartBeforeAccept" -count=1` from `muxcore`
- `go test ./ipc -count=1` from `muxcore`
- `go test ./... -count=1` from `muxcore`
- `go test ./... -count=1` from repo root
- local patched `mcp-mux.exe upgrade --restart` completed with `New daemon ready`
- fresh stdio smoke through patched `mcp-mux.exe` passed `initialize` + `tools/list` for `pr`, `time`, and `socraticode`

## Notes
This is the small follow-up CR for the Windows readiness false-negative observed after the v0.26.3 restart/reconnect release. It does not change the Unix socket path.