### PR TITLE
Reduce muxcore owner fanout after startup storms

### DIFF
--- a/muxcore/daemon/daemon.go
+++ b/muxcore/daemon/daemon.go
@@ -2211,9 +2211,11 @@ func mergeEnv(shimEnv map[string]string) map[string]string {
 	return merged
 }
 
-// envCompatible returns true if two env maps have no conflicting values
-// for semantically significant keys (API tokens, config paths, etc.).
-// Transient per-session vars (CLAUDE_CODE_*, WT_SESSION, etc.) are ignored.
+// envCompatible returns true if two env maps have no conflicting values for
+// keys that affect upstream process identity (credentials, config paths/URLs,
+// proxies, etc.). Ordinary launch noise (PATH, temp dirs, shell metadata, host
+// session IDs) is ignored so global-first sharing does not fragment into one
+// owner per MCP host session.
 //
 // Credential-bearing keys (GITHUB_TOKEN, OPENAI_API_KEY, anything matching
 // envCredentialKey()) additionally MUST match by presence: if a key exists
@@ -2226,6 +2228,9 @@ func mergeEnv(shimEnv map[string]string) map[string]string {
 func envCompatible(a, b map[string]string) bool {
 	for k, va := range a {
 		if envTransient(k) {
+			continue
+		}
+		if !envIdentityKey(k) {
 			continue
 		}
 		vb, ok := b[k]
@@ -2243,6 +2248,9 @@ func envCompatible(a, b map[string]string) bool {
 	// must also split. The loop over a alone cannot see keys unique to b.
 	for k := range b {
 		if envTransient(k) {
+			continue
+		}
+		if !envIdentityKey(k) {
 			continue
 		}
 		if _, ok := a[k]; ok {
@@ -2302,6 +2310,48 @@ func envCredentialKey(key string) bool {
 	return false
 }
 
+// envIdentityKey returns true for env vars that should partition a global
+// owner. This intentionally stays narrower than "all non-transient vars":
+// hashing PATH/TEMP/HOME-style noise recreates the process fan-out that
+// global-first identity is meant to eliminate. Unknown credential-like keys
+// remain identity keys via envCredentialKey; non-secret configuration keys use
+// conservative suffix/exact matches.
+func envIdentityKey(key string) bool {
+	if envCredentialKey(key) {
+		return true
+	}
+	upper := strings.ToUpper(key)
+	switch {
+	case strings.HasSuffix(upper, "_CONFIG"):
+		return true
+	case strings.HasSuffix(upper, "_CONFIG_FILE"):
+		return true
+	case strings.HasSuffix(upper, "_CONFIG_PATH"):
+		return true
+	case strings.HasSuffix(upper, "_CONFIG_DIR"):
+		return true
+	case strings.HasSuffix(upper, "_ENDPOINT"):
+		return true
+	case strings.HasSuffix(upper, "_BASE_URL"):
+		return true
+	case strings.HasSuffix(upper, "_URL"):
+		return true
+	case strings.HasSuffix(upper, "_HOST"):
+		return true
+	case strings.HasSuffix(upper, "_REGION"):
+		return true
+	case strings.HasSuffix(upper, "_PROFILE"):
+		return true
+	case upper == "HTTP_PROXY" || upper == "HTTPS_PROXY" || upper == "ALL_PROXY" || upper == "NO_PROXY":
+		return true
+	case upper == "SSL_CERT_FILE" || upper == "SSL_CERT_DIR":
+		return true
+	case upper == "REQUESTS_CA_BUNDLE" || upper == "CURL_CA_BUNDLE":
+		return true
+	}
+	return false
+}
+
 // semanticEnvHash returns a stable 8-hex-char hash of env entries that
 // envCompatible would consider semantically significant (non-transient
 // keys, sorted alphabetically with their values). Used as a sid suffix
@@ -2315,6 +2365,9 @@ func semanticEnvHash(env map[string]string) string {
 	keys := make([]string, 0, len(env))
 	for k := range env {
 		if envTransient(k) {
+			continue
+		}
+		if !envIdentityKey(k) {
 			continue
 		}
 		keys = append(keys, k)

--- a/muxcore/daemon/daemon.go
+++ b/muxcore/daemon/daemon.go
@@ -2344,6 +2344,10 @@ func envIdentityKey(key string) bool {
 		return true
 	case upper == "HTTP_PROXY" || upper == "HTTPS_PROXY" || upper == "ALL_PROXY" || upper == "NO_PROXY":
 		return true
+	case upper == "NPM_CONFIG_REGISTRY" || upper == "NPM_CONFIG_USERCONFIG" || upper == "NPM_CONFIG_GLOBALCONFIG":
+		return true
+	case upper == "NPM_CONFIG_PROXY" || upper == "NPM_CONFIG_HTTPS_PROXY" || upper == "NPM_CONFIG_CAFILE":
+		return true
 	case upper == "SSL_CERT_FILE" || upper == "SSL_CERT_DIR":
 		return true
 	case upper == "REQUESTS_CA_BUNDLE" || upper == "CURL_CA_BUNDLE":

--- a/muxcore/daemon/daemon.go
+++ b/muxcore/daemon/daemon.go
@@ -2344,9 +2344,7 @@ func envIdentityKey(key string) bool {
 		return true
 	case upper == "HTTP_PROXY" || upper == "HTTPS_PROXY" || upper == "ALL_PROXY" || upper == "NO_PROXY":
 		return true
-	case upper == "NPM_CONFIG_REGISTRY" || upper == "NPM_CONFIG_USERCONFIG" || upper == "NPM_CONFIG_GLOBALCONFIG":
-		return true
-	case upper == "NPM_CONFIG_PROXY" || upper == "NPM_CONFIG_HTTPS_PROXY" || upper == "NPM_CONFIG_CAFILE":
+	case strings.HasPrefix(upper, "NPM_CONFIG_"):
 		return true
 	case upper == "SSL_CERT_FILE" || upper == "SSL_CERT_DIR":
 		return true

--- a/muxcore/daemon/daemon.go
+++ b/muxcore/daemon/daemon.go
@@ -2225,6 +2225,10 @@ func mergeEnv(shimEnv map[string]string) map[string]string {
 // the same owner, leaking the first session's credential into the second.
 // Plain value-conflict checks miss this because the second map has no
 // key to conflict against.
+//
+// Non-credential identity keys are incompatible only when both env maps carry
+// the key with different values. Presence in only one env remains compatible so
+// optional config defaults do not fragment owners by themselves.
 func envCompatible(a, b map[string]string) bool {
 	for k, va := range a {
 		if envTransient(k) {
@@ -2338,9 +2342,17 @@ func envIdentityKey(key string) bool {
 		return true
 	case strings.HasSuffix(upper, "_HOST"):
 		return true
+	case strings.HasSuffix(upper, "_PORT"):
+		return true
 	case strings.HasSuffix(upper, "_REGION"):
 		return true
 	case strings.HasSuffix(upper, "_PROFILE"):
+		return true
+	case strings.HasSuffix(upper, "_CERT_PATH") || strings.HasSuffix(upper, "_CERT_FILE"):
+		return true
+	case upper == "HOST" || upper == "PORT" || upper == "URL" || upper == "ENDPOINT":
+		return true
+	case upper == "KUBECONFIG" || upper == "NODE_EXTRA_CA_CERTS":
 		return true
 	case upper == "HTTP_PROXY" || upper == "HTTPS_PROXY" || upper == "ALL_PROXY" || upper == "NO_PROXY":
 		return true

--- a/muxcore/daemon/daemon.go
+++ b/muxcore/daemon/daemon.go
@@ -2350,9 +2350,13 @@ func envIdentityKey(key string) bool {
 		return true
 	case strings.HasSuffix(upper, "_CERT_PATH") || strings.HasSuffix(upper, "_CERT_FILE"):
 		return true
-	case upper == "HOST" || upper == "PORT" || upper == "URL" || upper == "ENDPOINT":
+	case upper == "CONFIG" || upper == "CONFIG_FILE" || upper == "CONFIG_PATH" || upper == "CONFIG_DIR":
 		return true
-	case upper == "KUBECONFIG" || upper == "NODE_EXTRA_CA_CERTS":
+	case upper == "HOST" || upper == "PORT" || upper == "URL" || upper == "BASE_URL" || upper == "ENDPOINT":
+		return true
+	case upper == "REGION" || upper == "PROFILE":
+		return true
+	case upper == "KUBECONFIG" || upper == "NODE_EXTRA_CA_CERTS" || upper == "CERT_PATH" || upper == "CERT_FILE":
 		return true
 	case upper == "HTTP_PROXY" || upper == "HTTPS_PROXY" || upper == "ALL_PROXY" || upper == "NO_PROXY":
 		return true

--- a/muxcore/daemon/env_incompat_test.go
+++ b/muxcore/daemon/env_incompat_test.go
@@ -196,6 +196,38 @@ func TestSemanticEnvHash_Deterministic(t *testing.T) {
 	}
 }
 
+// TestSemanticEnvHash_NPMConfigIdentityKeys asserts that npm registry and
+// config-file settings remain identity keys while lifecycle/package metadata is
+// still ignored. This preserves the credential/config boundary without
+// restoring broad npm launch-noise fanout.
+func TestSemanticEnvHash_NPMConfigIdentityKeys(t *testing.T) {
+	registryA := semanticEnvHash(map[string]string{
+		"npm_config_registry":        "https://registry-a.example/",
+		"npm_lifecycle_event":        "start",
+		"npm_package_json":           "D:/repo-a/package.json",
+		"npm_package_integrity_hash": "session-a",
+	})
+	registryB := semanticEnvHash(map[string]string{
+		"npm_config_registry":        "https://registry-b.example/",
+		"npm_lifecycle_event":        "start",
+		"npm_package_json":           "D:/repo-b/package.json",
+		"npm_package_integrity_hash": "session-b",
+	})
+	if registryA == registryB {
+		t.Fatalf("different npm registry values produced identical hash %q", registryA)
+	}
+
+	withNoise := semanticEnvHash(map[string]string{
+		"npm_config_registry":        "https://registry-a.example/",
+		"npm_lifecycle_event":        "test",
+		"npm_package_json":           "D:/repo-c/package.json",
+		"npm_package_integrity_hash": "session-c",
+	})
+	if withNoise != registryA {
+		t.Fatalf("npm launch/package noise changed registry identity hash: got %q want %q", withNoise, registryA)
+	}
+}
+
 // TestSemanticEnvHash_IgnoresTransient asserts the helper skips transient
 // keys (CLAUDE_CODE_*, WT_*, SESSIONNAME, WSLENV) so per-session var
 // variation does not fragment owner identity.

--- a/muxcore/daemon/env_incompat_test.go
+++ b/muxcore/daemon/env_incompat_test.go
@@ -196,8 +196,8 @@ func TestSemanticEnvHash_Deterministic(t *testing.T) {
 	}
 }
 
-// TestSemanticEnvHash_NPMConfigIdentityKeys asserts that npm registry and
-// config-file settings remain identity keys while lifecycle/package metadata is
+// TestSemanticEnvHash_NPMConfigIdentityKeys asserts that npm config settings
+// remain identity keys while lifecycle/package metadata is
 // still ignored. This preserves the credential/config boundary without
 // restoring broad npm launch-noise fanout.
 func TestSemanticEnvHash_NPMConfigIdentityKeys(t *testing.T) {
@@ -215,6 +215,14 @@ func TestSemanticEnvHash_NPMConfigIdentityKeys(t *testing.T) {
 	})
 	if registryA == registryB {
 		t.Fatalf("different npm registry values produced identical hash %q", registryA)
+	}
+
+	strictSSLFalse := semanticEnvHash(map[string]string{
+		"npm_config_registry":   "https://registry-a.example/",
+		"npm_config_strict_ssl": "false",
+	})
+	if strictSSLFalse == registryA {
+		t.Fatalf("different npm strict_ssl values produced identical hash %q", strictSSLFalse)
 	}
 
 	withNoise := semanticEnvHash(map[string]string{

--- a/muxcore/daemon/env_incompat_test.go
+++ b/muxcore/daemon/env_incompat_test.go
@@ -115,19 +115,84 @@ func TestGlobalFirst_EnvCompatibleSharedSingleOwner(t *testing.T) {
 	}
 }
 
+// TestGlobalFirst_NonIdentityEnvNoiseSharedSingleOwner proves the process
+// explosion guard: global/shared owners must not split merely because MCP host
+// sessions carry different launch noise. Credential/config keys still split in
+// the tests above; this test covers PATH/temp/shell/session-style vars that
+// should not create one owner per host session.
+func TestGlobalFirst_NonIdentityEnvNoiseSharedSingleOwner(t *testing.T) {
+	cwd1 := t.TempDir()
+	cwd2 := t.TempDir()
+	d := testDaemon(t)
+	mockServer := mockServerAbsPath(t)
+	tempA := t.TempDir()
+	tempB := t.TempDir()
+	homeA := t.TempDir()
+	homeB := t.TempDir()
+
+	env1 := map[string]string{
+		"PATH":            "/tools/a",
+		"TEMP":            tempA,
+		"TMP":             tempA,
+		"USERPROFILE":     homeA,
+		"NVMD_SESSION_ID": "session-a",
+	}
+	env2 := map[string]string{
+		"PATH":            "/tools/b",
+		"TEMP":            tempB,
+		"TMP":             tempB,
+		"USERPROFILE":     homeB,
+		"NVMD_SESSION_ID": "session-b",
+	}
+
+	_, sid1, _, err := d.Spawn(control.Request{
+		Cmd:     "spawn",
+		Command: "go",
+		Args:    []string{"run", mockServer},
+		Cwd:     cwd1,
+		Env:     env1,
+	})
+	if err != nil {
+		t.Fatalf("Spawn 1: %v", err)
+	}
+
+	_, sid2, _, err := d.Spawn(control.Request{
+		Cmd:     "spawn",
+		Command: "go",
+		Args:    []string{"run", mockServer},
+		Cwd:     cwd2,
+		Env:     env2,
+	})
+	if err != nil {
+		t.Fatalf("Spawn 2: %v", err)
+	}
+
+	if sid1 != sid2 {
+		t.Errorf("non-identity env noise produced distinct sids %q vs %q", sid1, sid2)
+	}
+	if got := d.OwnerCount(); got != 1 {
+		t.Errorf("OwnerCount = %d, want 1 when only env noise differs", got)
+	}
+}
+
 // TestSemanticEnvHash_Deterministic asserts that the helper produces
 // identical hashes for identical inputs and different hashes for
 // different inputs on a semantically significant key.
 func TestSemanticEnvHash_Deterministic(t *testing.T) {
-	a := semanticEnvHash(map[string]string{"GITHUB_TOKEN": "abc", "PATH": "/usr/bin"})
-	b := semanticEnvHash(map[string]string{"GITHUB_TOKEN": "abc", "PATH": "/usr/bin"})
+	a := semanticEnvHash(map[string]string{"GITHUB_TOKEN": "abc", "MCP_SERVER_CONFIG": "/cfg/a.json"})
+	b := semanticEnvHash(map[string]string{"GITHUB_TOKEN": "abc", "MCP_SERVER_CONFIG": "/cfg/a.json"})
 	if a != b {
 		t.Errorf("identical inputs produced different hashes: %q vs %q", a, b)
 	}
 
-	c := semanticEnvHash(map[string]string{"GITHUB_TOKEN": "xyz", "PATH": "/usr/bin"})
+	c := semanticEnvHash(map[string]string{"GITHUB_TOKEN": "xyz", "MCP_SERVER_CONFIG": "/cfg/a.json"})
 	if a == c {
 		t.Errorf("different GITHUB_TOKEN produced identical hash: %q", a)
+	}
+
+	d := semanticEnvHash(map[string]string{"GITHUB_TOKEN": "abc", "MCP_SERVER_CONFIG": "/cfg/b.json"})
+	if a == d {
+		t.Errorf("different config path produced identical hash: %q", a)
 	}
 }
 
@@ -166,6 +231,25 @@ func TestSemanticEnvHash_EmptyEnv(t *testing.T) {
 	if allTransient != "00000000" {
 		t.Errorf("all-transient env hash = %q, want %q (no semantic content)",
 			allTransient, "00000000")
+	}
+}
+
+// TestSemanticEnvHash_IgnoresNonIdentityNoise asserts that common process
+// launch noise does not participate in the env bucket suffix. This keeps
+// shared/global owners from multiplying across MCP host sessions that differ
+// only by shell, temp, path, or local session metadata.
+func TestSemanticEnvHash_IgnoresNonIdentityNoise(t *testing.T) {
+	baseline := semanticEnvHash(map[string]string{"GITHUB_TOKEN": "abc"})
+	noisy := semanticEnvHash(map[string]string{
+		"GITHUB_TOKEN":    "abc",
+		"PATH":            "/tools/a",
+		"TEMP":            "/tmp/a",
+		"TMP":             "/tmp/a",
+		"USERPROFILE":     "/users/a",
+		"NVMD_SESSION_ID": "session-a",
+	})
+	if noisy != baseline {
+		t.Errorf("non-identity env noise leaked into hash: got %q, want %q", noisy, baseline)
 	}
 }
 

--- a/muxcore/daemon/env_incompat_test.go
+++ b/muxcore/daemon/env_incompat_test.go
@@ -256,6 +256,21 @@ func TestSemanticEnvHash_ConfigExactAndCertIdentityKeys(t *testing.T) {
 			b:    map[string]string{"HOST": "0.0.0.0"},
 		},
 		{
+			name: "exact-config",
+			a:    map[string]string{"CONFIG": "D:/configs/a.json"},
+			b:    map[string]string{"CONFIG": "D:/configs/b.json"},
+		},
+		{
+			name: "exact-region",
+			a:    map[string]string{"REGION": "us-east-1"},
+			b:    map[string]string{"REGION": "eu-west-1"},
+		},
+		{
+			name: "exact-profile",
+			a:    map[string]string{"PROFILE": "dev"},
+			b:    map[string]string{"PROFILE": "prod"},
+		},
+		{
 			name: "suffixed-port",
 			a:    map[string]string{"MCP_SERVER_PORT": "8811"},
 			b:    map[string]string{"MCP_SERVER_PORT": "8812"},

--- a/muxcore/daemon/env_incompat_test.go
+++ b/muxcore/daemon/env_incompat_test.go
@@ -236,6 +236,58 @@ func TestSemanticEnvHash_NPMConfigIdentityKeys(t *testing.T) {
 	}
 }
 
+// TestSemanticEnvHash_ConfigExactAndCertIdentityKeys covers common
+// configuration keys that do not fit the underscore-suffix pattern but still
+// change the upstream's process identity.
+func TestSemanticEnvHash_ConfigExactAndCertIdentityKeys(t *testing.T) {
+	cases := []struct {
+		name string
+		a    map[string]string
+		b    map[string]string
+	}{
+		{
+			name: "exact-port",
+			a:    map[string]string{"PORT": "3000"},
+			b:    map[string]string{"PORT": "3001"},
+		},
+		{
+			name: "exact-host",
+			a:    map[string]string{"HOST": "127.0.0.1"},
+			b:    map[string]string{"HOST": "0.0.0.0"},
+		},
+		{
+			name: "suffixed-port",
+			a:    map[string]string{"MCP_SERVER_PORT": "8811"},
+			b:    map[string]string{"MCP_SERVER_PORT": "8812"},
+		},
+		{
+			name: "kubeconfig",
+			a:    map[string]string{"KUBECONFIG": "D:/clusters/dev.yaml"},
+			b:    map[string]string{"KUBECONFIG": "D:/clusters/prod.yaml"},
+		},
+		{
+			name: "docker-cert-path",
+			a:    map[string]string{"DOCKER_CERT_PATH": "D:/certs/a"},
+			b:    map[string]string{"DOCKER_CERT_PATH": "D:/certs/b"},
+		},
+		{
+			name: "node-extra-ca-certs",
+			a:    map[string]string{"NODE_EXTRA_CA_CERTS": "D:/ca/a.pem"},
+			b:    map[string]string{"NODE_EXTRA_CA_CERTS": "D:/ca/b.pem"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			hashA := semanticEnvHash(tc.a)
+			hashB := semanticEnvHash(tc.b)
+			if hashA == hashB {
+				t.Fatalf("different %s env values produced identical hash %q", tc.name, hashA)
+			}
+		})
+	}
+}
+
 // TestSemanticEnvHash_IgnoresTransient asserts the helper skips transient
 // keys (CLAUDE_CODE_*, WT_*, SESSIONNAME, WSLENV) so per-session var
 // variation does not fragment owner identity.

--- a/muxcore/daemon/owner_lifecycle.go
+++ b/muxcore/daemon/owner_lifecycle.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -129,6 +130,33 @@ func (d *Daemon) forgetOwnerIfCurrent(serverID string, expected *OwnerEntry, rea
 
 func (d *Daemon) deleteOwnerEntryLocked(serverID string) {
 	delete(d.owners, serverID)
+	d.cleanupForcedIsolatedRetryCounterLocked(serverID)
+}
+
+func (d *Daemon) cleanupForcedIsolatedRetryCounterLocked(serverID string) {
+	base, ok := retryCounterBaseForServerID(serverID)
+	if !ok {
+		return
+	}
+	if _, exists := d.forcedIsolatedRetryCounters.Load(base); !exists {
+		return
+	}
+	for sid := range d.owners {
+		if sid == base || strings.HasPrefix(sid, base+"-r") {
+			return
+		}
+	}
+	d.forcedIsolatedRetryCounters.Delete(base)
+}
+
+func retryCounterBaseForServerID(serverID string) (string, bool) {
+	if matches := retrySidPattern.FindStringSubmatch(serverID); matches != nil {
+		return matches[1], true
+	}
+	if strings.HasPrefix(serverID, "isolated-") {
+		return serverID, true
+	}
+	return "", false
 }
 
 func (d *Daemon) recordOwnerRemovalLocked(result ownerRemovalResult) {

--- a/muxcore/daemon/owner_lifecycle_test.go
+++ b/muxcore/daemon/owner_lifecycle_test.go
@@ -2,9 +2,11 @@ package daemon
 
 import (
 	"errors"
+	"sync/atomic"
 	"testing"
 
 	"github.com/thebtf/mcp-mux/muxcore/owner"
+	"github.com/thebtf/mcp-mux/muxcore/serverid"
 	"github.com/thebtf/mcp-mux/muxcore/session"
 )
 
@@ -87,6 +89,38 @@ func TestCleanupDeadOwnerUsesOwnerRemovalPath(t *testing.T) {
 	}
 	status := d.HandleStatus()
 	assertOwnerRemovalStatus(t, status, 1, "zombie", 1)
+}
+
+func TestOwnerLifecycleRemovalCleansFinalRetryCounter(t *testing.T) {
+	d := testDaemon(t)
+	d.supervisor = nil
+
+	cwd := t.TempDir()
+	cmd := "echo"
+	args := []string{"hello"}
+	base := serverid.GenerateContextKey(serverid.ModeIsolated, cmd, args, nil, cwd)
+	sid := base + "-r1"
+	o := testReconnectOwner(t, sid)
+
+	d.forcedIsolatedRetryCounters.Store(base, &atomic.Int64{})
+	d.mu.Lock()
+	d.owners[sid] = &OwnerEntry{
+		Owner:           o,
+		ServerID:        sid,
+		Command:         cmd,
+		Args:            args,
+		Cwd:             cwd,
+		OwnerGeneration: "owner_gen_retry",
+		RestoreSource:   "fresh",
+	}
+	d.mu.Unlock()
+
+	if _, err := d.removeOwner(sid, ownerRemovalReasonIdle, false); err != nil {
+		t.Fatalf("removeOwner() error: %v", err)
+	}
+	if _, ok := d.forcedIsolatedRetryCounters.Load(base); ok {
+		t.Fatalf("retry counter for %q survived final retry owner removal", base)
+	}
 }
 
 func seedReconnectHistoryForOwner(t *testing.T, o *owner.Owner, token, ownerKey string) {

--- a/muxcore/daemon/retry_counter_rehydrate_test.go
+++ b/muxcore/daemon/retry_counter_rehydrate_test.go
@@ -108,6 +108,45 @@ func TestRehydrateRetryCounter_BumpsBeyondRestoredOnNextRetry(t *testing.T) {
 	}
 }
 
+func TestDeleteOwnerEntryCleansRetryCounterWhenLastRetryOwnerGone(t *testing.T) {
+	d, _ := testDaemonWithLog(t)
+	cwd := t.TempDir()
+	cmd := "echo"
+	args := []string{"hello"}
+	base := serverid.GenerateContextKey(serverid.ModeIsolated, cmd, args, nil, cwd)
+
+	d.forcedIsolatedRetryCounters.Store(base, &atomic.Int64{})
+	mustLoadCounter(t, d, base)
+
+	d.mu.Lock()
+	d.owners[base+"-r2"] = &OwnerEntry{ServerID: base + "-r2", Command: cmd, Args: args, Cwd: cwd}
+	d.deleteOwnerEntryLocked(base + "-r2")
+	d.mu.Unlock()
+
+	if _, ok := d.forcedIsolatedRetryCounters.Load(base); ok {
+		t.Fatalf("retry counter for %q survived after final retry owner removal", base)
+	}
+}
+
+func TestDeleteOwnerEntryKeepsRetryCounterWhileSiblingRetryOwnerExists(t *testing.T) {
+	d, _ := testDaemonWithLog(t)
+	cwd := t.TempDir()
+	cmd := "echo"
+	args := []string{"hello"}
+	base := serverid.GenerateContextKey(serverid.ModeIsolated, cmd, args, nil, cwd)
+
+	d.forcedIsolatedRetryCounters.Store(base, &atomic.Int64{})
+	d.mu.Lock()
+	d.owners[base+"-r1"] = &OwnerEntry{ServerID: base + "-r1", Command: cmd, Args: args, Cwd: cwd}
+	d.owners[base+"-r2"] = &OwnerEntry{ServerID: base + "-r2", Command: cmd, Args: args, Cwd: cwd}
+	d.deleteOwnerEntryLocked(base + "-r2")
+	d.mu.Unlock()
+
+	if _, ok := d.forcedIsolatedRetryCounters.Load(base); !ok {
+		t.Fatalf("retry counter for %q was removed while sibling retry owner remained", base)
+	}
+}
+
 func mustLoadCounter(t *testing.T, d *Daemon, base string) int64 {
 	t.Helper()
 	ctrI, ok := d.forcedIsolatedRetryCounters.Load(base)


### PR DESCRIPTION
## Summary

- clean forced-isolated retry counters when the final owner in a retry family is removed
- narrow env identity so ordinary launch noise no longer creates `-env-*` owner fanout
- preserve credential/config boundaries, including npm registry/config/proxy/cafile identity keys
- add regression coverage for retry-counter cleanup, noisy env convergence, and npm config identity

## Verification

- `go test ./daemon -run "TestGlobalFirst_Env|TestGlobalFirst_NonIdentityEnvNoise|TestSemanticEnvHash|TestDeriveEnvBucketedSid|TestOwnerLifecycleRemovalCleansFinalRetryCounter|TestDeleteOwnerEntry.*RetryCounter|TestRehydrateRetryCounter" -count=1 -v`
- `go test ./daemon -count=1`
- `go test ./...` from `D:\Dev\mcp-mux\muxcore`
- `go test ./...` from `D:\Dev\mcp-mux`

## Notes

This is a provider-side process-explosion reduction CR, not a workstation cleanup.
No live `mcp-mux`, `mcp-mux-engine`, `node`, `cmd`, or `aimux` processes were killed
or restarted. The current workstation runtime is stale relative to this branch, so
live counts should not be treated as proof against the patched source until a
release is deployed.
