### PR TITLE
muxcore: auto-manage engine namespaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,9 @@ jobs:
         working-directory: muxcore
         run: |
           go vet ./...
-          go test -race -count=1 -timeout 180s ./...
+          # Serialize packages because daemon and snapshot tests share the
+          # TEMP-based snapshot path; coverage already uses the same guard.
+          go test -race -count=1 -timeout 180s -p=1 ./...
 
   coverage:
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,24 @@ CC 4 ──stdio──> mcp-mux ──IPC──┘
 go get github.com/thebtf/mcp-mux/muxcore@v0.26.5
 ```
 
+### Next - auto-managed engine namespace
+
+**No breaking changes for ordinary `engine.New` consumers.** `engine.Config.Name`
+is now a human-readable/status label, and muxcore derives a collision-resistant
+transport namespace automatically from the label plus product identity. Daemon
+control sockets, owner sockets, daemon locks, stale-socket cleanup, snapshot
+restore, and reconnect behavior use the resolved namespace.
+
+| API | Semantics |
+|-----|-----------|
+| `engine.Config.Name` | Optional display label surfaced in status and registry descriptors. Empty derives from Go build metadata or executable name. |
+| `engine.Config.Namespace` | Optional legacy/advanced transport namespace override. Empty is the normal value; muxcore derives the namespace automatically. Set only to preserve a previously shipped namespace. |
+| `daemon.Config.Namespace` | Lower-level direct-daemon override. Empty defaults to `daemon.Config.Name` for compatibility; ordinary consumers should use `engine.New`. |
+
+Consumer impact: new consumers should not hand-pick pipe names. Existing
+consumers that must keep a shipped namespace for rolling compatibility can set
+`Namespace` explicitly during migration.
+
 ### v0.26.5 - process-explosion owner fanout reduction
 
 **No breaking changes.** v0.26.5 reduces two confirmed owner/process fanout
@@ -353,12 +371,17 @@ if err != nil {
 Two muxcore consumers on one host (e.g. mcp-mux + aimux) no longer share the
 literal `"mcp-mux-"` prefix and cannot interfere with each other.
 
+Historical note: this section describes the v0.22 migration point. The current
+consumer contract is the "Next - auto-managed engine namespace" section above:
+`engine.Config.Name` is a display label, and ordinary consumers should leave
+`engine.Config.Namespace` empty.
+
 | Change | Migration |
 |--------|-----------|
 | `serverid.IPCPath(id, baseDir)` → `serverid.IPCPath(baseDir, name, id)` | Pass engine name as the second argument. Format becomes `{baseDir}/{name}-{id}.sock`. |
 | `serverid.ControlPath(id, baseDir)` → `serverid.ControlPath(baseDir, name, id)` | Same — argument-order change + new name parameter. |
 | `serverid.LockPath(id, baseDir)` → `serverid.LockPath(baseDir, name, id)` | Same. |
-| `engine.Config.Name` is now MANDATORY | `engine.New(Config{Name: "..."})` — empty Name returns error: `"muxcore: engine.Config.Name is required (was empty); pass a name unique to this binary, e.g. \"aimux\", \"mcp-mux\", \"engram\""`. No silent default. |
+| v0.22-only `engine.Config.Name` requirement | At that release point, `engine.New(Config{Name: "..."})` rejected empty Name. Current muxcore derives Name and Namespace automatically for `engine.New`. |
 | `daemon.Config.Name string` (additive) | The engine layer now passes `cfg.Name` through to `daemon.Config.Name`. Internal callers are updated; library consumers that construct `daemon.Config` directly must set `Name`. |
 | `daemon.Config.Persistent bool` (additive) | The engine layer now passes `cfg.Persistent` through. Closes #103: SessionHandler-topology owners now hydrate `OwnerEntry.Persistent` from this field. Subprocess topology continues to derive Persistent from the upstream's `x-mux.persistent` capability — both paths converge on `OwnerEntry.Persistent` before the reaper reads it. |
 | `daemon.HandleListOwners` control RPC (new) | New `Cmd: "list_owners"` returns `ListOwnersResponse{Owners []OwnerInfo, Truncated bool}`. mcp-mux's `mux_list/mux_stop/mux_restart` now query this RPC instead of FS-scanning TEMP — closes #102. |

--- a/muxcore/README.md
+++ b/muxcore/README.md
@@ -78,15 +78,19 @@ func serveStdio(ctx context.Context, stdin io.Reader, stdout io.Writer) error {
 Every muxcore consumer should satisfy this checklist before shipping.
 
 1. **Use `engine.New` and `engine.Run` as the main runtime path.**
-   `engine.New` enforces the two most important setup errors: `Name` is
-   required, and at least one serving shape (`Command`, `Handler`, or
-   `SessionHandler`) is required. Direct `daemon.New` still has compatibility
-   defaults and can be misconfigured more easily.
+   `engine.New` enforces the most important setup error: at least one serving
+   shape (`Command`, `Handler`, or `SessionHandler`) is required. It also
+   derives a safe engine label and transport namespace when the consumer leaves
+   them empty. Direct `daemon.New` still has compatibility defaults and can be
+   misconfigured more easily.
 
-2. **Choose a unique, stable `engine.Config.Name`.**
-   The name scopes daemon control sockets, owner sockets, locks, stale-socket
-   cleanup, status, and reconnect behavior. Do not reuse `"mcp-mux"` for a
-   different product. Use values like `"aimux"` or `"engram"`.
+2. **Use `Name` as a display label; let muxcore manage the namespace.**
+   `engine.Config.Name` is surfaced in status and registry descriptors. It is
+   no longer the consumer's pipe-name contract. By default muxcore derives a
+   collision-resistant `Namespace` from the label plus product identity and uses
+   that namespace for daemon control sockets, owner sockets, locks,
+   stale-socket cleanup, and reconnect behavior. Set `engine.Config.Namespace`
+   only to preserve a previously shipped namespace during migration.
 
 3. **Choose one serving shape deliberately.**
 
@@ -361,7 +365,8 @@ _ = result
 The helper:
 
 1. Calls `upgrade.Swap(CurrentExe, StagedExe)`.
-2. Acquires the daemon namespace lock for `engine.Config.Name` and `BaseDir`.
+2. Acquires the daemon namespace lock for the resolved `engine.Config.Namespace`
+   and `BaseDir`.
 3. Sends `graceful-restart` with `successor_exe` set to `CurrentExe`.
 4. Falls back to `shutdown` if graceful restart is unavailable or rejected.
 5. Starts the replacement daemon from `CurrentExe` when a successor is not
@@ -398,15 +403,15 @@ These guardrails exist in current muxcore:
 
 | Guardrail | Where |
 | --- | --- |
-| Empty `engine.Config.Name` is rejected. | `engine.New` |
+| Empty `engine.Config.Name` is derived from build metadata or executable name. | `engine.New` |
 | Missing serving shape is rejected. | `engine.New` |
 | `SessionHandler` takes priority over `Handler` in daemon mode; proxy mode requires `Handler`. | `engine.Run` |
 | Daemon-managed owner connections require one-time tokens. | daemon spawn + owner accept loop |
 | Reconnect first tries token refresh, then falls back to daemon spawn. | resilient client |
 | Spawn is rejected while daemon shutdown/restart is in progress. | daemon spawn path |
 | Live updates use one engine helper for swap, daemon lock, restart, fallback, start, and ready wait. | `engine.ApplyUpdateAndRestart` |
-| Owner sockets are scoped by engine name. | serverid/daemon/owner paths |
-| Stale-socket cleanup is name-scoped. | daemon startup |
+| Daemon and owner sockets are scoped by resolved engine namespace. | engine/serverid/daemon/owner paths |
+| Stale-socket cleanup is namespace-scoped. | daemon startup |
 | `AuthorizeSession` panics cannot crash the daemon. | owner accept loop |
 | `OnFrameReceived` timeout/panic is fail-open. | owner frame dispatch |
 
@@ -452,7 +457,8 @@ Avoid these integration patterns:
 
 - Calling `daemon.New` directly for ordinary consumers. Use `engine.New` unless
   you are implementing muxcore internals or a custom control plane.
-- Reusing `Name: "mcp-mux"` in another product.
+- Setting `Namespace` by copy-paste for a new product. Leave it empty unless
+  you are intentionally preserving a previously shipped namespace.
 - Letting a CLI parser reject `--muxcore-daemon` before `engine.Run` can see it.
 - Implementing only `SessionHandler` and then wrapping the binary with an
   external `mcp-mux`; proxy mode needs `Handler`.
@@ -516,7 +522,7 @@ Current lifecycle evidence fields:
 
 | Field | Meaning |
 | --- | --- |
-| `engine_name` | Daemon namespace name such as `mcp-mux`, `aimux`, or `engram`; use it to avoid confusing product-native daemons with the `mcp-mux` product daemon. |
+| `engine_name` | Human-readable engine label such as `mcp-mux`, `aimux`, or `engram`; use it to avoid confusing product-native daemons with the `mcp-mux` product daemon. It is not the transport namespace. |
 | `daemon_generation` | Process-lifetime generation string for distinguishing predecessor and successor daemons. |
 | `reaped_owner_count` | Count of owners removed by idle lifecycle reaping. |
 | `owner_removal.total` | Count of owner-removal helper executions in this daemon process. |

--- a/muxcore/daemon/daemon.go
+++ b/muxcore/daemon/daemon.go
@@ -185,9 +185,10 @@ type Daemon struct {
 	// Initialized from Config.DaemonFlag; defaults to "--daemon" when empty.
 	daemonFlag string
 
-	// name is the engine instance name from Config.Name (e.g. "mcp-mux", "aimux").
-	// Used to scope IPC socket file paths and stale-socket cleanup to this engine.
-	name                        string
+	// name is the human-readable engine instance name from Config.Name.
+	name string
+	// namespace scopes IPC socket file paths and stale-socket cleanup to this engine.
+	namespace                   string
 	persistent                  bool
 	daemonGeneration            string
 	predecessorPID              int
@@ -319,11 +320,14 @@ type Config struct {
 	// pre-v0.21.7 callers that don't set it.
 	DaemonFlag string
 
-	// Name is the engine instance name (e.g. "mcp-mux", "aimux", "engram").
-	// Used to scope IPC socket file names and stale-socket cleanup to this
-	// engine only. Empty string defaults to "mcp-mux" for backward compatibility;
-	// callers that want FS isolation across multiple engine types must set this.
+	// Name is the human-readable engine instance name (e.g. "mcp-mux", "aimux",
+	// "engram"). It is surfaced in status and registry descriptors.
 	Name string
+
+	// Namespace scopes IPC socket file names and stale-socket cleanup to this
+	// daemon. Empty string defaults to Name for backward compatibility with
+	// direct daemon.New callers. engine.New supplies an auto-managed namespace.
+	Namespace string
 
 	// Persistent overrides per-owner Persistent detection. When true, all owners
 	// managed by this daemon are treated as persistent (not evicted on idle).
@@ -355,6 +359,10 @@ func New(cfg Config) (*Daemon, error) {
 	name := strings.TrimSpace(cfg.Name)
 	if name == "" {
 		name = "mcp-mux"
+	}
+	namespace := strings.TrimSpace(cfg.Namespace)
+	if namespace == "" {
+		namespace = name
 	}
 
 	logger := cfg.Logger
@@ -423,6 +431,7 @@ func New(cfg Config) (*Daemon, error) {
 		sessionHandler:         cfg.SessionHandler,
 		daemonFlag:             daemonFlag,
 		name:                   name,
+		namespace:              namespace,
 		persistent:             cfg.Persistent,
 		daemonGeneration:       daemonGeneration,
 		authorizeSession:       cfg.AuthorizeSession,
@@ -494,7 +503,7 @@ func New(cfg Config) (*Daemon, error) {
 	}
 
 	// Clean up stale socket files from previous daemon crashes/kills.
-	cleaned := cleanStaleSockets(d.name, logger)
+	cleaned := cleanStaleSockets(d.namespace, logger)
 	if cleaned > 0 {
 		logger.Printf("startup: cleaned %d stale socket files", cleaned)
 	}
@@ -1190,7 +1199,7 @@ func (d *Daemon) spawnOnce(reqPtr *control.Request) (string, string, string, err
 	d.owners[sid] = placeholder
 	d.mu.Unlock()
 
-	ipcPath := serverid.IPCPath("", d.name, sid)
+	ipcPath := serverid.IPCPath("", d.namespace, sid)
 
 	// Pass full session env to the owner. Shim-supplied vars WIN; daemon env
 	// fills gaps. Rationale: some shims are launched by tools that strip
@@ -1215,7 +1224,7 @@ func (d *Daemon) spawnOnce(reqPtr *control.Request) (string, string, string, err
 	}
 
 	// Build the shared owner config (used by both template and fresh paths).
-	controlPath := serverid.ControlPath("", d.name, sid)
+	controlPath := serverid.ControlPath("", d.namespace, sid)
 	ownerCfg := owner.OwnerConfig{
 		Command:          req.Command,
 		Args:             req.Args,

--- a/muxcore/daemon/daemon_test.go
+++ b/muxcore/daemon/daemon_test.go
@@ -204,6 +204,44 @@ func (noopSessionHandler) HandleRequest(context.Context, muxcore.ProjectContext,
 	return []byte(`{"jsonrpc":"2.0","id":1,"result":{"ok":true}}`), nil
 }
 
+func TestDaemonNamespaceScopesOwnerPathsWithoutChangingEngineName(t *testing.T) {
+	ctlPath := shortSocketPath(t, "daemon-namespace.ctl.sock")
+	d, err := New(Config{
+		Name:           "aimux",
+		Namespace:      "aimux-auto-test",
+		ControlPath:    ctlPath,
+		GracePeriod:    1 * time.Second,
+		IdleTimeout:    5 * time.Second,
+		SkipSnapshot:   true,
+		Logger:         testLogger(t),
+		SessionHandler: noopSessionHandler{},
+	})
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	t.Cleanup(func() { d.Shutdown() })
+
+	ipcPath, sid, _, err := d.Spawn(control.Request{
+		Cmd:     "spawn",
+		Command: "test-session-handler",
+		Mode:    "global",
+	})
+	if err != nil {
+		t.Fatalf("Spawn() error: %v", err)
+	}
+	if want := serverid.IPCPath("", "aimux-auto-test", sid); ipcPath != want {
+		t.Fatalf("Spawn() ipcPath = %q, want namespace-scoped %q", ipcPath, want)
+	}
+	if forbidden := serverid.IPCPath("", "aimux", sid); ipcPath == forbidden {
+		t.Fatalf("Spawn() ipcPath used display Name instead of Namespace: %q", ipcPath)
+	}
+
+	status := d.HandleStatus()
+	if status["engine_name"] != "aimux" {
+		t.Fatalf("status engine_name = %q, want display Name aimux", status["engine_name"])
+	}
+}
+
 func testReconnectOwner(t *testing.T, sid string) *owner.Owner {
 	t.Helper()
 	ipcPath := shortSocketPath(t, "refresh.sock")

--- a/muxcore/daemon/snapshot.go
+++ b/muxcore/daemon/snapshot.go
@@ -203,8 +203,8 @@ func (d *Daemon) loadSnapshot() int {
 	restored := 0
 	for _, ownerSnap := range snap.Owners {
 		sid := ownerSnap.ServerID
-		ipcPath := serverid.IPCPath("", d.name, sid)
-		controlPath := serverid.ControlPath("", d.name, sid)
+		ipcPath := serverid.IPCPath("", d.namespace, sid)
+		controlPath := serverid.ControlPath("", d.namespace, sid)
 
 		if ownerSnap.Classification == classify.ModeIsolated &&
 			len(ownerSnap.CwdSet) > 1 {

--- a/muxcore/engine/engine.go
+++ b/muxcore/engine/engine.go
@@ -615,8 +615,8 @@ func resolveEngineName(name string) string {
 	if trimmed := strings.TrimSpace(name); trimmed != "" {
 		return trimmed
 	}
-	if bi, ok := engineReadBuildInfo(); ok && bi.Main.Path != "" && bi.Main.Path != "command-line-arguments" {
-		if base := pathBaseNoExt(bi.Main.Path); base != "" {
+	if bi, ok := engineReadBuildInfo(); ok {
+		if base := pathBaseNoExt(buildInfoIdentityPath(bi)); base != "" {
 			return base
 		}
 	}
@@ -639,13 +639,28 @@ func resolveEngineNamespace(name, namespace string) string {
 }
 
 func engineIdentity(name string) string {
-	if bi, ok := engineReadBuildInfo(); ok && bi.Main.Path != "" && bi.Main.Path != "command-line-arguments" {
-		return "go-main:" + bi.Main.Path + "|name:" + name
+	if bi, ok := engineReadBuildInfo(); ok {
+		if path := buildInfoIdentityPath(bi); path != "" {
+			return "go-main:" + path + "|name:" + name
+		}
 	}
 	if exe, err := engineExecutable(); err == nil {
 		return "exe:" + normalizeExecutableIdentityPath(exe) + "|name:" + name
 	}
 	return "name:" + name
+}
+
+func buildInfoIdentityPath(bi *debug.BuildInfo) string {
+	if bi == nil {
+		return ""
+	}
+	if bi.Path != "" && bi.Path != "command-line-arguments" {
+		return bi.Path
+	}
+	if bi.Main.Path != "" && bi.Main.Path != "command-line-arguments" {
+		return bi.Main.Path
+	}
+	return ""
 }
 
 func normalizeExecutableIdentityPath(exe string) string {

--- a/muxcore/engine/engine.go
+++ b/muxcore/engine/engine.go
@@ -5,11 +5,15 @@ package engine
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"log"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"time"
@@ -27,6 +31,10 @@ var runResilientClient = owner.RunResilientClient
 var engineClientStartDaemon = func(e *MuxEngine) error {
 	return e.startDaemon()
 }
+
+var engineReadBuildInfo = debug.ReadBuildInfo
+
+var engineExecutable = os.Executable
 
 // Internal timing defaults for the engine. Kept as named constants (not inline
 // literals) so the rationale is discoverable and future tuning has a single
@@ -95,9 +103,17 @@ type Handler func(ctx context.Context, stdin io.Reader, stdout io.Writer) error
 
 // Config configures the muxcore engine.
 type Config struct {
-	// Name is used for log prefixes and socket file naming.
-	// Required.
+	// Name is the human-readable engine/product label surfaced in status and
+	// registry descriptors. If empty, muxcore derives a label from Go build
+	// metadata or the executable name.
 	Name string
+
+	// Namespace scopes daemon and owner IPC paths. Empty is the normal value:
+	// muxcore derives a collision-resistant namespace from the engine label and
+	// product identity so consumers do not have to hand-pick globally unique
+	// pipe names. Set only for deliberate legacy compatibility with a
+	// previously-shipped namespace.
+	Namespace string
 
 	// Command and Args define the upstream MCP server to spawn.
 	// Used in daemon mode to start the real server process.
@@ -227,12 +243,11 @@ type MuxEngine struct {
 // New creates a MuxEngine with the given configuration.
 // Validates config and applies defaults.
 func New(cfg Config) (*MuxEngine, error) {
-	if cfg.Name == "" {
-		return nil, fmt.Errorf("muxcore: engine.Config.Name is required (was empty); pass a name unique to this binary, e.g. \"aimux\", \"mcp-mux\", \"engram\"")
-	}
 	if cfg.Command == "" && cfg.Handler == nil && cfg.SessionHandler == nil {
 		return nil, fmt.Errorf("engine: Command, Handler, or SessionHandler is required")
 	}
+	cfg.Name = resolveEngineName(cfg.Name)
+	cfg.Namespace = resolveEngineNamespace(cfg.Name, cfg.Namespace)
 	if cfg.IdleTimeout <= 0 {
 		cfg.IdleTimeout = 5 * time.Minute
 	}
@@ -329,18 +344,18 @@ func (e *MuxEngine) Ready() <-chan struct{} {
 }
 
 // ControlSocketPath returns the canonical daemon control socket path for this
-// engine's Name and BaseDir. Mirrors serverid.DaemonControlPath exactly;
+// engine's Namespace and BaseDir. Mirrors serverid.DaemonControlPath exactly;
 // exposed so consumers do not need to import serverid directly or duplicate the
-// BaseDir/Name composition.
+// BaseDir/Namespace composition.
 func (e *MuxEngine) ControlSocketPath() string {
-	return serverid.DaemonControlPath(e.cfg.BaseDir, e.cfg.Name)
+	return serverid.DaemonControlPath(e.cfg.BaseDir, e.cfg.Namespace)
 }
 
 // runDaemon starts the global daemon that manages owners and accepts IPC
 // connections. It mirrors the behaviour of runGlobalDaemon() in cmd/mcp-mux/
 // but uses the engine's Config for timeouts and base directory.
 func (e *MuxEngine) runDaemon(ctx context.Context) error {
-	ctlPath := serverid.DaemonControlPath(e.cfg.BaseDir, e.cfg.Name)
+	ctlPath := serverid.DaemonControlPath(e.cfg.BaseDir, e.cfg.Namespace)
 
 	// If another daemon is already serving this engine namespace, do not unlink
 	// its control socket. ipc.Listen removes stale files after proving they are
@@ -365,6 +380,7 @@ func (e *MuxEngine) runDaemon(ctx context.Context) error {
 		SessionHandler:   e.cfg.SessionHandler,
 		DaemonFlag:       e.cfg.DaemonFlag,
 		Name:             e.cfg.Name,
+		Namespace:        e.cfg.Namespace,
 		Persistent:       e.cfg.Persistent,
 		Registry:         e.cfg.Registry,
 		AuthorizeSession: e.cfg.AuthorizeSession,
@@ -407,7 +423,7 @@ func (e *MuxEngine) runDaemon(ctx context.Context) error {
 func (e *MuxEngine) runClient(ctx context.Context) error {
 	e.markReady(ModeClient, nil)
 
-	ctlPath := serverid.DaemonControlPath(e.cfg.BaseDir, e.cfg.Name)
+	ctlPath := serverid.DaemonControlPath(e.cfg.BaseDir, e.cfg.Namespace)
 
 	// 1. Ensure the daemon is running, starting it if necessary.
 	if !isDaemonRunning(ctlPath) {
@@ -588,8 +604,82 @@ func (e *MuxEngine) startDaemon() error {
 		return fmt.Errorf("release daemon process: %w", err)
 	}
 
-	ctlPath := serverid.DaemonControlPath(e.cfg.BaseDir, e.cfg.Name)
+	ctlPath := serverid.DaemonControlPath(e.cfg.BaseDir, e.cfg.Namespace)
 	return waitForDaemon(ctlPath, daemonStartupTimeout)
+}
+
+func resolveEngineName(name string) string {
+	if trimmed := strings.TrimSpace(name); trimmed != "" {
+		return trimmed
+	}
+	if bi, ok := engineReadBuildInfo(); ok && bi.Main.Path != "" && bi.Main.Path != "command-line-arguments" {
+		if base := pathBaseNoExt(bi.Main.Path); base != "" {
+			return base
+		}
+	}
+	if exe, err := engineExecutable(); err == nil {
+		if base := pathBaseNoExt(exe); base != "" {
+			return base
+		}
+	}
+	return "muxcore-engine"
+}
+
+func resolveEngineNamespace(name, namespace string) string {
+	if trimmed := strings.TrimSpace(namespace); trimmed != "" {
+		return trimmed
+	}
+	label := sanitizeNamespaceComponent(name)
+	identity := engineIdentity(name)
+	sum := sha256.Sum256([]byte(identity))
+	return label + "-" + hex.EncodeToString(sum[:])[:12]
+}
+
+func engineIdentity(name string) string {
+	if bi, ok := engineReadBuildInfo(); ok && bi.Main.Path != "" && bi.Main.Path != "command-line-arguments" {
+		return "go-main:" + bi.Main.Path + "|name:" + name
+	}
+	if exe, err := engineExecutable(); err == nil {
+		return "exe:" + filepath.Clean(exe) + "|name:" + name
+	}
+	return "name:" + name
+}
+
+func sanitizeNamespaceComponent(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	var b strings.Builder
+	lastDash := false
+	for _, r := range s {
+		ok := r >= 'a' && r <= 'z' || r >= '0' && r <= '9'
+		if ok {
+			b.WriteRune(r)
+			lastDash = false
+			continue
+		}
+		if !lastDash {
+			b.WriteByte('-')
+			lastDash = true
+		}
+	}
+	out := strings.Trim(b.String(), "-")
+	if out == "" {
+		out = "muxcore-engine"
+	}
+	if len(out) > 48 {
+		out = strings.TrimRight(out[:48], "-")
+	}
+	if out == "" {
+		return "muxcore-engine"
+	}
+	return out
+}
+
+func pathBaseNoExt(path string) string {
+	base := filepath.Base(path)
+	if ext := filepath.Ext(base); ext != "" {
+		base = strings.TrimSuffix(base, ext)
+	}
+	return strings.TrimSpace(base)
 }
 
 // isDaemonRunning checks whether the daemon control socket responds to ping.

--- a/muxcore/engine/engine.go
+++ b/muxcore/engine/engine.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"runtime/debug"
 	"strings"
 	"sync"
@@ -35,6 +36,8 @@ var engineClientStartDaemon = func(e *MuxEngine) error {
 var engineReadBuildInfo = debug.ReadBuildInfo
 
 var engineExecutable = os.Executable
+
+var engineGOOS = runtime.GOOS
 
 // Internal timing defaults for the engine. Kept as named constants (not inline
 // literals) so the rationale is discoverable and future tuning has a single
@@ -640,9 +643,17 @@ func engineIdentity(name string) string {
 		return "go-main:" + bi.Main.Path + "|name:" + name
 	}
 	if exe, err := engineExecutable(); err == nil {
-		return "exe:" + filepath.Clean(exe) + "|name:" + name
+		return "exe:" + normalizeExecutableIdentityPath(exe) + "|name:" + name
 	}
 	return "name:" + name
+}
+
+func normalizeExecutableIdentityPath(exe string) string {
+	cleaned := filepath.Clean(exe)
+	if engineGOOS == "windows" {
+		return strings.ToLower(cleaned)
+	}
+	return cleaned
 }
 
 func sanitizeNamespaceComponent(s string) string {

--- a/muxcore/engine/engine_test.go
+++ b/muxcore/engine/engine_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"testing"
@@ -106,11 +107,82 @@ func TestNew_MissingName(t *testing.T) {
 		Command: "echo",
 	}
 	e, err := New(cfg)
-	if err == nil {
-		t.Fatal("New() expected error for missing Name, got nil")
+	if err != nil {
+		t.Fatalf("New() unexpected error for missing Name: %v", err)
 	}
-	if e != nil {
-		t.Fatal("New() expected nil engine on error, got non-nil")
+	if e == nil {
+		t.Fatal("New() returned nil engine")
+	}
+	if e.cfg.Name == "" {
+		t.Fatal("New() did not derive an engine name")
+	}
+	if e.cfg.Namespace == "" {
+		t.Fatal("New() did not derive an engine namespace")
+	}
+	if e.cfg.Name == e.cfg.Namespace {
+		t.Fatalf("derived namespace = name %q, want collision-resistant namespace", e.cfg.Name)
+	}
+}
+
+func TestNewDerivesDistinctNamespacesForSameNameDifferentProducts(t *testing.T) {
+	origReadBuildInfo := engineReadBuildInfo
+	origExecutable := engineExecutable
+	t.Cleanup(func() {
+		engineReadBuildInfo = origReadBuildInfo
+		engineExecutable = origExecutable
+	})
+	engineExecutable = func() (string, error) { return "ignored.exe", nil }
+
+	engineReadBuildInfo = func() (*debug.BuildInfo, bool) {
+		return &debug.BuildInfo{Main: debug.Module{Path: "example.com/products/alpha"}}, true
+	}
+	alpha, err := New(Config{Name: "mcp-mux", Command: "echo"})
+	if err != nil {
+		t.Fatalf("New(alpha): %v", err)
+	}
+
+	engineReadBuildInfo = func() (*debug.BuildInfo, bool) {
+		return &debug.BuildInfo{Main: debug.Module{Path: "example.com/products/beta"}}, true
+	}
+	beta, err := New(Config{Name: "mcp-mux", Command: "echo"})
+	if err != nil {
+		t.Fatalf("New(beta): %v", err)
+	}
+
+	if alpha.cfg.Name != beta.cfg.Name {
+		t.Fatalf("display names differ: alpha=%q beta=%q", alpha.cfg.Name, beta.cfg.Name)
+	}
+	if alpha.cfg.Namespace == beta.cfg.Namespace {
+		t.Fatalf("same display Name and different product identity produced same namespace %q", alpha.cfg.Namespace)
+	}
+	if alpha.cfg.Namespace == "mcp-mux" || beta.cfg.Namespace == "mcp-mux" {
+		t.Fatalf("auto namespace fell back to raw display name: alpha=%q beta=%q", alpha.cfg.Namespace, beta.cfg.Namespace)
+	}
+}
+
+func TestNewDerivesDistinctNamespacesForSameNameDifferentExecutables(t *testing.T) {
+	origReadBuildInfo := engineReadBuildInfo
+	origExecutable := engineExecutable
+	t.Cleanup(func() {
+		engineReadBuildInfo = origReadBuildInfo
+		engineExecutable = origExecutable
+	})
+	engineReadBuildInfo = func() (*debug.BuildInfo, bool) { return nil, false }
+
+	engineExecutable = func() (string, error) { return `C:\Products\Alpha\server.exe`, nil }
+	alpha, err := New(Config{Name: "server", Command: "echo"})
+	if err != nil {
+		t.Fatalf("New(alpha): %v", err)
+	}
+
+	engineExecutable = func() (string, error) { return `C:\Products\Beta\server.exe`, nil }
+	beta, err := New(Config{Name: "server", Command: "echo"})
+	if err != nil {
+		t.Fatalf("New(beta): %v", err)
+	}
+
+	if alpha.cfg.Namespace == beta.cfg.Namespace {
+		t.Fatalf("same display Name and executable basename produced same namespace %q", alpha.cfg.Namespace)
 	}
 }
 
@@ -315,6 +387,7 @@ func TestRunDaemonDoesNotStealActiveControlSocket(t *testing.T) {
 
 	e, err := New(Config{
 		Name:         name,
+		Namespace:    name,
 		Handler:      noopHandler,
 		BaseDir:      baseDir,
 		SkipSnapshot: true,
@@ -367,10 +440,11 @@ func TestRunClientConfiguresRefreshToken(t *testing.T) {
 	defer srv.Close()
 
 	e, err := New(Config{
-		Name:    name,
-		Command: "test-command",
-		Args:    []string{"--flag"},
-		BaseDir: baseDir,
+		Name:      name,
+		Namespace: name,
+		Command:   "test-command",
+		Args:      []string{"--flag"},
+		BaseDir:   baseDir,
 	})
 	if err != nil {
 		t.Fatalf("New() unexpected error: %v", err)
@@ -462,9 +536,10 @@ func TestRunClientReconnectWaitsForSuccessorBeforeSelfStart(t *testing.T) {
 	defer srv.Close()
 
 	e, err := New(Config{
-		Name:    name,
-		Command: "test-command",
-		BaseDir: baseDir,
+		Name:      name,
+		Namespace: name,
+		Command:   "test-command",
+		BaseDir:   baseDir,
 	})
 	if err != nil {
 		t.Fatalf("New() unexpected error: %v", err)
@@ -854,8 +929,9 @@ func TestEngine_AccessorsBeforeRun(t *testing.T) {
 		// expected: channel is open
 	}
 
-	// ControlSocketPath must be non-empty and match serverid.DaemonControlPath.
-	want := serverid.DaemonControlPath(cfg.BaseDir, cfg.Name)
+	// ControlSocketPath must be non-empty and match the resolved namespace,
+	// not the display Name.
+	want := serverid.DaemonControlPath(cfg.BaseDir, eng.cfg.Namespace)
 	got := eng.ControlSocketPath()
 	if got == "" {
 		t.Error("ControlSocketPath() returned empty string")
@@ -1008,9 +1084,9 @@ func TestEngineRegistryConfigPropagatesToDaemon(t *testing.T) {
 		cancel()
 		t.Fatalf("engine_name = %q, want er", rec.Descriptor.EngineName)
 	}
-	if rec.Descriptor.DaemonControlPath != serverid.DaemonControlPath(baseDir, "er") {
+	if rec.Descriptor.DaemonControlPath != serverid.DaemonControlPath(baseDir, eng.cfg.Namespace) {
 		cancel()
-		t.Fatalf("control path = %q, want %q", rec.Descriptor.DaemonControlPath, serverid.DaemonControlPath(baseDir, "er"))
+		t.Fatalf("control path = %q, want %q", rec.Descriptor.DaemonControlPath, serverid.DaemonControlPath(baseDir, eng.cfg.Namespace))
 	}
 
 	cancel()
@@ -1023,21 +1099,43 @@ func TestEngineRegistryConfigPropagatesToDaemon(t *testing.T) {
 
 // TestNewRejectsEmptyName verifies that New returns an error with the exact
 // required message when cfg.Name is empty.
-func TestNewRejectsEmptyName(t *testing.T) {
+func TestNewDerivesNameAndNamespaceWhenNameEmpty(t *testing.T) {
 	cfg := Config{
 		Command: "echo",
 		// Name intentionally omitted (empty string)
 	}
 	e, err := New(cfg)
-	if err == nil {
-		t.Fatal("New() expected error for empty Name, got nil")
+	if err != nil {
+		t.Fatalf("New() unexpected error for empty Name: %v", err)
 	}
-	if e != nil {
-		t.Fatal("New() expected nil engine on error, got non-nil")
+	if e == nil {
+		t.Fatal("New() returned nil engine")
 	}
-	const wantMsg = `muxcore: engine.Config.Name is required (was empty); pass a name unique to this binary, e.g. "aimux", "mcp-mux", "engram"`
-	if err.Error() != wantMsg {
-		t.Errorf("New() error message mismatch:\n  got:  %q\n  want: %q", err.Error(), wantMsg)
+	if e.cfg.Name == "" {
+		t.Fatal("New() did not derive Name")
+	}
+	if e.cfg.Namespace == "" {
+		t.Fatal("New() did not derive Namespace")
+	}
+	if e.cfg.Namespace == e.cfg.Name {
+		t.Fatalf("Namespace = Name = %q, want collision-resistant derived namespace", e.cfg.Name)
+	}
+}
+
+func TestNewPreservesExplicitNamespaceForLegacyCompatibility(t *testing.T) {
+	e, err := New(Config{
+		Name:      "aimux",
+		Namespace: "Legacy.Namespace_1",
+		Command:   "echo",
+	})
+	if err != nil {
+		t.Fatalf("New() unexpected error: %v", err)
+	}
+	if e.cfg.Name != "aimux" {
+		t.Fatalf("Name = %q, want aimux", e.cfg.Name)
+	}
+	if e.cfg.Namespace != "Legacy.Namespace_1" {
+		t.Fatalf("Namespace = %q, want Legacy.Namespace_1", e.cfg.Namespace)
 	}
 }
 

--- a/muxcore/engine/engine_test.go
+++ b/muxcore/engine/engine_test.go
@@ -163,11 +163,14 @@ func TestNewDerivesDistinctNamespacesForSameNameDifferentProducts(t *testing.T) 
 func TestNewDerivesDistinctNamespacesForSameNameDifferentExecutables(t *testing.T) {
 	origReadBuildInfo := engineReadBuildInfo
 	origExecutable := engineExecutable
+	origGOOS := engineGOOS
 	t.Cleanup(func() {
 		engineReadBuildInfo = origReadBuildInfo
 		engineExecutable = origExecutable
+		engineGOOS = origGOOS
 	})
 	engineReadBuildInfo = func() (*debug.BuildInfo, bool) { return nil, false }
+	engineGOOS = "windows"
 
 	engineExecutable = func() (string, error) { return `C:\Products\Alpha\server.exe`, nil }
 	alpha, err := New(Config{Name: "server", Command: "echo"})
@@ -183,6 +186,35 @@ func TestNewDerivesDistinctNamespacesForSameNameDifferentExecutables(t *testing.
 
 	if alpha.cfg.Namespace == beta.cfg.Namespace {
 		t.Fatalf("same display Name and executable basename produced same namespace %q", alpha.cfg.Namespace)
+	}
+}
+
+func TestNewNormalizesWindowsExecutableCaseForNamespaceIdentity(t *testing.T) {
+	origReadBuildInfo := engineReadBuildInfo
+	origExecutable := engineExecutable
+	origGOOS := engineGOOS
+	t.Cleanup(func() {
+		engineReadBuildInfo = origReadBuildInfo
+		engineExecutable = origExecutable
+		engineGOOS = origGOOS
+	})
+	engineReadBuildInfo = func() (*debug.BuildInfo, bool) { return nil, false }
+	engineGOOS = "windows"
+
+	engineExecutable = func() (string, error) { return `C:\Products\Alpha\Server.exe`, nil }
+	upper, err := New(Config{Name: "server", Command: "echo"})
+	if err != nil {
+		t.Fatalf("New(upper): %v", err)
+	}
+
+	engineExecutable = func() (string, error) { return `c:\products\alpha\server.exe`, nil }
+	lower, err := New(Config{Name: "server", Command: "echo"})
+	if err != nil {
+		t.Fatalf("New(lower): %v", err)
+	}
+
+	if upper.cfg.Namespace != lower.cfg.Namespace {
+		t.Fatalf("Windows executable path case changed namespace: upper=%q lower=%q", upper.cfg.Namespace, lower.cfg.Namespace)
 	}
 }
 

--- a/muxcore/engine/engine_test.go
+++ b/muxcore/engine/engine_test.go
@@ -134,7 +134,7 @@ func TestNewDerivesDistinctNamespacesForSameNameDifferentProducts(t *testing.T) 
 	engineExecutable = func() (string, error) { return "ignored.exe", nil }
 
 	engineReadBuildInfo = func() (*debug.BuildInfo, bool) {
-		return &debug.BuildInfo{Main: debug.Module{Path: "example.com/products/alpha"}}, true
+		return &debug.BuildInfo{Path: "example.com/products/alpha/cmd/server"}, true
 	}
 	alpha, err := New(Config{Name: "mcp-mux", Command: "echo"})
 	if err != nil {
@@ -142,7 +142,7 @@ func TestNewDerivesDistinctNamespacesForSameNameDifferentProducts(t *testing.T) 
 	}
 
 	engineReadBuildInfo = func() (*debug.BuildInfo, bool) {
-		return &debug.BuildInfo{Main: debug.Module{Path: "example.com/products/beta"}}, true
+		return &debug.BuildInfo{Path: "example.com/products/beta/cmd/server"}, true
 	}
 	beta, err := New(Config{Name: "mcp-mux", Command: "echo"})
 	if err != nil {
@@ -157,6 +157,42 @@ func TestNewDerivesDistinctNamespacesForSameNameDifferentProducts(t *testing.T) 
 	}
 	if alpha.cfg.Namespace == "mcp-mux" || beta.cfg.Namespace == "mcp-mux" {
 		t.Fatalf("auto namespace fell back to raw display name: alpha=%q beta=%q", alpha.cfg.Namespace, beta.cfg.Namespace)
+	}
+}
+
+func TestNewDerivesDistinctNamespacesForSameModuleDifferentCommands(t *testing.T) {
+	origReadBuildInfo := engineReadBuildInfo
+	origExecutable := engineExecutable
+	t.Cleanup(func() {
+		engineReadBuildInfo = origReadBuildInfo
+		engineExecutable = origExecutable
+	})
+	engineExecutable = func() (string, error) { return "ignored.exe", nil }
+
+	engineReadBuildInfo = func() (*debug.BuildInfo, bool) {
+		return &debug.BuildInfo{
+			Path: "example.com/suite/cmd/alpha",
+			Main: debug.Module{Path: "example.com/suite"},
+		}, true
+	}
+	alpha, err := New(Config{Name: "suite", Command: "echo"})
+	if err != nil {
+		t.Fatalf("New(alpha): %v", err)
+	}
+
+	engineReadBuildInfo = func() (*debug.BuildInfo, bool) {
+		return &debug.BuildInfo{
+			Path: "example.com/suite/cmd/beta",
+			Main: debug.Module{Path: "example.com/suite"},
+		}, true
+	}
+	beta, err := New(Config{Name: "suite", Command: "echo"})
+	if err != nil {
+		t.Fatalf("New(beta): %v", err)
+	}
+
+	if alpha.cfg.Namespace == beta.cfg.Namespace {
+		t.Fatalf("same module and display Name for different commands produced same namespace %q", alpha.cfg.Namespace)
 	}
 }
 

--- a/muxcore/engine/update.go
+++ b/muxcore/engine/update.go
@@ -247,7 +247,7 @@ func (e *MuxEngine) restartDaemonWithSuccessor(ctx context.Context, opts Restart
 		result.Warnings = append(result.Warnings, fmt.Sprintf("could not read daemon identity before restart: %v", identityErr))
 	}
 
-	lockPath := serverid.DaemonLockPath(e.cfg.BaseDir, e.cfg.Name)
+	lockPath := serverid.DaemonLockPath(e.cfg.BaseDir, e.cfg.Namespace)
 	lock, err := engineAcquireDaemonLock(lockPath)
 	if err != nil {
 		if !opts.ProceedWithoutLock {

--- a/muxcore/engine/update_test.go
+++ b/muxcore/engine/update_test.go
@@ -14,6 +14,7 @@ import (
 
 	muxcore "github.com/thebtf/mcp-mux/muxcore"
 	"github.com/thebtf/mcp-mux/muxcore/control"
+	"github.com/thebtf/mcp-mux/muxcore/serverid"
 )
 
 type fakeDaemonLock struct {
@@ -279,6 +280,40 @@ func TestRestartWithSuccessor_GracefulSuccessUsesExplicitSuccessor(t *testing.T)
 	}
 	if !lock.closed {
 		t.Fatal("daemon lock was not released")
+	}
+}
+
+func TestRestartWithSuccessor_UsesNamespaceForDaemonLock(t *testing.T) {
+	restoreUpdateSeams(t)
+	baseDir := t.TempDir()
+	eng, err := New(Config{
+		Name:       "display-name",
+		Namespace:  "transport-ns",
+		Command:    "test-command",
+		BaseDir:    baseDir,
+		DaemonFlag: "--test-daemon",
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	var gotLockPath string
+	engineIsDaemonRunning = func(string) bool { return true }
+	engineAcquireDaemonLock = func(path string) (daemonLock, error) {
+		gotLockPath = path
+		return &fakeDaemonLock{}, nil
+	}
+	engineControlSendWithTimeout = func(string, control.Request, time.Duration) (*control.Response, error) {
+		return &control.Response{OK: true}, nil
+	}
+	engineWaitForDaemonReady = func(context.Context, string, time.Duration) error { return nil }
+
+	if _, err := eng.RestartWithSuccessor(context.Background(), baseRestartWithSuccessorOptions()); err != nil {
+		t.Fatalf("RestartWithSuccessor: %v", err)
+	}
+	wantLockPath := serverid.DaemonLockPath(baseDir, "transport-ns")
+	if gotLockPath != wantLockPath {
+		t.Fatalf("lock path = %q, want %q", gotLockPath, wantLockPath)
 	}
 }
 


### PR DESCRIPTION
## Summary
- separate muxcore engine display name from transport namespace
- derive a collision-resistant namespace in engine.New by default
- add Namespace escape hatch for legacy/advanced compatibility
- route daemon owner paths, stale cleanup, and snapshot restore through the resolved namespace
- update consumer docs so products stop hand-picking pipe names

## Issue lifecycle
- unblocks source-side Engram aimux #297 after release
- unblocks source-side Engram engram #298 after release
- consumers should wait for a muxcore release tag containing f1c953d

## Verification
- go test ./serverid ./engine ./daemon -count=1 (from muxcore)
- go test ./... -count=1 (from muxcore)
- go test ./... -count=1 (repo root)
- git diff --check
