### PR TITLE
fix: serialize template background spawn for v0.27.2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,14 @@ patch closes a process-authority race for snapshot/template owners:
 - when snapshot restoration has already started the template-cache background
   upstream, the first uncached request waits for that existing start instead of
   opening a competing request-respawn generation;
+- a successful pending generation releases the gate only after the upstream
+  answers `initialize` and muxcore writes `notifications/initialized`, so
+  ordinary requests cannot overtake the MCP lifecycle handshake; exact-
+  generation terminal failure releases the gate into the existing explicit
+  error/respawn path;
+- proactive requests and ordinary responses are bound to one exact upstream
+  generation; dead-generation registry entries are drained, and stale or
+  unclaimed responses cannot mutate caches, pending counts, or sessions;
 - the wait remains bounded by the existing upstream readiness timeout and owner
   shutdown, after which the request receives an explicit error rather than an
   unowned process tree;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,8 +71,29 @@ do not call the full critical muxcore scope shipped.
 ### Upgrade
 
 ```bash
-go get github.com/thebtf/mcp-mux/muxcore@v0.27.1
+go get github.com/thebtf/mcp-mux/muxcore@v0.27.2
 ```
+
+### v0.27.2 - template background-spawn ownership gate
+
+**No required consumer code changes for ordinary `engine.New` users.** This
+patch closes a process-authority race for snapshot/template owners:
+
+- when snapshot restoration has already started the template-cache background
+  upstream, the first uncached request waits for that existing start instead of
+  opening a competing request-respawn generation;
+- the wait remains bounded by the existing upstream readiness timeout and owner
+  shutdown, after which the request receives an explicit error rather than an
+  unowned process tree;
+- ordinary request-triggered respawn remains available when no background start
+  is pending or the completed background start did not produce a writable
+  upstream.
+
+Consumer impact: update to v0.27.2. The fix prevents duplicate direct upstream
+roots, locked source-checkout entrypoints, and respawn storms caused by two
+startup paths writing the same owner process slot. Do not add product-local
+spawn locks, file-replacement retries, PID sweeps, stale-process kill loops, or
+parallel lifecycle mechanisms; muxcore retains single process-tree authority.
 
 ### v0.27.1 - idle-gate rolling-compatibility hotfix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.27.2] - 2026-07-17
+
+### Fixed
+
+- Fixed snapshot/template background startup racing the first uncached request
+  into a second upstream respawn for the same owner. The request path now waits
+  on the existing bounded background start before deciding whether a replacement
+  is needed, preserving one authoritative upstream process tree.
+
 ## [0.27.1] - 2026-07-14
 
 ### Fixed
@@ -112,6 +121,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   v1-to-v2 compatibility, rollback behavior, forbidden local workarounds, and
   the distinction between Serena dashboard configuration and process cleanup.
 
-[Unreleased]: https://github.com/thebtf/mcp-mux/compare/v0.27.1...HEAD
+[Unreleased]: https://github.com/thebtf/mcp-mux/compare/v0.27.2...HEAD
+[0.27.2]: https://github.com/thebtf/mcp-mux/compare/v0.27.1...v0.27.2
 [0.27.1]: https://github.com/thebtf/mcp-mux/compare/v0.27.0...v0.27.1
 [0.27.0]: https://github.com/thebtf/mcp-mux/compare/v0.26.13...v0.27.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,15 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ### Fixed
 
 - Fixed snapshot/template background startup racing the first uncached request
-  into a second upstream respawn for the same owner. The request path now waits
-  on the existing bounded background start before deciding whether a replacement
-  is needed, preserving one authoritative upstream process tree.
+  into a second upstream respawn for the same owner. The request path now joins
+  the existing bounded background start until the new generation either
+  completes its `initialize` / `notifications/initialized` handshake or
+  terminates. A successful generation cannot be overtaken by ordinary requests;
+  terminal failure follows the existing explicit error/respawn path while
+  preserving one authoritative upstream process tree.
+  Proactive discovery IDs and response claims are now owner/generation scoped,
+  so dead-generation entries are drained and stale or unclaimed responses are
+  dropped before they can change caches, pending state, or session routing.
 
 ## [0.27.1] - 2026-07-14
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,10 +14,20 @@ could then install different processes into the same owner slot, leaving the
 losing upstream generation outside normal finalization.
 
 The request path now joins an already-pending template background start before
-deciding whether respawn is necessary. The wait uses the existing bounded
-upstream readiness timeout and owner shutdown signal. If the completed
-background start produced a writable upstream, the request uses it; otherwise
-the existing request-respawn path remains available.
+deciding whether respawn is necessary. A successful generation keeps the gate
+pending until the upstream has answered `initialize` and muxcore has written
+`notifications/initialized`, so the first uncached request cannot overtake the
+MCP lifecycle handshake. Exact-generation terminal failure also releases the
+gate into the existing explicit error/respawn path. The wait remains bounded by
+the existing upstream readiness timeout and owner shutdown signal. If the
+completed background start produced a writable upstream, the request uses it;
+otherwise request-triggered respawn remains available.
+
+Response ownership is now generation-bound as well. Proactive discovery IDs are
+unique per owner, their registry entries are tied to the exact upstream process
+and drained when that generation dies, and stale or unclaimed responses are
+dropped before they can change caches, pending counts, progress ownership, or
+downstream session routing.
 
 This is the conservative race repair. It does not change when template owners
 are eagerly materialized; demand-driven upstream materialization remains a
@@ -48,13 +58,14 @@ authority and make failures harder to attribute.
 
 ## Verification
 
-The release candidate includes the deterministic
-`TestSnapshotBackgroundSpawnBlocksRequestRespawn` regression. The deployed
-repair completed a `32h 18m` post-cutover Windows soak with zero actual
-runtime locked-entrypoint errors and zero request-triggered competing-respawn
-markers. The same daemon generation stayed live; unrelated network-failure
-respawns are classified separately in
-`.agent/reports/2026-07-17-v0.27.2-soak.md`.
+The release candidate includes deterministic regressions for the background-
+spawn/request-respawn gate, MCP initialization ordering, owner-unique proactive
+IDs, dead-generation proactive drain, stale and unclaimed ordinary responses,
+and the terminal proactive-registration race. The deployed repair completed a
+`32h 18m` post-cutover Windows soak with zero actual runtime locked-entrypoint
+errors and zero request-triggered competing-respawn markers. The same daemon
+generation stayed live; unrelated network-failure respawns are classified
+separately in `.agent/reports/2026-07-17-v0.27.2-soak.md`.
 
 Release closeout still requires the current root and muxcore suites, `go vet`,
 the repository critical suite, applicable native-consumer and lifecycle

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,99 +1,80 @@
-# mcp-mux v0.27.1
+# mcp-mux v0.27.2
 
-**Release date:** 2026-07-14
+**Release date:** 2026-07-17
 
 **Type:** Non-breaking patch release
 
 ## Summary
 
-Persistent daemon/owner state and downstream transport lifetime are now
-separate. Persistent products such as Aimux and Engram retain their transport
-by default because MCP permits background notifications. They may opt into
-`AllowPersistentIdleSuspend` only after proving no-background-events or a
-buffer/replay policy; that opt-in still requires muxcore's exact-owner daemon
-gate. Ordinary `engine.New` users remain source-compatible and receive that
-gate automatically when they enable `IdleSuspendDelay`.
+v0.27.2 fixes a process-authority race for snapshot/template owners. A restored
+owner can begin materializing its cached upstream in the background while its
+first uncached request arrives. Before this patch, the request path could start
+a second respawn before the background start published readiness. Both paths
+could then install different processes into the same owner slot, leaving the
+losing upstream generation outside normal finalization.
 
-The installed stable launcher and active versioned engine are distinct binaries
-and may differ byte-for-byte. Private dormant frames require protocol-v2
-target-bound attestation over a one-shot current-user-only local IPC endpoint.
-The engine verifies that the endpoint server PID is its direct parent and keeps
-the proof bytes separate from host stdio. Provider-derived version-store layout,
-active-engine pointer, and direct-parent executable path checks remain
-mandatory; custom, copied, or environment-forwarded engine paths fail closed.
-A verified engine can update the stable launcher only for future invocations
-through the existing two-rename swap. An already-running v0.27.0-or-older
-launcher lacks the v2 attestation server and needs one explicit host/session
-restart (or exact scoped maintenance cleanup). A silent host has no MCP
-completion signal, so full dormant exit is the explicit
-`MCPMUX_LAUNCHER_DORMANT_LEASE` opt-in, not a default promise.
+The request path now joins an already-pending template background start before
+deciding whether respawn is necessary. The wait uses the existing bounded
+upstream readiness timeout and owner shutdown signal. If the completed
+background start produced a writable upstream, the request uses it; otherwise
+the existing request-respawn path remains available.
 
-v0.27.1 fixes a control-plane retry herd introduced by the v0.27.0 idle-shim
-lifecycle. During rolling coexistence, a new shim could ask a v0.26.13 daemon
-whether it was safe to suspend. The old daemon correctly replied
-`unknown command: can_suspend`, but the shim treated that permanent response as
-transient and opened another named-pipe control connection every five seconds.
-Hundreds of retained Desktop/CLI-worker transports could therefore consume
-multiple daemon CPU cores even though their upstream owners were idle.
+This is the conservative race repair. It does not change when template owners
+are eagerly materialized; demand-driven upstream materialization remains a
+separate architecture change and release track.
 
 ## What changes for users
 
-- Unsupported, unknown-token, owner-gone, persistent-owner, malformed, and
-  other non-transient gate outcomes are one-shot and fail closed. The shim keeps
-  its existing daemon IPC session connected and stops polling.
-- Actual transport failure and daemon shutdown remain recoverable. Retries use
-  capped, per-token jittered exponential backoff instead of a synchronized fixed
-  cadence.
-- Busy, pending-request, and active-progress denials remain recheckable because
-  those conditions can clear safely.
-- Product shims include the spawn-returned owner ID in the gate request. The
-  daemon checks that owner's token history directly instead of scanning every
-  owner. A forged owner ID or a stale token after same-ID owner recreation is
-  rejected.
-
-The lifecycle behavior shipped in v0.27.0 remains unchanged: disposable shims
-can become dormant, exact-owner wake remains available, persistent owners retain
-transport by default, and full subprocess trees are finalized when their owner
-is removed.
+- Snapshot/template background startup and first-request recovery no longer
+  create competing upstream generations for one owner.
+- Windows source-checkout upstreams no longer receive duplicate concurrent
+  launches from this race, avoiding locked entrypoint replacement failures and
+  the associated crash/respawn storm.
+- Timeout and shutdown remain explicit request errors. The fix does not add
+  unbounded waits or replay already-sent requests.
+- Ordinary `engine.New` and direct muxcore consumers require no source changes.
 
 ## Upgrade
 
 ```bash
-go get github.com/thebtf/mcp-mux/muxcore@v0.27.1
+go get github.com/thebtf/mcp-mux/muxcore@v0.27.2
 ```
 
-Ordinary `engine.New` consumers need no source changes. Existing v0.27.0 shim
-engines must enter the v0.27.1 binary generation before the retry fix applies.
-The active engine can bootstrap the stable launcher for future invocations, but
-an already-running v0.27.0-or-older launcher cannot acquire the target-bound v2
-attestation server in memory; restart that host/session before expecting
-launcher dormancy. Do not add product-local retry loops, token indexes, PID-only
-cleanup, or stale process sweeps.
-
-## Serena dashboard
-
-Serena dashboard policy is independent of mux process lifecycle:
-
-- `--open-web-dashboard false` or
-  `web_dashboard_open_on_launch: false` prevents automatic browser opening but
-  leaves the dashboard available.
-- `web_dashboard: false` disables the dashboard service.
+Consumers should remove or quarantine any workaround added specifically for
+duplicate background/request starts. Do not add product-local spawn locks,
+file-replacement retries, PID sweeps, stale-process kill loops, or parallel
+lifecycle mechanisms; they compete with muxcore's Job Object/process-group
+authority and make failures harder to attribute.
 
 ## Verification
 
-Before release, the final candidate SHA must pass root and muxcore full suites,
-`go vet`, focused Windows races, Linux races, cross-platform builds, and the
-Windows lifecycle smoke. Earlier Windows artifacts are useful regression
-evidence only; they do not certify a later repaired SHA.
+The release candidate includes the deterministic
+`TestSnapshotBackgroundSpawnBlocksRequestRespawn` regression. The deployed
+repair completed a `32h 18m` post-cutover Windows soak with zero actual
+runtime locked-entrypoint errors and zero request-triggered competing-respawn
+markers. The same daemon generation stayed live; unrelated network-failure
+respawns are classified separately in
+`.agent/reports/2026-07-17-v0.27.2-soak.md`.
 
-GitHub issue [#138](https://github.com/thebtf/mcp-mux/issues/138) tracks the
-regression and release proof.
+Release closeout still requires the current root and muxcore suites, `go vet`,
+the repository critical suite, applicable native-consumer and lifecycle
+playbook evidence, independent review, remote tag parity, published artifact
+verification, and public muxcore module resolution.
 
 ## Consumer handoff closeout
 
-This release affects every muxcore consumer that adopted v0.27.0 lifecycle
-behavior. The final release closeout must update and re-read the existing aimux
-and engram adoption issues with `muxcore/v0.27.1`, compatibility notes, and
-customer-mode verification. If that cannot be completed, record
+This release affects every muxcore consumer that can restore snapshot/template
+owners and accept requests while background startup is pending. After
+`muxcore/v0.27.2` resolves, release closeout must update and re-read the Aimux
+and Engram adoption issues with the tagged version, the single-authority
+invariant, forbidden local workarounds, customer-mode smoke expectations,
+rollback notes, and provider evidence. If that cannot be completed, record
 `CONSUMER_HANDOFF_BLOCKED` and do not call the full critical muxcore scope
 shipped.
+
+## Rollback
+
+Consumers can pin `muxcore/v0.27.1` or restore the previous product binary. That
+rollback reintroduces the snapshot/template background-start race. Do not mask
+it with consumer-local retry or process cleanup loops; prefer upgrading again
+to v0.27.2 after diagnosing the rollback reason.

--- a/muxcore/README.md
+++ b/muxcore/README.md
@@ -38,17 +38,25 @@ idle/dormant controls, protocol-v2 tree-authority handoff, and full process-tree
 containment. v0.27.1 prevents permanent idle-gate outcomes from creating a
 control-plane retry herd and binds normal product gate checks to one exact
 owner. v0.27.2 makes a first uncached request join an already-pending
-snapshot/template background start instead of creating a competing upstream
-generation for the same owner.
+snapshot/template background start through its MCP initialization handshake
+instead of creating a competing upstream generation for the same owner.
 
 ### v0.27.2 - template background-spawn ownership gate
 
 **No required consumer code changes for ordinary `engine.New` users.** When a
 snapshot/template owner already has `SpawnUpstreamBackground` in progress, the
-request-readiness path waits for that bounded start before deciding whether a
-request-triggered respawn is needed. A completed start with a writable upstream
-is reused; timeout, owner shutdown, or a completed start without a usable
-upstream follows the existing explicit error/respawn behavior.
+request-readiness path joins that bounded start. A successful generation keeps
+the gate pending through the upstream's `initialize` response and muxcore's
+`notifications/initialized` write before ordinary request dispatch can proceed.
+Exact-generation terminal failure releases the gate into the existing explicit
+error/respawn path. A completed start with a writable upstream is reused;
+timeout, owner shutdown, or a completed start without a usable upstream follows
+the existing explicit error/respawn behavior.
+
+Proactive discovery IDs and response ownership are scoped to one owner and one
+exact upstream generation. Dead-generation registry entries are drained, while
+stale or unclaimed responses are discarded before cache, pending-state,
+progress, or downstream-session side effects.
 
 This preserves one authoritative upstream process tree per owner and prevents
 duplicate source-checkout launches, locked entrypoint replacement failures, and

--- a/muxcore/README.md
+++ b/muxcore/README.md
@@ -12,17 +12,17 @@ Claude/Codex config, use the top-level `mcp-mux` CLI instead.
 
 Pin a tagged muxcore module. Do not depend on `latest` for production
 consumers; muxcore is a runtime layer and downstream behavior changes matter.
-After the `muxcore/v0.27.1` tag is published and resolves through the Go proxy,
+After the `muxcore/v0.27.2` tag is published and resolves through the Go proxy,
 upgrade with:
 
 ```bash
-go get github.com/thebtf/mcp-mux/muxcore@v0.27.1
+go get github.com/thebtf/mcp-mux/muxcore@v0.27.2
 ```
 
-Until that tag resolves, keep production consumers on v0.26.13; do not pin this
-branch or a pseudo-version. Use v0.27.1 as the consumer target after publication.
+Until that tag resolves, keep production consumers on v0.27.1; do not pin this
+branch or a pseudo-version. Use v0.27.2 as the consumer target after publication.
 
-v0.27.1 includes the v0.25.3 native SessionHandler hot-update contract (`RestartWithSuccessor` /
+v0.27.2 includes the v0.25.3 native SessionHandler hot-update contract (`RestartWithSuccessor` /
 `ApplyUpdateAndRestart`), the v0.26.x opt-in daemon registry, the v0.26.4
 occupied-control-pipe guard, the v0.26.5 owner fanout reduction, and the
 v0.26.6 auto-managed engine namespace. It also preserves snapshot-restored
@@ -37,7 +37,25 @@ automatically after a short safety-gated delay. v0.27.0 adds opt-in shim
 idle/dormant controls, protocol-v2 tree-authority handoff, and full process-tree
 containment. v0.27.1 prevents permanent idle-gate outcomes from creating a
 control-plane retry herd and binds normal product gate checks to one exact
-owner.
+owner. v0.27.2 makes a first uncached request join an already-pending
+snapshot/template background start instead of creating a competing upstream
+generation for the same owner.
+
+### v0.27.2 - template background-spawn ownership gate
+
+**No required consumer code changes for ordinary `engine.New` users.** When a
+snapshot/template owner already has `SpawnUpstreamBackground` in progress, the
+request-readiness path waits for that bounded start before deciding whether a
+request-triggered respawn is needed. A completed start with a writable upstream
+is reused; timeout, owner shutdown, or a completed start without a usable
+upstream follows the existing explicit error/respawn behavior.
+
+This preserves one authoritative upstream process tree per owner and prevents
+duplicate source-checkout launches, locked entrypoint replacement failures, and
+respawn storms from this race. Consumers must not add product-local spawn locks,
+file-replacement retries, PID sweeps, stale-process kill loops, or parallel
+lifecycle mechanisms. Demand-driven template materialization is a separate
+future architecture change; v0.27.2 is the conservative ownership repair.
 
 ### v0.27.1 - idle-gate rolling-compatibility hotfix
 
@@ -59,10 +77,10 @@ authorizes suspension. Persistent owners retain their downstream transport by
 default; explicit `AllowPersistentIdleSuspend` still requires the same exact
 pending-request, active-progress, and busy-work gate.
 
-Release-candidate handoff status: `CONSUMER_HANDOFF_BLOCKED`. Aimux remains on
-v0.26.13 until `muxcore/v0.27.1` is published and its consumer smoke tests pass.
-Adopting the product-private dormant launcher is separately blocked on the
-reusable native-consumer contract tracked in mcp-mux issue #140.
+`muxcore/v0.27.1` is published and its consumer handoff completed. Aimux's
+v0.27.1 adoption retained persistent connected transport; native persistent-
+client dormancy remains separately blocked on the reusable consumer contract
+tracked in mcp-mux issue #140.
 
 ### v0.27.0 - lifecycle convergence and process-tree authority
 

--- a/muxcore/owner/handoff_from.go
+++ b/muxcore/owner/handoff_from.go
@@ -63,6 +63,7 @@ func newOwnerWithProcess(cfg OwnerConfig, payload HandoffPayload, proc *upstream
 	}
 
 	o := &Owner{
+		proactiveNamespace:     nextProactiveNamespace(),
 		upstream:               proc,
 		ipcPath:                cfg.IPCPath,
 		cwd:                    cwd,
@@ -131,7 +132,7 @@ func newOwnerWithProcess(cfg OwnerConfig, payload HandoffPayload, proc *upstream
 
 	// Start goroutines — identical set to NewOwner.
 	go o.readUpstream(proc)
-	go o.sendProactiveInit()
+	go o.sendProactiveInit(proc, nil)
 	go o.acceptLoop()
 	go o.runProgressReporter(doneContext(o.done))
 

--- a/muxcore/owner/mux_test.go
+++ b/muxcore/owner/mux_test.go
@@ -8,11 +8,13 @@ import (
 	"io"
 	"log"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/thebtf/mcp-mux/muxcore/ipc"
+	"github.com/thebtf/mcp-mux/muxcore/upstream"
 )
 
 // testLogger returns a logger that writes to test output.
@@ -941,10 +943,44 @@ func TestSnapshotOwnerServesCachedToolsDuringBackgroundRefresh(t *testing.T) {
 	}
 
 	handlerStarted := make(chan struct{})
+	initializeReceived := make(chan struct{})
+	allowInitializeResponse := make(chan struct{})
+	initializeReleased := false
+	defer func() {
+		if !initializeReleased {
+			close(allowInitializeResponse)
+		}
+	}()
 	handlerFunc := func(ctx context.Context, stdin io.Reader, stdout io.Writer) error {
 		_ = ctx
-		_ = stdout
 		close(handlerStarted)
+		scanner := bufio.NewScanner(stdin)
+		var req struct {
+			ID     json.RawMessage `json:"id"`
+			Method string          `json:"method"`
+		}
+		for scanner.Scan() {
+			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+				return err
+			}
+			if req.Method == "initialize" {
+				break
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			return err
+		}
+		if req.Method != "initialize" {
+			return io.ErrUnexpectedEOF
+		}
+		close(initializeReceived)
+		<-allowInitializeResponse
+		if _, err := fmt.Fprintf(stdout, `{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":"2025-11-25","capabilities":{"tools":{}},"serverInfo":{"name":"snap-server","version":"0.1.0"}}}`+"\n", req.ID); err != nil {
+			return err
+		}
+		if !scanner.Scan() {
+			return scanner.Err()
+		}
 		_, _ = io.Copy(io.Discard, stdin)
 		return nil
 	}
@@ -968,15 +1004,44 @@ func TestSnapshotOwnerServesCachedToolsDuringBackgroundRefresh(t *testing.T) {
 	}
 	owner.SpawnUpstreamBackground()
 	select {
-	case <-bgCh:
-	case <-time.After(2 * time.Second):
-		t.Fatal("background spawn did not finish")
-	}
-	select {
 	case <-handlerStarted:
 	case <-time.After(2 * time.Second):
 		t.Fatal("background handler did not start")
 	}
+	select {
+	case <-initializeReceived:
+	case <-time.After(2 * time.Second):
+		t.Fatal("background handler did not receive proactive initialize")
+	}
+	select {
+	case <-bgCh:
+		t.Fatal("background spawn became publicly ready before proactive initialization")
+	default:
+	}
+
+	// A late initialize response from a dead predecessor must not release this
+	// generation's lifecycle gate or overwrite its public snapshot cache.
+	staleDone := make(chan struct{})
+	close(staleDone)
+	staleID := strconv.Quote(owner.proactiveNamespace + "-stale-0")
+	owner.registerProactive(staleID, proactiveRequest{method: "initialize", upstreamDone: staleDone})
+	if err := owner.handleUpstreamMessage(parseMessage([]byte(fmt.Sprintf(`{"jsonrpc":"2.0","id":%s,"result":{"serverInfo":{"name":"stale-server"}}}`, staleID)))); err != nil {
+		t.Fatalf("handle stale proactive initialize response: %v", err)
+	}
+	if cached := owner.getCachedResponse("initialize"); !strings.Contains(string(cached), "snap-server") {
+		t.Fatalf("stale generation response replaced public cached initialize: %s", cached)
+	}
+	select {
+	case <-bgCh:
+		t.Fatal("stale generation response released the current background spawn")
+	default:
+	}
+
+	// Session admission emits roots/listChanged synchronously. Discard that
+	// unrelated notification while this test deliberately holds initialize.
+	owner.mu.Lock()
+	owner.upstreamWriter = io.Discard
+	owner.mu.Unlock()
 
 	conn, err := ipc.Dial(ipcPath)
 	if err != nil {
@@ -1015,6 +1080,20 @@ func TestSnapshotOwnerServesCachedToolsDuringBackgroundRefresh(t *testing.T) {
 	initLine := readLineWithin(500 * time.Millisecond)
 	if !strings.Contains(initLine, `"id":42`) || !strings.Contains(initLine, "snap-server") {
 		t.Fatalf("unexpected cached initialize response: %s", initLine)
+	}
+
+	owner.mu.Lock()
+	owner.upstreamWriter = nil
+	owner.mu.Unlock()
+
+	// The snapshot's cached initialize remains public readiness while the new
+	// generation-local lifecycle handshake is intentionally still pending.
+	close(allowInitializeResponse)
+	initializeReleased = true
+	select {
+	case <-bgCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("background spawn did not finish after proactive initialization")
 	}
 
 	if _, err := conn.Write([]byte(`{"jsonrpc":"2.0","method":"notifications/initialized"}` + "\n")); err != nil {
@@ -1096,5 +1175,207 @@ func TestNewOwnerFromSnapshot_ClassificationPreserved(t *testing.T) {
 	}
 	if status["classification_source"] != "capability" {
 		t.Errorf("classification_source = %v, want capability", status["classification_source"])
+	}
+}
+
+func TestProactiveRegistryDrainsDeadGenerationAndSwallowsStaleResponses(t *testing.T) {
+	o := newMinimalOwner()
+	o.proactiveNamespace = nextProactiveNamespace()
+	o.initReady = make(chan struct{})
+	o.classified = make(chan struct{})
+
+	deadDone := make(chan struct{})
+	close(deadDone)
+	currentDone := make(chan struct{})
+	staleID := strconv.Quote(o.proactiveNamespace + "-old-0")
+	currentID := strconv.Quote(o.proactiveNamespace + "-new-0")
+	currentInit := make(chan struct{})
+	o.registerProactive(staleID, proactiveRequest{method: "initialize", upstreamDone: deadDone})
+	o.drainProactiveRequests(nil)
+	o.drainProactiveRequests(nil)
+	if got := o.PendingRequests(); got != 0 {
+		t.Fatalf("pending after repeated dead-generation drain = %d, want 0", got)
+	}
+	o.registerProactive(currentID, proactiveRequest{method: "initialize", initResponse: currentInit, upstreamDone: currentDone})
+	if got := o.PendingRequests(); got != 1 {
+		t.Fatalf("pending after current-generation registration = %d, want 1", got)
+	}
+	closedDone := make(chan struct{})
+	close(closedDone)
+	if o.registerProactive(strconv.Quote(o.proactiveNamespace+"-closed-0"), proactiveRequest{method: "tools/list", upstreamDone: closedDone}) {
+		t.Fatal("registerProactive accepted an already-dead generation")
+	}
+	if got := o.PendingRequests(); got != 1 {
+		t.Fatalf("pending after rejected registration = %d, want 1", got)
+	}
+
+	oldProc := &upstream.Process{}
+	currentProc := &upstream.Process{}
+	o.mu.Lock()
+	o.upstream = currentProc
+	o.mu.Unlock()
+	oldID := strconv.Quote(o.proactiveNamespace + "-old-live-0")
+	oldWait := make(chan struct{})
+	o.registerProactive(oldID, proactiveRequest{method: "initialize", initResponse: oldWait, upstream: oldProc, upstreamDone: currentDone})
+	oldResponse := []byte(fmt.Sprintf(`{"jsonrpc":"2.0","id":%s,"result":{"serverInfo":{"name":"old-live"}}}`, oldID))
+	if err := o.handleUpstreamMessageFrom(oldProc, parseMessage(oldResponse)); err != nil {
+		t.Fatalf("handle stale live-generation response: %v", err)
+	}
+	select {
+	case <-oldWait:
+		t.Fatal("stale live-generation response released its init waiter")
+	default:
+	}
+	if cached := o.getCachedResponse("initialize"); cached != nil {
+		t.Fatalf("stale live-generation response populated cache: %s", cached)
+	}
+	o.drainProactiveRequests(oldProc)
+	o.mu.Lock()
+	o.upstream = nil
+	o.mu.Unlock()
+
+	staleInit := []byte(fmt.Sprintf(`{"jsonrpc":"2.0","id":%s,"result":{"serverInfo":{"name":"stale"}}}`, staleID))
+	if err := o.handleUpstreamMessage(parseMessage(staleInit)); err != nil {
+		t.Fatalf("handle stale initialize response: %v", err)
+	}
+	if got := o.PendingRequests(); got != 1 {
+		t.Fatalf("pending after stale initialize response = %d, want 1", got)
+	}
+	if cached := o.getCachedResponse("initialize"); cached != nil {
+		t.Fatalf("stale initialize response populated cache: %s", cached)
+	}
+	select {
+	case <-currentInit:
+		t.Fatal("stale initialize response released newer init waiter")
+	default:
+	}
+
+	toolsID := strconv.Quote(o.proactiveNamespace + "-new-1")
+	o.registerProactive(toolsID, proactiveRequest{method: "tools/list", upstreamDone: currentDone})
+	freshTools := []byte(fmt.Sprintf(`{"jsonrpc":"2.0","id":%s,"result":{"tools":[{"name":"fresh"}]}}`, toolsID))
+	if err := o.handleUpstreamMessage(parseMessage(freshTools)); err != nil {
+		t.Fatalf("handle fresh tools response: %v", err)
+	}
+	if got := o.PendingRequests(); got != 1 {
+		t.Fatalf("pending after fresh tools response = %d, want 1", got)
+	}
+	staleTools := []byte(fmt.Sprintf(`{"jsonrpc":"2.0","id":%s,"result":{"tools":[{"name":"stale"}]}}`, toolsID))
+	if err := o.handleUpstreamMessage(parseMessage(staleTools)); err != nil {
+		t.Fatalf("handle duplicate tools response: %v", err)
+	}
+	if got := o.PendingRequests(); got != 1 {
+		t.Fatalf("pending after duplicate tools response = %d, want 1", got)
+	}
+	if cached := o.getCachedResponse("tools/list"); !strings.Contains(string(cached), "fresh") || strings.Contains(string(cached), "stale") {
+		t.Fatalf("duplicate tools response changed cache: %s", cached)
+	}
+
+	close(currentDone)
+	o.drainProactiveRequests(nil)
+	if got := o.PendingRequests(); got != 0 {
+		t.Fatalf("pending after current-generation drain = %d, want 0", got)
+	}
+}
+
+func TestOwnerInstancesUseDistinctFirstProactiveIDs(t *testing.T) {
+	ids := make(chan string, 2)
+	newOwner := func() *Owner {
+		o, err := NewOwner(OwnerConfig{
+			IPCPath: testIPCPath(t),
+			Logger:  testLogger(t),
+			HandlerFunc: func(_ context.Context, stdin io.Reader, _ io.Writer) error {
+				var request struct {
+					ID json.RawMessage `json:"id"`
+				}
+				if err := json.NewDecoder(stdin).Decode(&request); err != nil {
+					return err
+				}
+				ids <- string(request.ID)
+				return nil
+			},
+		})
+		if err != nil {
+			t.Fatalf("NewOwner: %v", err)
+		}
+		return o
+	}
+
+	o1 := newOwner()
+	defer o1.Shutdown()
+	o2 := newOwner()
+	defer o2.Shutdown()
+	first := make([]string, 0, 2)
+	for len(first) < 2 {
+		select {
+		case id := <-ids:
+			first = append(first, id)
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for proactive initialize IDs")
+		}
+	}
+	if first[0] == first[1] {
+		t.Fatalf("first proactive IDs collided: %s", first[0])
+	}
+}
+
+func TestOrdinaryResponsesRequireCurrentSourceAndInflightClaim(t *testing.T) {
+	o := newMinimalOwner()
+	current := &upstream.Process{}
+	stale := &upstream.Process{}
+	o.upstream = current
+	o.toolList = []byte(`{"result":{"tools":[{"name":"cached"}]}}`)
+
+	staleID := strconv.Quote("ordinary-stale")
+	o.inflightTracker.Store(staleID, &InflightRequest{Method: "tools/list"})
+	o.methodTags.Store(staleID, "tools/list")
+	o.pendingRequests.Add(1)
+	staleResponse := parseMessage([]byte(fmt.Sprintf(`{"jsonrpc":"2.0","id":%s,"result":{"tools":[{"name":"stale"}]}}`, staleID)))
+	if err := o.handleUpstreamMessageFrom(stale, staleResponse); err != nil {
+		t.Fatalf("handle stale-source response: %v", err)
+	}
+	if got := o.PendingRequests(); got != 1 {
+		t.Fatalf("pending after stale-source response = %d, want 1", got)
+	}
+	if _, ok := o.inflightTracker.Load(staleID); !ok {
+		t.Fatal("stale-source response claimed current inflight request")
+	}
+	if cached := o.getCachedResponse("tools/list"); !strings.Contains(string(cached), "cached") || strings.Contains(string(cached), "stale") {
+		t.Fatalf("stale-source response changed cache: %s", cached)
+	}
+
+	unclaimedID := strconv.Quote("ordinary-unclaimed")
+	o.methodTags.Store(unclaimedID, "tools/list")
+	unclaimedResponse := parseMessage([]byte(fmt.Sprintf(`{"jsonrpc":"2.0","id":%s,"result":{"tools":[{"name":"unclaimed"}]}}`, unclaimedID)))
+	if err := o.handleUpstreamMessageFrom(current, unclaimedResponse); err != nil {
+		t.Fatalf("handle unclaimed current-source response: %v", err)
+	}
+	if got := o.PendingRequests(); got != 1 {
+		t.Fatalf("pending after unclaimed response = %d, want 1", got)
+	}
+	if _, ok := o.methodTags.Load(unclaimedID); !ok {
+		t.Fatal("unclaimed response consumed method tag")
+	}
+	if cached := o.getCachedResponse("tools/list"); !strings.Contains(string(cached), "cached") || strings.Contains(string(cached), "unclaimed") {
+		t.Fatalf("unclaimed response changed cache: %s", cached)
+	}
+}
+
+func TestRegisterProactiveDrainedAfterStoreDoesNotLeakPending(t *testing.T) {
+	o := newMinimalOwner()
+	done := make(chan struct{})
+	id := strconv.Quote("proactive-registration-race")
+	o.afterProactiveStore = func() {
+		close(done)
+		o.drainProactiveRequests(nil)
+	}
+
+	if o.registerProactive(id, proactiveRequest{method: "tools/list", upstreamDone: done}) {
+		t.Fatal("registerProactive accepted a generation drained in its published-entry window")
+	}
+	if got := o.PendingRequests(); got != 0 {
+		t.Fatalf("pending after published-entry drain = %d, want 0", got)
+	}
+	if _, found := o.proactiveRequests.Load(id); found {
+		t.Fatal("published-entry drain left a proactive registry record")
 	}
 }

--- a/muxcore/owner/owner.go
+++ b/muxcore/owner/owner.go
@@ -17,6 +17,7 @@ import (
 	"path/filepath"
 	"runtime/debug"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -87,6 +88,10 @@ func initVersion() string {
 	return rev + dirty
 }
 
+func nextProactiveNamespace() string {
+	return fmt.Sprintf("mux-init-%d-%d", os.Getpid(), proactiveOwnerSequence.Add(1))
+}
+
 // InflightRequest holds metadata about a request currently being processed by upstream.
 // Used for observability: mux_list --verbose shows what's pending and for how long.
 type InflightRequest struct {
@@ -95,6 +100,16 @@ type InflightRequest struct {
 	SessionID int       `json:"session"`
 	StartTime time.Time `json:"started_at"`
 }
+
+// proactiveRequest is claimed exactly once by its response or bound upstream death.
+type proactiveRequest struct {
+	method       string
+	initResponse chan struct{}
+	upstream     *upstream.Process
+	upstreamDone <-chan struct{}
+}
+
+var proactiveOwnerSequence atomic.Uint64
 
 // Owner is the multiplexer core. It manages a single upstream process and
 // routes requests from multiple downstream sessions through it.
@@ -119,8 +134,8 @@ type Owner struct {
 	serverID                    string    // server identity hash
 	listener                    net.Listener
 	logger                      *log.Logger
+	onZeroSessions              func(serverID string)
 
-	onZeroSessions       func(serverID string)
 	onUpstreamExit       func(serverID string)
 	onPersistentDetected func(serverID string)
 	onCacheReady         func(serverID string)
@@ -162,12 +177,14 @@ type Owner struct {
 	progressTokenRequestID map[string]string   // progressToken → remapped request ID that registered it
 	requestToTokens        map[string][]string // remapped request ID → list of progress tokens
 
-	progressTracker *progress.Tracker // dedup state for synthetic progress emission
-
-	upstreamDead            atomic.Bool // set when upstream exits; prevents sending to dead pipe
-	methodTags              sync.Map    // remapped request ID (string) -> method name
-	inflightTracker         sync.Map    // remapped request ID (string) -> *InflightRequest
-	timedOutIDs             sync.Map    // remapped request ID (string) -> struct{} — watchdog-claimed IDs, late upstream responses are dropped
+	progressTracker         *progress.Tracker // dedup state for synthetic progress emission
+	upstreamDead            atomic.Bool       // set when upstream exits; prevents sending to dead pipe
+	methodTags              sync.Map          // remapped request ID (string) -> method name
+	proactiveNamespace      string            // unique across Owner construction and live handoff
+	proactiveInitSeq        atomic.Uint64     // per-owner proactive handshake sequence
+	proactiveRequests       sync.Map          // proactive response ID -> proactiveRequest
+	inflightTracker         sync.Map          // remapped request ID (string) -> *InflightRequest
+	timedOutIDs             sync.Map          // remapped request ID (string) -> struct{} — watchdog-claimed IDs, late upstream responses are dropped
 	pendingRequests         atomic.Int64
 	drainTimeout            time.Duration // from x-mux.drainTimeout capability; 0 = use default
 	toolTimeoutNs           atomic.Int64  // from x-mux.toolTimeout capability; stored as nanoseconds for atomic access
@@ -192,6 +209,7 @@ type Owner struct {
 	// allowing Serve to block instead of treating nil upstream as dead.
 	backgroundSpawnCh         chan struct{}
 	beforeBackgroundSpawnWait func() // test-only synchronization seam; nil in production
+	afterProactiveStore       func() // test-only registration race seam
 
 	respawnMu sync.Mutex
 	respawn   *upstreamRespawn
@@ -324,8 +342,8 @@ func NewOwnerFromSnapshot(cfg OwnerConfig, snap OwnerSnapshot) (*Owner, error) {
 	if cfg.Cwd != "" {
 		cwdSet[cfg.Cwd] = true
 	}
-
 	o := &Owner{
+		proactiveNamespace:   nextProactiveNamespace(),
 		ipcPath:              cfg.IPCPath,
 		cwd:                  cfg.Cwd,
 		cwdSet:               cwdSet,
@@ -453,12 +471,7 @@ func (o *Owner) SpawnUpstreamBackground() {
 		}
 		if o.sessionHandler != nil && o.handlerFunc == nil {
 			o.logger.Printf("background SessionHandler-only spawn: no upstream process")
-			o.mu.Lock()
-			if o.backgroundSpawnCh != nil {
-				close(o.backgroundSpawnCh)
-				o.backgroundSpawnCh = nil
-			}
-			o.mu.Unlock()
+			o.finishBackgroundSpawn()
 			return
 		}
 
@@ -481,13 +494,7 @@ func (o *Owner) SpawnUpstreamBackground() {
 		}
 		if err != nil {
 			o.logger.Printf("background upstream spawn failed: %v (serving stale cache)", err)
-			// Unblock Serve — spawn is done (failed), nil upstream will be observed via upstreamDeadCh.
-			o.mu.Lock()
-			if o.backgroundSpawnCh != nil {
-				close(o.backgroundSpawnCh)
-				o.backgroundSpawnCh = nil
-			}
-			o.mu.Unlock()
+			o.finishBackgroundSpawn()
 			return
 		}
 
@@ -495,24 +502,15 @@ func (o *Owner) SpawnUpstreamBackground() {
 		select {
 		case <-o.done:
 			proc.Close()
-			// Still unblock Serve so it can observe o.done and exit cleanly.
-			o.mu.Lock()
-			if o.backgroundSpawnCh != nil {
-				close(o.backgroundSpawnCh)
-				o.backgroundSpawnCh = nil
-			}
-			o.mu.Unlock()
+			o.finishBackgroundSpawn()
 			return
 		default:
 		}
 
 		o.mu.Lock()
 		o.upstream = proc
-		// Unblock Serve — upstream is now set; upstreamDeadCh will return proc.Done.
-		if o.backgroundSpawnCh != nil {
-			close(o.backgroundSpawnCh)
-			o.backgroundSpawnCh = nil
-		}
+		// Keep public cached readiness intact while a separate generation-local
+		// proactive handshake proves this new process is lifecycle-ready.
 		hadCachedLists := o.toolList != nil || o.promptList != nil ||
 			o.resourceList != nil || o.resourceTemplateList != nil
 		if hadCachedLists {
@@ -526,15 +524,25 @@ func (o *Owner) SpawnUpstreamBackground() {
 		}
 		o.mu.Unlock()
 
-		// Start reading upstream responses
+		// Start reading and monitoring before initialization so a failed generation
+		// always releases the pending background-spawn gate.
 		go o.readUpstream(proc)
-
-		// Send proactive init to refresh caches from new upstream
-		go o.sendProactiveInit()
-
-		// Monitor upstream exit.
 		go o.monitorUpstreamExit(proc)
+
+		// Keep backgroundSpawnCh pending until the new generation has answered
+		// initialize and notifications/initialized has been written. This prevents
+		// the first uncached request from overtaking the MCP lifecycle handshake.
+		o.sendProactiveInit(proc, o.finishBackgroundSpawn)
 	}()
+}
+
+func (o *Owner) finishBackgroundSpawn() {
+	o.mu.Lock()
+	if o.backgroundSpawnCh != nil {
+		close(o.backgroundSpawnCh)
+		o.backgroundSpawnCh = nil
+	}
+	o.mu.Unlock()
 }
 
 // NewOwner creates and starts a new Owner.
@@ -588,6 +596,7 @@ func NewOwner(cfg OwnerConfig) (*Owner, error) {
 		args:                 cfg.Args,
 		env:                  cfg.Env,
 		handlerFunc:          cfg.HandlerFunc,
+		proactiveNamespace:   nextProactiveNamespace(),
 		sessionHandler:       cfg.SessionHandler,
 		upstreamWriter:       cfg.UpstreamWriter,
 		serverID:             cfg.ServerID,
@@ -654,7 +663,7 @@ func NewOwner(cfg OwnerConfig) (*Owner, error) {
 	// InitReady() but init requires a session to send the request — deadlock.
 	// SessionHandler-only owners have no upstream, so skip the proactive init.
 	if proc != nil {
-		go o.sendProactiveInit()
+		go o.sendProactiveInit(proc, nil)
 	}
 
 	// Start accepting IPC connections
@@ -1020,12 +1029,15 @@ func (o *Owner) handleDownstreamMessage(s *Session, msg *jsonrpc.Message) error 
 			o.startToolWatchdog(string(newID), msg.ID, s, msg.Method)
 		}
 
-		if err := o.writeUpstream(remapped); err != nil {
-			o.logger.Printf("session %d: upstream write failed for request id=%s: %v", s.ID, string(newID), err)
-			o.upstreamDead.Store(true)
-			o.drainInflightRequests()
-			if o.shouldRespawnUpstream() {
-				o.startUpstreamRespawn("write_error")
+		proc, writeErr := o.writeUpstreamFromCurrent(remapped)
+		if writeErr != nil {
+			o.logger.Printf("session %d: upstream write failed for request id=%s: %v", s.ID, string(newID), writeErr)
+			if proc != nil && o.markCurrentUpstreamDead(proc) {
+				o.initReadyOnce.Do(func() { close(o.initReady) })
+				_ = proc.Close()
+				if o.shouldRespawnUpstream() {
+					o.startUpstreamRespawn("write_error")
+				}
 			}
 			return nil
 		}
@@ -1138,53 +1150,66 @@ func (o *Owner) dispatchToSessionHandler(s *Session, msg *jsonrpc.Message) error
 // which closes initReady. Subsequent sessions get instant cached replay.
 //
 // Also sends notifications/initialized and tools/list to pre-populate caches.
-func (o *Owner) sendProactiveInit() {
-	initReq := `{"jsonrpc":"2.0","id":"mux-init-0","method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{"roots":{"listChanged":true}},"clientInfo":{"name":"mcp-mux","version":"1.0.0"}}}`
-	o.mu.RLock()
-	initReady := o.initReady
-	o.mu.RUnlock()
-
-	// Tag the request so handleUpstreamMessage caches the response.
-	// Key must match string(msg.ID) which includes JSON quotes: "\"mux-init-0\"".
-	o.methodTags.Store(`"mux-init-0"`, "initialize")
-	o.pendingRequests.Add(1)
-
-	if err := o.writeUpstream([]byte(initReq)); err != nil {
-		o.logger.Printf("proactive init: write failed: %v", err)
+func (o *Owner) sendProactiveInit(proc *upstream.Process, afterInitialized func()) {
+	sequence := o.proactiveInitSeq.Add(1)
+	initID := fmt.Sprintf("%s-%d-0", o.proactiveNamespace, sequence)
+	initKey := strconv.Quote(initID)
+	initResponse := make(chan struct{})
+	if !o.registerProactive(initKey, proactiveRequest{method: "initialize", initResponse: initResponse, upstream: proc, upstreamDone: proc.Done}) {
+		o.markCurrentUpstreamDead(proc)
+		if afterInitialized != nil {
+			afterInitialized()
+		}
 		return
 	}
-	// Do NOT capture fingerprint from proactive init — let the first real
-	// session's initialize capture it. Our synthetic protocolVersion may
-	// differ from what CC actually sends, causing fingerprint mismatches.
+	initReq := fmt.Sprintf(`{"jsonrpc":"2.0","id":%s,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{"roots":{"listChanged":true}},"clientInfo":{"name":"mcp-mux","version":"1.0.0"}}}`, initKey)
+
+	complete := func() {}
+	if afterInitialized != nil {
+		complete = sync.OnceFunc(afterInitialized)
+	}
+	if err := proc.WriteLine([]byte(initReq)); err != nil {
+		if _, claimed := o.claimProactive(initKey); claimed {
+			o.decrementPending()
+		}
+		o.failProactiveGeneration(proc)
+		o.logger.Printf("proactive init: write failed: %v", err)
+		complete()
+		return
+	}
 	o.logger.Printf("proactive init: sent initialize request")
 
-	// After init response is cached (signaled by initReady), send the
-	// followup notifications/initialized + tools/list to pre-populate caches.
-	go func(initReady <-chan struct{}) {
+	go func() {
+		defer complete()
 		select {
-		case <-initReady:
+		case <-initResponse:
+		case <-proc.Done:
+			o.markCurrentUpstreamDead(proc)
+			return
 		case <-o.done:
 			return
 		}
-		if !o.InitSuccess() {
-			return
-		}
 
-		// Send notifications/initialized (required by MCP after initialize)
-		notif := `{"jsonrpc":"2.0","method":"notifications/initialized"}`
-		if err := o.writeUpstream([]byte(notif)); err != nil {
+		if err := proc.WriteLine([]byte(`{"jsonrpc":"2.0","method":"notifications/initialized"}`)); err != nil {
+			o.failProactiveGeneration(proc)
 			o.logger.Printf("proactive init: notifications/initialized failed: %v", err)
 			return
 		}
-
-		// Request tools/list to pre-populate tool cache + trigger classification
-		toolsReq := `{"jsonrpc":"2.0","id":"mux-init-1","method":"tools/list","params":{}}`
-		o.methodTags.Store(`"mux-init-1"`, "tools/list")
-		o.pendingRequests.Add(1)
-		if err := o.writeUpstream([]byte(toolsReq)); err != nil {
+		complete()
+		toolsID := fmt.Sprintf("%s-%d-1", o.proactiveNamespace, sequence)
+		toolsKey := strconv.Quote(toolsID)
+		if !o.registerProactive(toolsKey, proactiveRequest{method: "tools/list", upstream: proc, upstreamDone: proc.Done}) {
+			return
+		}
+		toolsReq := fmt.Sprintf(`{"jsonrpc":"2.0","id":%s,"method":"tools/list","params":{}}`, toolsKey)
+		if err := proc.WriteLine([]byte(toolsReq)); err != nil {
+			if _, claimed := o.claimProactive(toolsKey); claimed {
+				o.decrementPending()
+			}
+			o.failProactiveGeneration(proc)
 			o.logger.Printf("proactive init: tools/list failed: %v", err)
 		}
-	}(initReady)
+	}()
 }
 
 // readUpstream reads responses from one upstream generation and routes them to
@@ -1205,16 +1230,13 @@ func (o *Owner) readUpstream(proc *upstream.Process) {
 			return
 		}
 
-		// Any line from upstream counts as activity for reaper idle tracking.
 		o.touchActivity()
-
 		msg, err := jsonrpc.Parse(line)
 		if err != nil {
 			o.logger.Printf("upstream parse error: %v", err)
 			continue
 		}
-
-		if err := o.handleUpstreamMessage(msg); err != nil {
+		if err := o.handleUpstreamMessageFrom(proc, msg); err != nil {
 			o.logger.Printf("upstream handle error: %v", err)
 		}
 	}
@@ -1281,6 +1303,7 @@ func (o *Owner) notifyUpstreamExit() {
 }
 
 func (o *Owner) markCurrentUpstreamDead(proc *upstream.Process) bool {
+	o.drainProactiveRequests(proc)
 	if !o.isCurrentUpstream(proc) {
 		return false
 	}
@@ -1289,13 +1312,19 @@ func (o *Owner) markCurrentUpstreamDead(proc *upstream.Process) bool {
 	return true
 }
 
+func (o *Owner) failProactiveGeneration(proc *upstream.Process) {
+	o.markCurrentUpstreamDead(proc)
+	_ = proc.Close()
+}
+
 func (o *Owner) ensureUpstreamReadyForRequest() error {
 	o.mu.RLock()
 	backgroundSpawnCh := o.backgroundSpawnCh
+	beforeWait := o.beforeBackgroundSpawnWait
 	o.mu.RUnlock()
 	if backgroundSpawnCh != nil {
-		if o.beforeBackgroundSpawnWait != nil {
-			o.beforeBackgroundSpawnWait()
+		if beforeWait != nil {
+			beforeWait()
 		}
 		timer := time.NewTimer(upstreamRespawnWaitTimeout)
 		defer timer.Stop()
@@ -1392,7 +1421,7 @@ func (o *Owner) runUpstreamRespawn(reason string) error {
 		o.logger.Printf("upstream respawn started attempt=%d reason=%s", attempt, reason)
 		go o.readUpstream(proc)
 		go o.monitorUpstreamExit(proc)
-		o.sendProactiveInit()
+		o.sendProactiveInit(proc, nil)
 
 		timer := time.NewTimer(upstreamRespawnWaitTimeout)
 		select {
@@ -1447,13 +1476,36 @@ func (o *Owner) waitBeforeRespawnRetry(wait time.Duration) bool {
 	}
 }
 
-// isProactiveID reports whether a response ID was generated by the owner's
-// own sendProactiveInit handshake ("mux-init-0", "mux-init-1"). Those IDs are
-// intentionally unprefixed (no session scope) because they are sent before
-// any session connects. They must NOT be run through remap.Deremap.
-func isProactiveID(id json.RawMessage) bool {
-	s := string(id)
-	return s == `"mux-init-0"` || s == `"mux-init-1"`
+// isProactiveID identifies only this Owner's proactive namespace. A response
+// for another Owner, including a predecessor from live handoff, is never ours.
+func (o *Owner) isProactiveID(id json.RawMessage) bool {
+	value, err := strconv.Unquote(string(id))
+	return err == nil && o.proactiveNamespace != "" && strings.HasPrefix(value, o.proactiveNamespace+"-")
+}
+
+func (o *Owner) registerProactive(id string, request proactiveRequest) bool {
+	o.pendingRequests.Add(1)
+	o.proactiveRequests.Store(id, request)
+	if o.afterProactiveStore != nil {
+		o.afterProactiveStore()
+	}
+	select {
+	case <-request.upstreamDone:
+		if _, claimed := o.claimProactive(id); claimed {
+			o.decrementPending()
+		}
+		return false
+	default:
+		return true
+	}
+}
+
+func (o *Owner) claimProactive(id string) (proactiveRequest, bool) {
+	request, ok := o.proactiveRequests.LoadAndDelete(id)
+	if !ok {
+		return proactiveRequest{}, false
+	}
+	return request.(proactiveRequest), true
 }
 
 // decrementPending atomically decrements pendingRequests, clamping at zero.
@@ -1475,9 +1527,16 @@ func (o *Owner) decrementPending() {
 	}
 }
 
-// handleUpstreamMessage routes a message from the upstream to the correct session.
-// It also intercepts server→client requests like roots/list.
+// handleUpstreamMessage routes a test-injected upstream message without a process source.
 func (o *Owner) handleUpstreamMessage(msg *jsonrpc.Message) error {
+	return o.handleUpstreamMessageFrom(nil, msg)
+}
+
+// handleUpstreamMessageFrom routes a message from one exact upstream generation.
+func (o *Owner) handleUpstreamMessageFrom(proc *upstream.Process, msg *jsonrpc.Message) error {
+	if proc != nil && !o.isCurrentUpstream(proc) {
+		return nil
+	}
 	if msg.IsNotification() {
 		// Route progress notifications to owning session instead of broadcast.
 		//
@@ -1517,62 +1576,53 @@ func (o *Owner) handleUpstreamMessage(msg *jsonrpc.Message) error {
 	}
 
 	if msg.IsRequest() {
-		// Server→client request (e.g., roots/list, sampling/createMessage)
 		return o.handleUpstreamRequest(msg)
 	}
-
 	if !msg.IsResponse() {
 		return fmt.Errorf("unexpected message type from upstream: %s", msg.Type)
+	}
+	if request, claimed := o.claimProactive(string(msg.ID)); claimed {
+		o.decrementPending()
+		if request.upstream != proc || !o.isCurrentUpstream(request.upstream) {
+			return nil
+		}
+		select {
+		case <-request.upstreamDone:
+			return nil
+		default:
+		}
+		o.cacheResponse(request.method, msg.Raw)
+		if request.initResponse != nil {
+			close(request.initResponse)
+		}
+		return nil
+	}
+	if o.isProactiveID(msg.ID) {
+		return nil
 	}
 
 	// If the watchdog already claimed this request as timed-out, drop the
 	// late upstream response to prevent duplicate delivery to the session.
-	// Note: we keep methodTags caching (upstream response is still useful
-	// for future cached replays), just skip the session delivery path.
 	if _, timedOut := o.timedOutIDs.LoadAndDelete(string(msg.ID)); timedOut {
 		o.logger.Printf("dropping late response for timed-out request id=%s", string(msg.ID))
-		// Still cache if tagged — the response body is valid even if late
 		if methodRaw, ok := o.methodTags.LoadAndDelete(string(msg.ID)); ok {
 			o.cacheResponse(methodRaw.(string), msg.Raw)
 		}
-		// Clean up progress tokens for the (watchdog-timed-out) request (FIX 1).
 		o.clearProgressTokensForRequest(string(msg.ID))
 		return nil
 	}
 
-	// Atomically claim the inflight entry. If the watchdog claimed it first,
-	// the timedOutIDs check above would have caught it — but we double-check
-	// via LoadAndDelete here to handle any concurrent claim race safely.
-	//
-	// decrementPending is conditional: only decrement if we successfully claimed
-	// the inflight entry, OR if this is a proactive ID (mux-init-0/1) which is
-	// never stored in inflightTracker but always has a corresponding Add(1).
-	// If !claimed and not proactive, the watchdog already claimed and decremented
-	// — calling decrementPending here would cause a double-decrement that drives
-	// pendingRequests below the true in-flight count, causing HandleShutdown to
-	// drain too early and tear down while real requests are still outstanding.
-	_, claimed := o.inflightTracker.LoadAndDelete(string(msg.ID))
-	if claimed || isProactiveID(msg.ID) {
-		o.decrementPending()
+	// Ordinary responses must win their inflight claim before they can affect
+	// pending state, caches, progress ownership, or a downstream session.
+	if _, claimed := o.inflightTracker.LoadAndDelete(string(msg.ID)); !claimed {
+		return nil
 	}
+	o.decrementPending()
 	o.sessionMgr.CompleteRequest(string(msg.ID))
-
-	// Clean up any progress tokens registered for this request (FIX 1).
 	o.clearProgressTokensForRequest(string(msg.ID))
 
-	// Cache response if this was a tagged cacheable request
 	if methodRaw, ok := o.methodTags.LoadAndDelete(string(msg.ID)); ok {
 		o.cacheResponse(methodRaw.(string), msg.Raw)
-	}
-
-	// Proactive init responses (mux-init-0, mux-init-1) have no session
-	// prefix by design — they are sent by the owner itself before any
-	// session connects, to warm caches. The response caching above has
-	// already consumed them; there is nothing to route. Return cleanly
-	// rather than propagating a deremap error that fills the log with
-	// "missing session prefix in mux-init-N" noise for every spawn.
-	if isProactiveID(msg.ID) {
-		return nil
 	}
 
 	// Deremap the ID to find the target session
@@ -2404,8 +2454,11 @@ func (o *Owner) drainInflightRequests() {
 		return
 	}
 	o.logger.Printf("upstream died: sending error responses for %d in-flight requests", len(entries))
-
 	for _, entry := range entries {
+		if _, claimed := o.inflightTracker.LoadAndDelete(entry.RemappedID); !claimed {
+			continue
+		}
+		o.decrementPending()
 		remappedID := json.RawMessage(entry.RemappedID)
 		if !json.Valid(remappedID) {
 			remappedID = json.RawMessage(strconv.Quote(entry.RemappedID))
@@ -2427,25 +2480,29 @@ func (o *Owner) drainInflightRequests() {
 				o.logger.Printf("drainInflight: write error to session %d: %v", result.SessionID, writeErr)
 			}
 		}
-		// Use LoadAndDelete to atomically claim the inflightTracker entry.
-		// If the watchdog already claimed it (LoadAndDelete returns false), skip
-		// the decrement — the watchdog already decremented. Without this guard a
-		// concurrent watchdog timeout during upstream teardown causes a
-		// double-decrement that drives pendingRequests below the real in-flight
-		// count, making HandleShutdown drain too early.
-		if _, claimed := o.inflightTracker.LoadAndDelete(entry.RemappedID); claimed {
-			o.decrementPending()
-		}
 		o.methodTags.Delete(entry.RemappedID)
 		o.timedOutIDs.Delete(entry.RemappedID)
 		o.clearProgressTokensForRequest(entry.RemappedID)
 	}
+}
+func (o *Owner) drainProactiveRequests(proc *upstream.Process) {
+	o.proactiveRequests.Range(func(key, value any) bool {
+		request := value.(proactiveRequest)
+		if request.upstream != proc {
+			return true
+		}
+		if _, claimed := o.claimProactive(key.(string)); claimed {
+			o.decrementPending()
+		}
+		return true
+	})
 }
 
 // Shutdown stops the owner, closing all sessions and the upstream.
 // Cleanup completes before Done() is signaled, ensuring sockets are removed
 // before the process exits.
 func (o *Owner) Shutdown() {
+
 	o.shutdownOnce.Do(func() {
 		o.isAccepting.Store(false)
 		o.teardownExceptUpstream()
@@ -2756,6 +2813,8 @@ func (o *Owner) IsReachable() bool {
 // exited. Used by Daemon.Spawn to block until the server is ready, preventing CC
 // from timing out on slow-starting upstreams.
 func (o *Owner) InitReady() <-chan struct{} {
+	o.mu.RLock()
+	defer o.mu.RUnlock()
 	return o.initReady
 }
 
@@ -2942,6 +3001,13 @@ func (o *Owner) touchActivity() {
 // to the injected writer followed by a newline, mirroring upstream.WriteLine
 // semantics. Used by tests to capture output without a subprocess.
 func (o *Owner) writeUpstream(data []byte) error {
+	_, err := o.writeUpstreamFromCurrent(data)
+	return err
+}
+
+// writeUpstreamFromCurrent returns the exact process generation used for the
+// write so a failure cannot retire a replacement generation.
+func (o *Owner) writeUpstreamFromCurrent(data []byte) (*upstream.Process, error) {
 	o.touchActivity()
 	o.mu.RLock()
 	writer := o.upstreamWriter
@@ -2949,17 +3015,17 @@ func (o *Owner) writeUpstream(data []byte) error {
 	o.mu.RUnlock()
 	if writer != nil {
 		if _, err := writer.Write(data); err != nil {
-			return fmt.Errorf("upstream writer: write: %w", err)
+			return nil, fmt.Errorf("upstream writer: write: %w", err)
 		}
 		if _, err := writer.Write([]byte("\n")); err != nil {
-			return fmt.Errorf("upstream writer: write newline: %w", err)
+			return nil, fmt.Errorf("upstream writer: write newline: %w", err)
 		}
-		return nil
+		return nil, nil
 	}
 	if up == nil {
-		return errors.New("upstream writer unavailable")
+		return nil, errors.New("upstream writer unavailable")
 	}
-	return up.WriteLine(data)
+	return up, up.WriteLine(data)
 }
 
 func (o *Owner) hasWritableUpstream() bool {

--- a/muxcore/owner/owner.go
+++ b/muxcore/owner/owner.go
@@ -190,7 +190,8 @@ type Owner struct {
 	// where the upstream is started asynchronously via SpawnUpstreamBackground.
 	// It is closed (under mu) when background spawn finishes (success or failure),
 	// allowing Serve to block instead of treating nil upstream as dead.
-	backgroundSpawnCh chan struct{}
+	backgroundSpawnCh         chan struct{}
+	beforeBackgroundSpawnWait func() // test-only synchronization seam; nil in production
 
 	respawnMu sync.Mutex
 	respawn   *upstreamRespawn
@@ -1289,6 +1290,23 @@ func (o *Owner) markCurrentUpstreamDead(proc *upstream.Process) bool {
 }
 
 func (o *Owner) ensureUpstreamReadyForRequest() error {
+	o.mu.RLock()
+	backgroundSpawnCh := o.backgroundSpawnCh
+	o.mu.RUnlock()
+	if backgroundSpawnCh != nil {
+		if o.beforeBackgroundSpawnWait != nil {
+			o.beforeBackgroundSpawnWait()
+		}
+		timer := time.NewTimer(upstreamRespawnWaitTimeout)
+		defer timer.Stop()
+		select {
+		case <-backgroundSpawnCh:
+		case <-timer.C:
+			return fmt.Errorf("background upstream spawn still pending after %s", upstreamRespawnWaitTimeout)
+		case <-o.done:
+			return errors.New("owner shutting down")
+		}
+	}
 	if o.hasWritableUpstream() && !o.upstreamDead.Load() {
 		return nil
 	}

--- a/muxcore/owner/respawn_test.go
+++ b/muxcore/owner/respawn_test.go
@@ -66,6 +66,9 @@ func TestOwnerRespawnsUpstreamForLiveSession(t *testing.T) {
 func TestSnapshotBackgroundSpawnBlocksRequestRespawn(t *testing.T) {
 	var starts atomic.Int32
 	requestWaiting := make(chan struct{})
+	initializeReceived := make(chan struct{})
+	allowInitializeResponse := make(chan struct{})
+	initializedReceived := make(chan error, 1)
 	release := make(chan struct{})
 	handler := func(_ context.Context, stdin io.Reader, stdout io.Writer) error {
 		starts.Add(1)
@@ -79,9 +82,33 @@ func TestSnapshotBackgroundSpawnBlocksRequestRespawn(t *testing.T) {
 		if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
 			return err
 		}
+		close(initializeReceived)
+		<-allowInitializeResponse
 		if _, err := fmt.Fprintf(stdout, `{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":"2025-11-25","capabilities":{},"serverInfo":{"name":"background-gate","version":"1"}}}`+"\n", req.ID); err != nil {
 			return err
 		}
+
+		if !scanner.Scan() {
+			err := scanner.Err()
+			if err == nil {
+				err = io.ErrUnexpectedEOF
+			}
+			initializedReceived <- err
+			return err
+		}
+		var notification struct {
+			Method string `json:"method"`
+		}
+		if err := json.Unmarshal(scanner.Bytes(), &notification); err != nil {
+			initializedReceived <- err
+			return err
+		}
+		if notification.Method != "notifications/initialized" {
+			err := fmt.Errorf("first post-initialize message method = %q, want notifications/initialized", notification.Method)
+			initializedReceived <- err
+			return err
+		}
+		initializedReceived <- nil
 		<-release
 		return nil
 	}
@@ -94,8 +121,14 @@ func TestSnapshotBackgroundSpawnBlocksRequestRespawn(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewOwnerFromSnapshot() error: %v", err)
 	}
+	o.mu.Lock()
 	o.beforeBackgroundSpawnWait = func() {
 		close(requestWaiting)
+	}
+	spawnDone := o.backgroundSpawnCh
+	o.mu.Unlock()
+	if spawnDone == nil {
+		t.Fatal("snapshot owner has no pending background-spawn channel")
 	}
 
 	clientR, serverW := io.Pipe()
@@ -104,10 +137,14 @@ func TestSnapshotBackgroundSpawnBlocksRequestRespawn(t *testing.T) {
 	o.AddSession(session)
 
 	respawnLocked := true
+	initializeReleased := false
 	o.respawnMu.Lock()
 	t.Cleanup(func() {
 		if respawnLocked {
 			o.respawnMu.Unlock()
+		}
+		if !initializeReleased {
+			close(allowInitializeResponse)
 		}
 		o.removeSession(session)
 		session.Close()
@@ -131,6 +168,38 @@ func TestSnapshotBackgroundSpawnBlocksRequestRespawn(t *testing.T) {
 	waitForCondition(t, time.Second, func() bool {
 		return starts.Load() == 1
 	}, "background upstream did not start")
+	select {
+	case <-initializeReceived:
+	case <-time.After(time.Second):
+		t.Fatal("background upstream did not receive initialize")
+	}
+
+	select {
+	case <-spawnDone:
+		t.Fatal("background-spawn gate closed before the new upstream answered initialize")
+	default:
+	}
+	select {
+	case err := <-ready:
+		t.Fatalf("request readiness returned before initialize completed: %v", err)
+	default:
+	}
+
+	close(allowInitializeResponse)
+	initializeReleased = true
+	select {
+	case err := <-initializedReceived:
+		if err != nil {
+			t.Fatalf("proactive initialization error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("background upstream did not receive notifications/initialized")
+	}
+	select {
+	case <-spawnDone:
+	case <-time.After(time.Second):
+		t.Fatal("background-spawn gate did not close after notifications/initialized")
+	}
 
 	select {
 	case err := <-ready:

--- a/muxcore/owner/respawn_test.go
+++ b/muxcore/owner/respawn_test.go
@@ -2,13 +2,16 @@ package owner
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestOwnerRespawnsUpstreamForLiveSession(t *testing.T) {
@@ -57,6 +60,93 @@ func TestOwnerRespawnsUpstreamForLiveSession(t *testing.T) {
 	replacementGeneration := respawnGeneration(t, resp)
 	if replacementGeneration <= initialGeneration {
 		t.Fatalf("post-respawn ping response = %s, want generation > %d from same session", resp, initialGeneration)
+	}
+}
+
+func TestSnapshotBackgroundSpawnBlocksRequestRespawn(t *testing.T) {
+	var starts atomic.Int32
+	requestWaiting := make(chan struct{})
+	release := make(chan struct{})
+	handler := func(_ context.Context, stdin io.Reader, stdout io.Writer) error {
+		starts.Add(1)
+		scanner := bufio.NewScanner(stdin)
+		if !scanner.Scan() {
+			return scanner.Err()
+		}
+		var req struct {
+			ID json.RawMessage `json:"id"`
+		}
+		if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(stdout, `{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":"2025-11-25","capabilities":{},"serverInfo":{"name":"background-gate","version":"1"}}}`+"\n", req.ID); err != nil {
+			return err
+		}
+		<-release
+		return nil
+	}
+
+	o, err := NewOwnerFromSnapshot(OwnerConfig{
+		HandlerFunc: handler,
+		IPCPath:     testIPCPath(t),
+		Logger:      testLogger(t),
+	}, OwnerSnapshot{})
+	if err != nil {
+		t.Fatalf("NewOwnerFromSnapshot() error: %v", err)
+	}
+	o.beforeBackgroundSpawnWait = func() {
+		close(requestWaiting)
+	}
+
+	clientR, serverW := io.Pipe()
+	serverR, clientW := io.Pipe()
+	session := NewSession(serverR, serverW)
+	o.AddSession(session)
+
+	respawnLocked := true
+	o.respawnMu.Lock()
+	t.Cleanup(func() {
+		if respawnLocked {
+			o.respawnMu.Unlock()
+		}
+		o.removeSession(session)
+		session.Close()
+		_ = clientR.Close()
+		_ = clientW.Close()
+		close(release)
+		o.Shutdown()
+	})
+
+	ready := make(chan error, 1)
+	go func() {
+		ready <- o.ensureUpstreamReadyForRequest()
+	}()
+
+	select {
+	case <-requestWaiting:
+	case <-time.After(time.Second):
+		t.Fatal("request path did not enter the pending background-spawn wait")
+	}
+	o.SpawnUpstreamBackground()
+	waitForCondition(t, time.Second, func() bool {
+		return starts.Load() == 1
+	}, "background upstream did not start")
+
+	select {
+	case err := <-ready:
+		if err != nil {
+			t.Fatalf("ensureUpstreamReadyForRequest() error: %v", err)
+		}
+	case <-time.After(time.Second):
+		o.respawnMu.Unlock()
+		respawnLocked = false
+		t.Fatal("request path started a competing respawn instead of waiting for the pending background spawn")
+	}
+
+	o.respawnMu.Unlock()
+	respawnLocked = false
+	if got := starts.Load(); got != 1 {
+		t.Fatalf("upstream starts = %d, want 1", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- make first-request readiness join an already-pending snapshot/template background start instead of starting a competing request respawn
- hold a successful generation behind the gate through `initialize` and `notifications/initialized`; exact-generation terminal failure releases into the existing explicit error/respawn path
- bind proactive discovery and ordinary response claims to one exact upstream generation, drain dead-generation entries, and drop stale or unclaimed responses before side effects
- add deterministic regressions for spawn ownership, MCP initialization ordering, unique proactive IDs, dead-generation drain, ordinary response claims, and terminal registration
- prepare the non-breaking `v0.27.2` / `muxcore/v0.27.2` release and consumer guidance

This is intentionally the conservative ownership repair. Demand-driven upstream materialization remains a separate feature track.

## Runtime evidence

The deployed repair completed a 32h18m Windows soak on the same daemon PID/generation. Post-cutover parsing found zero actual runtime locked-entrypoint failures and zero request-triggered competing-respawn markers. A transient network incident produced unrelated upstream exits, recorded separately; zombie and reconnect-give-up counters remained zero.

Evidence: `.agent/reports/2026-07-17-v0.27.2-soak.md`.

## Verification

- `go test ./owner -count=1 -timeout=180s`
- `go test -race ./owner -count=1 -timeout=240s`
- root `go test ./... -count=1 -timeout=240s`
- muxcore sequential full suite: `go test -p 1 ./... -count=1 -timeout=300s`
- root and muxcore `go vet ./...`
- Windows repository critical suite with explicit `mcp-launcher`: PASS, 5/5 stages, including process lifecycle convergence, real reconnect, current-topology oracle, and native SessionHandler hot update
- WSL/Linux focused owner, daemon, process-group, and upstream lifecycle proof: PASS
- final independent implementation review: APPROVE
- final independent verification: ACCEPT
- `git diff --check`: PASS

Two default-parallel Windows muxcore runs previously hit the existing transient `CancelSynchronousIo: The handle is invalid` handoff-test class; both exact tests passed repeated focused runs, the full owner race suite passed, and the clean sequential muxcore suite passed. Remote CI is the final default-parallel cross-platform gate.

## Review findings addressed

- read `beforeBackgroundSpawnWait` under the owner lock
- wait through MCP initialization before releasing a successful background generation
- prevent stale predecessor responses and notifications from mutating the current owner generation
- require an inflight claim before ordinary response side effects
- close the proactive registration-vs-terminal-drain window without pending-count leaks

## Release closeout

After merge, publish annotated `v0.27.2` and `muxcore/v0.27.2`, verify remote tag parity, release artifacts, and Go module resolution, then update and re-read Aimux #382 and Engram #381 for `CONSUMER_HANDOFF_PASS`.