### PR TITLE
feat: add demand-driven upstream materialization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.25.12"
       - run: go vet ./...
       - run: go test -race -count=1 -timeout 120s ./...
       - name: muxcore module
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.25.12"
       - run: go test -race -coverprofile=coverage.out -p=1 ./...
       - name: muxcore coverage
         working-directory: muxcore
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.25.12"
       - name: Compile muxcore upstream for FreeBSD
         working-directory: muxcore
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.25.12"
       - name: Build
         shell: bash
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,13 +66,38 @@ issues or comments for `aimux`, `engram`, and any other impacted muxcore
 consumer. If Engram cannot be updated, report `CONSUMER_HANDOFF_BLOCKED` and
 do not call the full critical muxcore scope shipped.
 
-## muxcore Library API (v0.27.x)
+## muxcore Library API (v0.28.x)
 
 ### Upgrade
 
 ```bash
-go get github.com/thebtf/mcp-mux/muxcore@v0.27.2
+go get github.com/thebtf/mcp-mux/muxcore@v0.28.0
 ```
+
+### v0.28.0 - demand-driven upstream materialization
+
+**No required consumer code changes for ordinary `engine.New` users.** After a
+compatible discovery template exists, muxcore can create a cache-only owner
+that serves cached `initialize` and `tools/list` without an upstream process.
+The first uncached request starts exactly one generation, completes MCP
+initialization, and forwards the original request once on the same transport.
+
+Template authorization uses the full SHA-256 identity of the effective
+security-relevant environment; isolated templates also require the exact
+canonical working directory. Missing, incompatible, or repeatedly racing
+templates take one bounded cold/eager path and never replay partial or
+cross-context discovery.
+
+An installed generation remains authoritative through retirement until both
+`Process.Done` and process-group or Windows Job authority retirement are
+proven. `FINALIZE_BLOCKED` prevents an overlapping replacement while the exact
+generation is retried. Restart negotiation failures before detach leave the
+predecessor serving; post-detach failure proves successor exit and pre-starts
+one clean snapshot successor before predecessor shutdown.
+
+Consumer impact: update to v0.28.0. Persistent owners and explicitly eager
+callers retain eager startup. Do not add consumer-local spawn locks, retry
+loops, PID sweeps, stale-process kill loops, or parallel lifecycle mechanisms.
 
 ### v0.27.2 - template background-spawn ownership gate
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,15 +20,24 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 - Template reuse now requires an exact full SHA-256 identity of the effective
   security-relevant environment, plus the exact canonical working directory
-  for isolated templates. A first template revision race performs one fresh
-  lookup; a repeated mismatch takes one bounded cold/eager bypass.
+  for isolated templates; a stricter per-CWD isolated entry shadows any later
+  relaxed template. Windows environment keys normalize case-insensitively
+  before shim override, fingerprinting, or launch. A first template revision
+  race performs one fresh lookup; a repeated mismatch takes one bounded
+  cold/eager bypass.
 - Process retirement, owner removal, snapshot fallback, and mixed handoff now
   retain the installed generation until both process completion and process-tree
   authority retirement are proven. Unproven finalization remains visible as
-  `FINALIZE_BLOCKED` and is retried without allowing an overlapping generation.
-- Restart restore invalidates secondary discovery caches before refresh, and
-  failed/rejected local demand clears remap, pending, progress, and session-token
-  authority instead of replaying later.
+  `FINALIZE_BLOCKED` and retries retirement proof for that same installed
+  generation without allowing a competing generation.
+- Restart restore invalidates secondary discovery caches before refresh.
+  Failed/rejected local demand clears request-scoped remap, pending, inflight,
+  and progress residue instead of replaying later; session-token revocation is
+  reserved for isolation eviction.
+INS.POST 39:
+- Official CI and release artifacts now use Go 1.25.12. Root and muxcore
+  `govulncheck` report zero reachable vulnerabilities under that toolchain;
+  this does not treat an imported-but-unreached advisory as reachable.
 - Graceful restart now treats listener/spawn/accept and exact-Hello negotiation
   failures as pre-detach aborts that retain the predecessor. A post-detach
   protocol failure must prove the failed successor exited, rewrite the pinned

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,6 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   Failed/rejected local demand clears request-scoped remap, pending, inflight,
   and progress residue instead of replaying later; session-token revocation is
   reserved for isolation eviction.
-INS.POST 39:
 - Official CI and release artifacts now use Go 1.25.12. Root and muxcore
   `govulncheck` report zero reachable vulnerabilities under that toolchain;
   this does not treat an imported-but-unreached advisory as reachable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.28.0] - 2026-07-17
+
 ### Added
 
 - Added demand-driven upstream materialization for compatible template-backed
@@ -156,7 +158,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   v1-to-v2 compatibility, rollback behavior, forbidden local workarounds, and
   the distinction between Serena dashboard configuration and process cleanup.
 
-[Unreleased]: https://github.com/thebtf/mcp-mux/compare/v0.27.2...HEAD
+[Unreleased]: https://github.com/thebtf/mcp-mux/compare/v0.28.0...HEAD
+[0.28.0]: https://github.com/thebtf/mcp-mux/compare/v0.27.2...v0.28.0
 [0.27.2]: https://github.com/thebtf/mcp-mux/compare/v0.27.1...v0.27.2
 [0.27.1]: https://github.com/thebtf/mcp-mux/compare/v0.27.0...v0.27.1
 [0.27.0]: https://github.com/thebtf/mcp-mux/compare/v0.26.13...v0.27.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Added
+
+- Added demand-driven upstream materialization for compatible template-backed
+  owners. Host `initialize` / `tools/list` startup can now complete from cache
+  with no upstream process, while the first uncached request materializes one
+  generation and succeeds on the same open transport.
+
+### Changed
+
+- Template reuse now requires an exact full SHA-256 identity of the effective
+  security-relevant environment, plus the exact canonical working directory
+  for isolated templates. A first template revision race performs one fresh
+  lookup; a repeated mismatch takes one bounded cold/eager bypass.
+- Process retirement, owner removal, snapshot fallback, and mixed handoff now
+  retain the installed generation until both process completion and process-tree
+  authority retirement are proven. Unproven finalization remains visible as
+  `FINALIZE_BLOCKED` and is retried without allowing an overlapping generation.
+- Restart restore invalidates secondary discovery caches before refresh, and
+  failed/rejected local demand clears remap, pending, progress, and session-token
+  authority instead of replaying later.
+- Graceful restart now treats listener/spawn/accept and exact-Hello negotiation
+  failures as pre-detach aborts that retain the predecessor. A post-detach
+  protocol failure must prove the failed successor exited, rewrite the pinned
+  snapshot, and pre-start exactly one clean snapshot successor before the
+  predecessor may shut down.
+- Staged snapshot activation is transactional: an owner-construction failure
+  rolls back partial registrations, preserves the exact pinned environment in a
+  filtered recovery snapshot, and fails before the new control endpoint serves.
+
 ## [0.27.2] - 2026-07-17
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -166,17 +166,34 @@ Cache entries are invalidated when the upstream sends the corresponding `*_chang
 For `initialize`, the cache is keyed on `protocolVersion`. A new client using a different protocol
 version bypasses the cache and goes to the upstream directly.
 
-## Proactive Init
+## Cache-Only Startup and Lazy Materialization
 
-When a new owner is created, mcp-mux sends a synthetic `initialize` request to the upstream
-immediately — before any CC session connects. This pre-populates the response cache so the first
-session gets an instant cached replay instead of waiting for the upstream to start.
+The first time mcp-mux sees a command and security context, it starts the
+upstream and performs a synthetic `initialize` plus `tools/list` to learn the
+server's sharing mode and publish a reusable discovery template.
 
-For slow-starting servers (serena via uvx ~3s, tavily via npx ~5s), this eliminates the CC
-"failed" status that occurred when the upstream couldn't respond within CC's startup timeout.
+After that owner is removed, a compatible session can start as a **cache-only
+owner**:
 
-The proactive init also sends `notifications/initialized` and `tools/list` to warm the full
-cache and trigger auto-classification.
+- cached `initialize`, `tools/list`, and any captured prompt/resource discovery
+  responses are replayed without starting the upstream process;
+- `notifications/initialized` is suppressed while no upstream exists;
+- the first uncached request starts exactly one upstream generation and forwards
+  the original request on the same open host transport after initialization;
+- `mcp-mux status` reports `materialization_state: "CACHE_ONLY"` with
+  `upstream_pid: 0` until demand arrives, then `READY` with the live PID.
+
+Template reuse is fail-closed. A missing, stale, or incompatible template takes
+one bounded cold/eager path instead of replaying cached frames from the wrong
+context. Compatibility uses an exact SHA-256 identity of the effective
+security-relevant environment; isolated templates also require the exact
+canonical working directory. Raw environment values are not stored in the
+identity or exposed in status. Persistent owners and callers that explicitly
+require eager startup continue to materialize without waiting for a request.
+
+For slow-starting servers (serena via uvx ~3s, tavily via npx ~5s), a compatible
+template lets later host startup complete from cache while deferring that cost
+until the server is actually used.
 
 ## Daemon Mode
 
@@ -470,25 +487,31 @@ Done   ──(transferred, aborted lists)──>
   every other prepared tree aborts and is eligible for snapshot respawn.
 - **30s accept + total timeout** on both sides.
 - **Version skew (FR-3):** negotiation happens before any owner detaches. A
-  mismatched `protocol_version`, including the first v1-to-v2 restart, takes
-  one bounded snapshot-backed shutdown+respawn path (FR-8).
+  mismatched `protocol_version`, token mismatch, listener timeout, or handoff
+  successor start failure aborts the restart, releases restart pins, and leaves
+  the predecessor serving.
 
 ### FR-8 degraded fallback
 
-If any of the following happens, the daemon automatically falls back to the
-bounded snapshot-backed shutdown-and-respawn path:
+Snapshot fallback is authorized only after exact version/token Hello and owner
+detach. On a later receipt or final-ack failure, the daemon:
 
-- Platform unsupported (socket bind failure on an exotic OS)
-- Successor spawn failure
-- Handoff socket accept timeout exceeded
-- Shared token mismatch (`ErrTokenMismatch`)
-- Protocol version mismatch (`ErrProtocolVersionMismatch`)
-- Any other `performHandoff` error
+1. proves the failed handoff successor has exited;
+2. aborts the prepared transfer, permanently closing the detached predecessor
+   owner and terminating its process tree;
+3. rewrites the pinned snapshot from the retained logical generation metadata;
+4. pre-starts exactly one clean snapshot successor; and
+5. only then returns the post-response predecessor shutdown callback.
 
-All paths log `handoff.fallback reason=…` — search `mcp-muxd-debug.log` for operator diagnostics.
-After fallback the successor daemon respawns upstreams from snapshot;
-`drainOrphanedInflight` returns JSON-RPC errors by original id to in-flight
-callers. It does not replay those requests.
+No-process/cache-only restarts likewise pre-start one snapshot successor before
+predecessor shutdown. A pre-detach failure logs `handoff.abort` and does not
+spawn fallback. A successful post-detach recovery logs `handoff.fallback`;
+failure to prove successor exit, rewrite the snapshot, or start the backup logs
+`handoff.fallback_blocked` and remains fail-closed.
+
+The snapshot successor eagerly restores upstreams; `drainOrphanedInflight`
+returns JSON-RPC errors by original id to in-flight callers. It does not replay
+those requests.
 
 ### Operator visibility
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -152,20 +152,35 @@ flowchart TD
 
 Для `initialize` кеш индексируется по `protocolVersion`. Клиент с другой версией протокола обходит кеш и обращается к upstream напрямую.
 
-## Проактивная инициализация
+## Cache-only запуск и отложенная материализация
 
-При создании нового owner mcp-mux сразу отправляет upstream синтетический
-запрос `initialize` — ещё до подключения первой сессии CC. Ответ заранее
-попадает в кеш, поэтому первая сессия получает его немедленно и не ждёт запуска
-upstream.
+При первом запуске команды в новом security context mcp-mux создаёт upstream
+и отправляет синтетические `initialize`, `notifications/initialized` и
+`tools/list`. Так owner определяет sharing mode и публикует совместимый шаблон
+discovery-кеша.
+
+После удаления этого owner следующая совместимая сессия может создать
+**cache-only owner** без процесса upstream:
+
+- кешированные `initialize`, `tools/list` и сохранённые prompt/resource-ответы
+  возвращаются без запуска процесса;
+- `notifications/initialized` подавляется, пока upstream отсутствует;
+- первый запрос без кешированного ответа запускает ровно одно поколение
+  upstream и передаётся с исходным JSON-RPC id по тому же открытому transport;
+- `mcp-mux status` показывает `materialization_state: "CACHE_ONLY"` и
+  `upstream_pid: 0`, а после первого спроса — `READY` и pid процесса.
+
+Повторное использование шаблона работает в fail-closed режиме. Отсутствующий,
+устаревший или несовместимый шаблон ведёт к одному ограниченному cold/eager
+запуску без воспроизведения чужого кеша. Совместимость требует точного
+SHA-256 identity эффективного security-relevant environment; для isolated
+шаблонов также нужен точный canonical working directory. Исходные значения
+environment не сохраняются в identity и не выводятся в status. Persistent owner
+и явно eager-сценарии по-прежнему запускаются без ожидания запроса.
 
 Для медленно запускающихся серверов (Serena через uvx — около 3 секунд, Tavily
-через npx — около 5 секунд) это предотвращает ложный статус «failed», который
-возникал, если upstream не успевал ответить в пределах стартового таймаута CC.
-
-После `initialize` mcp-mux также отправляет `notifications/initialized` и
-`tools/list`, чтобы прогреть весь кеш и выполнить автоматическую
-классификацию.
+через npx — около 5 секунд) cache-only шаблон ускоряет host startup, а стоимость
+запуска переносится на момент реального обращения к серверу.
 
 ## Daemon-режим
 
@@ -451,26 +466,32 @@ Done   ──(transferred, aborted lists)──>
   восстановлены из snapshot.
 - **Таймаут accept и общий таймаут — 30 секунд** с обеих сторон.
 - **Расхождение версий (FR-3):** согласование завершается до отсоединения
-  owner. Несовпадение `protocol_version`, включая первый переход v1 → v2,
-  запускает один ограниченный snapshot-backed shutdown-and-respawn (FR-8).
+  owner. Несовпадение `protocol_version` или токена, таймаут accept и ошибка
+  запуска handoff-successor отменяют рестарт: daemon освобождает restart pin,
+  не запускает fallback и оставляет predecessor в рабочем состоянии.
 
 ### Деградация по FR-8
 
-При неподдерживаемой платформе, ошибке запуска successor, таймауте accept,
-несоответствии токена (`ErrTokenMismatch`), несовпадении версии протокола
-(`ErrProtocolVersionMismatch`) или другой ошибке `performHandoff` daemon
-выполняет ограниченный snapshot-backed shutdown-and-respawn. Successor
-перезапускает upstream из snapshot; `drainOrphanedInflight` возвращает
-незавершённым запросам JSON-RPC ошибки с исходным id и не воспроизводит их.
+Snapshot fallback разрешён только после точного Hello и отсоединения owner.
+При последующей ошибке receipt или final ACK daemon подтверждает остановку
+неудачного successor, завершает подготовленное дерево, повторно записывает
+удержанный snapshot и заранее запускает ровно один чистый snapshot-successor.
+Только после этого control-ответ разрешает выключить predecessor.
 
-Все пути логируют `handoff.fallback reason=…` — ищите в `mcp-muxd-debug.log` для диагностики.
+Рестарт без process-backed owner также заранее запускает один
+snapshot-successor. Ошибка до отсоединения логируется как `handoff.abort`;
+успешное восстановление после отсоединения — как `handoff.fallback`. Если
+нельзя подтвердить остановку successor, записать snapshot или запустить backup,
+daemon логирует `handoff.fallback_blocked` и остаётся в fail-closed состоянии.
+`drainOrphanedInflight` возвращает незавершённым запросам JSON-RPC-ошибки
+с исходным id и не воспроизводит их.
 
 ### Видимость для оператора
 
 Новые счётчики в `mux_list` / `HandleStatus`: `handoff_attempted`, `handoff_transferred`,
 `handoff_aborted`, `handoff_fallback`. Структурированные маркеры логов: `handoff.start`,
-`handoff.upstream.transferred`, `handoff.complete`, `handoff.fallback`,
-`handoff.receive.{start,complete,fail}`.
+`handoff.abort`, `handoff.upstream.transferred`, `handoff.complete`, `handoff.fallback`,
+`handoff.fallback_blocked`, `handoff.receive.{start,complete,fail}`.
 
 ### Миграция на v0.27.0
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -16,16 +16,19 @@ same open transport.
 
 Template reuse is fail-closed: authorization requires the full SHA-256 identity
 of the effective security-relevant environment and, for isolated templates, the
-exact canonical working directory. Missing, incompatible, or repeatedly racing
-templates take one bounded cold/eager path rather than replaying discovery from
-the wrong context.
+exact canonical working directory. A stricter per-CWD isolated entry shadows a
+later relaxed template, and Windows environment keys normalize case-insensitively
+before shim override, fingerprinting, or launch. Missing, incompatible, or
+repeatedly racing templates take one bounded cold/eager path rather than replaying
+discovery from the wrong context.
 
 ## Lifecycle and restart safety
 
 An installed generation remains authoritative during retirement until both
 `Process.Done` and process-group or Windows Job authority retirement are proven.
-If that proof is unavailable, muxcore reports `FINALIZE_BLOCKED`, retries the
-same generation, and does not admit an overlapping replacement.
+If that proof is unavailable, muxcore reports `FINALIZE_BLOCKED` and retries
+retirement proof for that same installed generation; it does not admit a
+competing replacement.
 
 Graceful-restart negotiation remains pre-detach: listener, spawn, accept,
 version, or token failures leave the predecessor serving. A later receipt or
@@ -71,6 +74,10 @@ materialization on the original transport, exact environment and isolated-CWD
 template authorization, bounded revision mismatch handling, failure cleanup,
 and process-tree retirement. It also covers pre-detach restart aborts,
 post-detach single-successor fallback, and transactional snapshot activation.
+
+Official CI and release artifacts use Go 1.25.12. Under that toolchain, root
+and muxcore `govulncheck` report zero reachable vulnerabilities; this result
+does not classify an imported-but-unreached advisory as reachable.
 
 Before release closeout, run the current root and muxcore suites, `go vet`, the
 repository critical suite, applicable native-consumer and lifecycle-playbook

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,91 +1,88 @@
-# mcp-mux v0.27.2
+# mcp-mux v0.28.0
 
 **Release date:** 2026-07-17
 
-**Type:** Non-breaking patch release
+**Type:** Backward-compatible feature release
 
 ## Summary
 
-v0.27.2 fixes a process-authority race for snapshot/template owners. A restored
-owner can begin materializing its cached upstream in the background while its
-first uncached request arrives. Before this patch, the request path could start
-a second respawn before the background start published readiness. Both paths
-could then install different processes into the same owner slot, leaving the
-losing upstream generation outside normal finalization.
+v0.28.0 adds demand-driven upstream materialization for compatible
+template-backed owners. After an upstream has published a compatible discovery
+template, a later owner can answer cached `initialize`, `tools/list`, and
+captured discovery requests without starting an upstream process. The first
+uncached request materializes exactly one upstream generation, completes the
+MCP initialization handshake, and forwards the original JSON-RPC request on the
+same open transport.
 
-The request path now joins an already-pending template background start before
-deciding whether respawn is necessary. A successful generation keeps the gate
-pending until the upstream has answered `initialize` and muxcore has written
-`notifications/initialized`, so the first uncached request cannot overtake the
-MCP lifecycle handshake. Exact-generation terminal failure also releases the
-gate into the existing explicit error/respawn path. The wait remains bounded by
-the existing upstream readiness timeout and owner shutdown signal. If the
-completed background start produced a writable upstream, the request uses it;
-otherwise request-triggered respawn remains available.
+Template reuse is fail-closed: authorization requires the full SHA-256 identity
+of the effective security-relevant environment and, for isolated templates, the
+exact canonical working directory. Missing, incompatible, or repeatedly racing
+templates take one bounded cold/eager path rather than replaying discovery from
+the wrong context.
 
-Response ownership is now generation-bound as well. Proactive discovery IDs are
-unique per owner, their registry entries are tied to the exact upstream process
-and drained when that generation dies, and stale or unclaimed responses are
-dropped before they can change caches, pending counts, progress ownership, or
-downstream session routing.
+## Lifecycle and restart safety
 
-This is the conservative race repair. It does not change when template owners
-are eagerly materialized; demand-driven upstream materialization remains a
-separate architecture change and release track.
+An installed generation remains authoritative during retirement until both
+`Process.Done` and process-group or Windows Job authority retirement are proven.
+If that proof is unavailable, muxcore reports `FINALIZE_BLOCKED`, retries the
+same generation, and does not admit an overlapping replacement.
 
-## What changes for users
-
-- Snapshot/template background startup and first-request recovery no longer
-  create competing upstream generations for one owner.
-- Windows source-checkout upstreams no longer receive duplicate concurrent
-  launches from this race, avoiding locked entrypoint replacement failures and
-  the associated crash/respawn storm.
-- Timeout and shutdown remain explicit request errors. The fix does not add
-  unbounded waits or replay already-sent requests.
-- Ordinary `engine.New` and direct muxcore consumers require no source changes.
+Graceful-restart negotiation remains pre-detach: listener, spawn, accept,
+version, or token failures leave the predecessor serving. A later receipt or
+final-ack failure must prove the failed successor exited, finalize the detached
+generation, rewrite the pinned snapshot, and pre-start exactly one clean
+snapshot successor before predecessor shutdown.
 
 ## Upgrade
 
+Upgrade muxcore consumers to the released tag:
+
 ```bash
-go get github.com/thebtf/mcp-mux/muxcore@v0.27.2
+go get github.com/thebtf/mcp-mux/muxcore@v0.28.0
 ```
 
-Consumers should remove or quarantine any workaround added specifically for
-duplicate background/request starts. Do not add product-local spawn locks,
-file-replacement retries, PID sweeps, stale-process kill loops, or parallel
-lifecycle mechanisms; they compete with muxcore's Job Object/process-group
-authority and make failures harder to attribute.
+For the product binary, use the documented versioned-engine upgrade path:
+
+```powershell
+.\mcp-mux.exe upgrade --restart
+```
+
+Ordinary `engine.New` consumers require no source changes. Do not add
+consumer-local spawn locks, retry loops, PID sweeps, stale-process kill loops,
+or parallel lifecycle mechanisms; they undermine muxcore's single
+process-tree-authority contract.
+
+## Compatibility and rollback
+
+v0.28.0 is backward compatible for ordinary `engine.New` consumers. Persistent
+owners and callers that explicitly require eager startup continue to
+materialize without waiting for a request.
+
+To roll back, pin `muxcore/v0.27.2` or restore the previous product binary.
+That removes cache-only startup and demand-driven materialization; it does not
+change the v0.27.2 template background-spawn ownership fix. Do not compensate
+with consumer-local process cleanup or retry mechanisms; diagnose the rollback
+reason and upgrade again when resolved.
 
 ## Verification
 
-The release candidate includes deterministic regressions for the background-
-spawn/request-respawn gate, MCP initialization ordering, owner-unique proactive
-IDs, dead-generation proactive drain, stale and unclaimed ordinary responses,
-and the terminal proactive-registration race. The deployed repair completed a
-`32h 18m` post-cutover Windows soak with zero actual runtime locked-entrypoint
-errors and zero request-triggered competing-respawn markers. The same daemon
-generation stayed live; unrelated network-failure respawns are classified
-separately in `.agent/reports/2026-07-17-v0.27.2-soak.md`.
+Release verification covers cache-only discovery replay, first-demand
+materialization on the original transport, exact environment and isolated-CWD
+template authorization, bounded revision mismatch handling, failure cleanup,
+and process-tree retirement. It also covers pre-detach restart aborts,
+post-detach single-successor fallback, and transactional snapshot activation.
 
-Release closeout still requires the current root and muxcore suites, `go vet`,
-the repository critical suite, applicable native-consumer and lifecycle
-playbook evidence, independent review, remote tag parity, published artifact
-verification, and public muxcore module resolution.
+Before release closeout, run the current root and muxcore suites, `go vet`, the
+repository critical suite, applicable native-consumer and lifecycle-playbook
+evidence, independent review, published artifact/tag parity checks, and public
+muxcore module resolution.
 
-## Consumer handoff closeout
+## Consumer handoff
 
-This release affects every muxcore consumer that can restore snapshot/template
-owners and accept requests while background startup is pending. After
-`muxcore/v0.27.2` resolves, release closeout must update and re-read the Aimux
-and Engram adoption issues with the tagged version, the single-authority
-invariant, forbidden local workarounds, customer-mode smoke expectations,
-rollback notes, and provider evidence. If that cannot be completed, record
-`CONSUMER_HANDOFF_BLOCKED` and do not call the full critical muxcore scope
-shipped.
-
-## Rollback
-
-Consumers can pin `muxcore/v0.27.1` or restore the previous product binary. That
-rollback reintroduces the snapshot/template background-start race. Do not mask
-it with consumer-local retry or process cleanup loops; prefer upgrading again
-to v0.27.2 after diagnosing the rollback reason.
+This release affects muxcore consumers that restore owners, use discovery
+caches, or manage daemon restart. After `muxcore/v0.28.0` resolves, update and
+re-read the Aimux and Engram adoption issues with the tagged version, cache-only
+startup behavior, single-authority invariant, forbidden local workarounds,
+customer-mode smoke expectations, rollback notes, and provider evidence. If
+that cannot be completed, record `CONSUMER_HANDOFF_BLOCKED` and do not call the
+full critical muxcore scope shipped.

--- a/TECHNICAL_DEBT.md
+++ b/TECHNICAL_DEBT.md
@@ -29,7 +29,21 @@ All items from the 2026-04-08 debt batch have been resolved:
 
 ## Open items
 
-(none)
+The following v0.28.0 follow-ups are non-blocking and out of scope for the
+current release:
+
+- **Cancellation provenance fallback** — unknown or expired cancellation may
+  currently target the current generation after inflight provenance is gone;
+  consider dropping the fallback or retaining a short-lived generation
+  tombstone.
+- **Extremal retry coverage** — add a test with two prior general spawn retries,
+  followed by two template mismatches and the cold fifth attempt.
+- **Windows DACL isolation** — evaluate a logon-SID DACL instead of an
+  account-SID DACL only if terminal-session isolation becomes a requirement.
+- **Detached listener test flake** —
+  `TestDetachedProcessListenerAcceptsParentDial` failed once in the full Windows
+  muxcore suite with empty helper output but passed 10 focused repetitions;
+  investigate separately.
 
 
 <!--

--- a/docs/PRODUCTION-TESTING-PLAYBOOK.md
+++ b/docs/PRODUCTION-TESTING-PLAYBOOK.md
@@ -516,8 +516,8 @@ Broken signals:
 - An already-sent in-flight request is replayed after reconnect instead of
   receiving one explicit error with its original id.
 - A persistent owner suspends or reaps.
-- A v1 peer detaches before version rejection, or fallback loops through more
-  than one cold respawn.
+- A v1 peer detaches, starts snapshot fallback, or shuts down the predecessor
+  instead of failing negotiation with the predecessor still serving.
 - A v2 predecessor releases tree authority before final adoption, both daemon
   generations retain authority, or any descendant survives final tree cleanup.
 
@@ -536,7 +536,7 @@ with this table:
 | 5b | Native Muxcore Consumer Hot Update | Consumer-owned update path preserves MCP session and reports new version |  | PASS/FAIL/SKIPPED |
 | 6 | Isolated Short Idle Cleanup (v0.25.0) | Target isolated owner reaped within ~70s of zero sessions (60s idle + 10s sweep) |  | PASS/FAIL |
 | 7 | Credential Boundary (v0.25.0) | 2 owners under different credential, 2 under presence asymmetry |  | PASS/FAIL |
-| 8 | Lifecycle Convergence and Tree Authority (v0.27.0) | Dormant wake is exact-once; v1 fallback is bounded; same-v2 handoff retains one full-tree authority |  | PASS/FAIL |
+| 8 | Lifecycle Convergence and Tree Authority (v0.27.0+) | Dormant wake is exact-once; v1 skew aborts pre-detach; post-Hello fallback is single-shot; same-v2 handoff retains one full-tree authority |  | PASS/FAIL |
 | 9 | Critical muxcore consumer handoff | `CONSUMER_HANDOFF_PASS`, or `CONSUMER_HANDOFF_BLOCKED` with the full critical scope not called shipped |  | PASS/BLOCKED |
 
 Overall verdict:

--- a/docs/PRODUCTION-TESTING-PLAYBOOK.md
+++ b/docs/PRODUCTION-TESTING-PLAYBOOK.md
@@ -521,6 +521,55 @@ Broken signals:
 - A v2 predecessor releases tree authority before final adoption, both daemon
   generations retain authority, or any descendant survives final tree cleanup.
 
+## Scenario 9: Demand-Driven Upstream Materialization (v0.28.0)
+
+Run this scenario for v0.28.0 and later releases that change template-backed
+owner discovery, demand-driven upstream creation, template compatibility, or
+template revision publication.
+
+Objective: prove template-backed MCP entries publish cached discovery without
+starting an upstream, then materialize exactly one compatible owner only when
+an uncached request demands it.
+
+Focused automated proof:
+
+```powershell
+Push-Location muxcore
+go test ./daemon -run 'Test(TemplateBackedIsolatedStormMaterializesOnlyDemandedOwner|TemplateBackedSharedStormConvergesOneOwnerOneGeneration|CodexEightEntryHandshakeBurstSameTransportWake|CompatibleTemplateCachedBurstThenUncachedWakeSameIPCSession|TemplateCompatibilityUsesExactEnvAndIsolatedCwd|TwoTemplateRevisionMismatchesThenOneColdBypassWithoutStaleFrames|PersistentTemplateMaterializesEagerly)' -count=1
+Pop-Location
+```
+
+Customer-mode observed invariants:
+
+1. Start eight template-backed Codex-style entries with compatible isolated
+   contexts. Cached discovery completes with **8 owners, 0 upstream processes,
+   and 0 starts**.
+2. Send an uncached request through one existing open IPC transport. The
+   request returns successfully on that same transport, then topology reports
+   **8 owners, 1 upstream process, and 1 start**.
+3. Repeat the burst for a shared template. The storm converges to **1 owner and
+   0 processes** before demand, then produces exactly **1 generation** after
+   demand.
+4. Replay using an incompatible CWD or effective environment. It reuses zero
+   cached discovery and follows the bounded cold path; it must not receive
+   stale cached frames.
+5. Repeat with a persistent/eager template owner. It still starts eagerly,
+   rather than waiting for an uncached request.
+
+Broken signals:
+
+- Any template-backed discovery starts an upstream before an uncached request,
+  or eight isolated entries do not remain eight owners with zero starts.
+- The uncached request fails, uses a new IPC transport, creates more than one
+  upstream generation, or leaves counts other than 8 owners / 1 process / 1
+  start.
+- A shared storm has more than one owner before demand or more than one
+  generation after demand.
+- An incompatible CWD or effective environment receives cached frames, retries
+  without the bounded cold path, or sees stale frames after revision mismatch.
+- A persistent/eager template owner waits for demand instead of starting
+  eagerly.
+
 ## Verdict Template
 
 Create a run report under `.agent/reports/emulation-playbook-run-YYYYMMDD-HHMM.md`
@@ -537,7 +586,8 @@ with this table:
 | 6 | Isolated Short Idle Cleanup (v0.25.0) | Target isolated owner reaped within ~70s of zero sessions (60s idle + 10s sweep) |  | PASS/FAIL |
 | 7 | Credential Boundary (v0.25.0) | 2 owners under different credential, 2 under presence asymmetry |  | PASS/FAIL |
 | 8 | Lifecycle Convergence and Tree Authority (v0.27.0+) | Dormant wake is exact-once; v1 skew aborts pre-detach; post-Hello fallback is single-shot; same-v2 handoff retains one full-tree authority |  | PASS/FAIL |
-| 9 | Critical muxcore consumer handoff | `CONSUMER_HANDOFF_PASS`, or `CONSUMER_HANDOFF_BLOCKED` with the full critical scope not called shipped |  | PASS/BLOCKED |
+| 9 | Demand-Driven Upstream Materialization (v0.28.0) | 8 owners / 0 processes before demand; same transport response; 8 / 1 after one wake; one authority |  | PASS/FAIL |
+| 10 | Critical muxcore consumer handoff | `CONSUMER_HANDOFF_PASS`, or `CONSUMER_HANDOFF_BLOCKED` with the full critical scope not called shipped |  | PASS/BLOCKED |
 
 Overall verdict:
 

--- a/docs/PRODUCTION-TESTING-PLAYBOOK.md
+++ b/docs/PRODUCTION-TESTING-PLAYBOOK.md
@@ -490,11 +490,11 @@ Runtime idle/dormant proof:
 
 Planned-restart proof:
 
-- v1-to-v2: start a pre-v0.27 candidate, stage v0.27.0, and request the normal
+- v1-to-v2: start a pre-v0.27 candidate, stage v0.28.0, and request the normal
   safe restart with zero live sessions. Evidence must show protocol mismatch
-  before owner detach, one bounded `snapshot_fallback` respawn, and a usable
-  successor. In-flight work may receive explicit JSON-RPC errors by original
-  id; it must not be replayed.
+  before owner detach, the predecessor still serving, and no snapshot fallback
+  or successor spawn. In-flight work may receive explicit JSON-RPC errors by
+  original id; it must not be replayed.
 - v2-to-v2: restart between two v2 candidates with a subprocess tree. Evidence
   must show `snapshot_handoff`, a changed daemon generation, the same upstream
   PID/process tree, a complete accepted/aborted final partition, and no

--- a/docs/PRODUCTION-TESTING-PLAYBOOK.md
+++ b/docs/PRODUCTION-TESTING-PLAYBOOK.md
@@ -28,7 +28,7 @@ health/status surface, and chosen update topology.
   sandboxed agent hosts can produce a host-specific Windows named-pipe
   `Access is denied` false failure. The script self-reexecs under `pwsh` when
   launched from Windows PowerShell 5.1.
-- Go toolchain matching CI (`go version` should be compatible with `go 1.25`).
+- Go 1.25.12 matching CI (`go version` should report Go 1.25.12).
 - `uvx` available for `mcp-server-time`.
 - `D:\Dev\mcp-launcher\mcp-launcher.exe` available for the topology PoC.
 - Do not run smoke tests directly against the production binary path
@@ -535,7 +535,8 @@ Focused automated proof:
 
 ```powershell
 Push-Location muxcore
-go test ./daemon -run 'Test(TemplateBackedIsolatedStormMaterializesOnlyDemandedOwner|TemplateBackedSharedStormConvergesOneOwnerOneGeneration|CodexEightEntryHandshakeBurstSameTransportWake|CompatibleTemplateCachedBurstThenUncachedWakeSameIPCSession|TemplateCompatibilityUsesExactEnvAndIsolatedCwd|TwoTemplateRevisionMismatchesThenOneColdBypassWithoutStaleFrames|PersistentTemplateMaterializesEagerly)' -count=1
+$env:GOTOOLCHAIN = 'go1.25.12'
+go test ./daemon -run 'Test(TemplateBackedIsolatedStormMaterializesOnlyDemandedOwner|TemplateBackedSharedStormConvergesOneOwnerOneGeneration|CodexEightEntryHandshakeBurstSameTransportWake|CompatibleTemplateCachedBurstThenUncachedWakeSameIPCSession|TemplateCompatibilityUsesExactEnvAndIsolatedCwd|IncompatibleTemplateContextGetsNoCachedFramesAndOneColdProcess|TwoTemplateRevisionMismatchesThenOneColdBypassWithoutStaleFrames|PersistentTemplateMaterializesEagerly)' -count=1
 Pop-Location
 ```
 

--- a/muxcore/README.md
+++ b/muxcore/README.md
@@ -41,6 +41,40 @@ owner. v0.27.2 makes a first uncached request join an already-pending
 snapshot/template background start through its MCP initialization handshake
 instead of creating a competing upstream generation for the same owner.
 
+### Unreleased - demand-driven upstream materialization
+
+**No consumer API change is required for ordinary `engine.New` users.** After
+one generation has published a compatible discovery template, muxcore can
+construct a cache-only owner that serves cached `initialize` and `tools/list`
+without spawning an upstream process. The first uncached request retains its
+original JSON-RPC ID and session, starts one generation, waits for the MCP
+initialization handshake, and is forwarded once on the same transport.
+
+Template authorization is intentionally stricter than live shared-owner
+compatibility: it compares a full SHA-256 identity of the effective
+security-relevant environment, and isolated templates also require the exact
+canonical CWD. Raw identity values remain only in the existing launch context.
+Missing, incompatible, or repeatedly racing templates take one bounded
+cold/eager path and never receive partial cached replay.
+
+Lifecycle integration is fail-closed. A failed installed process remains the
+authoritative generation through retirement until `Process.Done` and process
+group / Windows Job authority finalization are both proven. Reaper, operator
+removal, snapshot fallback, restart pins, and protocol-v2 handoff cannot admit a
+replacement while that proof is missing; status reports `FINALIZE_BLOCKED` and
+the exact generation is retried.
+
+Graceful restart keeps version/token negotiation strictly pre-detach: mismatch,
+accept timeout, or successor-start failure leaves the predecessor serving and
+does not spawn fallback. A later protocol failure must stop the failed handoff
+successor, abort the prepared generation, rewrite the pinned snapshot, and
+pre-start exactly one clean snapshot successor before predecessor shutdown.
+
+Staged snapshot activation is transactional. If any fallback owner cannot be
+constructed, muxcore rolls back partial registrations, rewrites the filtered
+recovery snapshot with the exact pinned launch environment, and fails startup
+before the successor control endpoint begins serving.
+
 ### v0.27.2 - template background-spawn ownership gate
 
 **No required consumer code changes for ordinary `engine.New` users.** When a
@@ -62,8 +96,8 @@ This preserves one authoritative upstream process tree per owner and prevents
 duplicate source-checkout launches, locked entrypoint replacement failures, and
 respawn storms from this race. Consumers must not add product-local spawn locks,
 file-replacement retries, PID sweeps, stale-process kill loops, or parallel
-lifecycle mechanisms. Demand-driven template materialization is a separate
-future architecture change; v0.27.2 is the conservative ownership repair.
+lifecycle mechanisms. Demand-driven template materialization is not part of
+v0.27.2; its unreleased consumer contract is documented above.
 
 ### v0.27.1 - idle-gate rolling-compatibility hotfix
 

--- a/muxcore/README.md
+++ b/muxcore/README.md
@@ -12,36 +12,28 @@ Claude/Codex config, use the top-level `mcp-mux` CLI instead.
 
 Pin a tagged muxcore module. Do not depend on `latest` for production
 consumers; muxcore is a runtime layer and downstream behavior changes matter.
-After the `muxcore/v0.27.2` tag is published and resolves through the Go proxy,
-upgrade with:
+Install the current release after its tag resolves through the Go proxy:
 
 ```bash
-go get github.com/thebtf/mcp-mux/muxcore@v0.27.2
+go get github.com/thebtf/mcp-mux/muxcore@v0.28.0
 ```
 
-Until that tag resolves, keep production consumers on v0.27.1; do not pin this
-branch or a pseudo-version. Use v0.27.2 as the consumer target after publication.
+v0.28.0 includes the v0.25.3 native SessionHandler hot-update contract
+(`RestartWithSuccessor` / `ApplyUpdateAndRestart`), the v0.26.x opt-in daemon
+registry, the v0.26.4 occupied-control-pipe guard, the v0.26.5 owner fanout
+reduction, and the v0.26.6 auto-managed engine namespace. It preserves
+snapshot-restored `tools/list` cache during background refresh, keeps live
+downstream sessions attached across upstream process exit/update with explicit
+JSON-RPC errors for in-flight requests, enters degraded retry without closing
+the parent stdio transport, and safely cleans zero-session disposable owners.
+v0.27.0 adds opt-in shim idle/dormant controls, protocol-v2 tree-authority
+handoff, and full process-tree containment. v0.27.1 prevents permanent
+idle-gate outcomes from creating a control-plane retry herd, and v0.27.2 makes
+the first uncached request join a pending snapshot/template background start.
+v0.28.0 adds cache-only startup and demand-driven materialization for compatible
+templates.
 
-v0.27.2 includes the v0.25.3 native SessionHandler hot-update contract (`RestartWithSuccessor` /
-`ApplyUpdateAndRestart`), the v0.26.x opt-in daemon registry, the v0.26.4
-occupied-control-pipe guard, the v0.26.5 owner fanout reduction, and the
-v0.26.6 auto-managed engine namespace. It also preserves snapshot-restored
-`tools/list` cache during background refresh so new MCP host sessions can replay
-cached tool discovery while the replacement upstream refreshes. For pipe-backed
-owners, it also keeps live downstream sessions attached across upstream process
-exit/update by draining current in-flight requests with explicit JSON-RPC
-errors and automatically respawning the replacement upstream for the next
-request. Reconnect timeout now enters degraded retry instead of closing the
-parent stdio transport, and zero-session disposable owners are cleaned
-automatically after a short safety-gated delay. v0.27.0 adds opt-in shim
-idle/dormant controls, protocol-v2 tree-authority handoff, and full process-tree
-containment. v0.27.1 prevents permanent idle-gate outcomes from creating a
-control-plane retry herd and binds normal product gate checks to one exact
-owner. v0.27.2 makes a first uncached request join an already-pending
-snapshot/template background start through its MCP initialization handshake
-instead of creating a competing upstream generation for the same owner.
-
-### Unreleased - demand-driven upstream materialization
+### v0.28.0 - demand-driven upstream materialization
 
 **No consumer API change is required for ordinary `engine.New` users.** After
 one generation has published a compatible discovery template, muxcore can
@@ -96,8 +88,8 @@ This preserves one authoritative upstream process tree per owner and prevents
 duplicate source-checkout launches, locked entrypoint replacement failures, and
 respawn storms from this race. Consumers must not add product-local spawn locks,
 file-replacement retries, PID sweeps, stale-process kill loops, or parallel
-lifecycle mechanisms. Demand-driven template materialization is not part of
-v0.27.2; its unreleased consumer contract is documented above.
+lifecycle mechanisms. Demand-driven template materialization is part of
+v0.28.0; v0.27.2 remains the conservative ownership repair.
 
 ### v0.27.1 - idle-gate rolling-compatibility hotfix
 

--- a/muxcore/control/control_test.go
+++ b/muxcore/control/control_test.go
@@ -864,6 +864,43 @@ func TestCloseIdempotent(t *testing.T) {
 	srv.Close() // second close must be a no-op, not a panic
 }
 
+func TestPausedServerDoesNotDispatchUntilStart(t *testing.T) {
+	path := testSocketPath(t)
+	srv, err := NewPausedServer(path, &mockHandler{}, testLogger(t))
+	if err != nil {
+		t.Fatalf("NewPausedServer: %v", err)
+	}
+	defer srv.Close()
+
+	result := make(chan error, 1)
+	go func() {
+		resp, sendErr := SendWithTimeout(path, Request{Cmd: "status"}, 2*time.Second)
+		if sendErr == nil && !resp.OK {
+			sendErr = fmt.Errorf("status response not OK: %s", resp.Message)
+		}
+		result <- sendErr
+	}()
+	select {
+	case err := <-result:
+		t.Fatalf("paused server dispatched before Start: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	srv.Start()
+	srv.Start()
+	select {
+	case err := <-result:
+		if err != nil {
+			t.Fatalf("status after Start: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("paused server did not dispatch after Start")
+	}
+	srv.Close()
+	srv.Close()
+	srv.Start()
+}
+
 func TestCloseRemovesSocketPath(t *testing.T) {
 	path := testSocketPath(t)
 	handler := &mockHandler{}

--- a/muxcore/control/server.go
+++ b/muxcore/control/server.go
@@ -21,10 +21,11 @@ type Server struct {
 	handler    CommandHandler
 	logger     *log.Logger
 
-	mu     sync.Mutex
-	closed bool
-	done   chan struct{}
-	wg     sync.WaitGroup
+	mu      sync.Mutex
+	started bool
+	closed  bool
+	done    chan struct{}
+	wg      sync.WaitGroup
 }
 
 var (
@@ -34,22 +35,40 @@ var (
 
 // NewServer creates and starts a control server at the given socket path.
 func NewServer(socketPath string, handler CommandHandler, logger *log.Logger) (*Server, error) {
+	s, err := NewPausedServer(socketPath, handler, logger)
+	if err != nil {
+		return nil, err
+	}
+	s.Start()
+	return s, nil
+}
+
+// NewPausedServer binds the control socket without accepting connections.
+// Call Start after the handler's restart state is ready to serve.
+func NewPausedServer(socketPath string, handler CommandHandler, logger *log.Logger) (*Server, error) {
 	ln, err := ipc.Listen(socketPath)
 	if err != nil {
 		return nil, fmt.Errorf("control: listen %s: %w", socketPath, err)
 	}
-
-	s := &Server{
+	return &Server{
 		listener:   ln,
 		socketPath: socketPath,
 		handler:    handler,
 		logger:     logger,
 		done:       make(chan struct{}),
+	}, nil
+}
+
+// Start begins accepting connections. Repeated calls and calls after Close are no-ops.
+func (s *Server) Start() {
+	s.mu.Lock()
+	if s.started || s.closed {
+		s.mu.Unlock()
+		return
 	}
-
+	s.started = true
+	s.mu.Unlock()
 	go s.acceptLoop()
-
-	return s, nil
 }
 
 func (s *Server) acceptLoop() {
@@ -309,8 +328,10 @@ func (s *Server) writeResponse(conn net.Conn, resp Response) error {
 	return io.ErrShortWrite
 }
 
-var errUnknownToken = errors.New("unknown token")
-var errOwnerGone = errors.New("owner gone")
+var (
+	errUnknownToken = errors.New("unknown token")
+	errOwnerGone    = errors.New("owner gone")
+)
 
 func matchesControlError(err error, target error) bool {
 	return errors.Is(err, target) || err.Error() == target.Error()

--- a/muxcore/daemon/daemon.go
+++ b/muxcore/daemon/daemon.go
@@ -2943,15 +2943,8 @@ func mergeEnv(shimEnv map[string]string) map[string]string {
 		return merged
 	}
 
-	windowsKeys := make(map[string]string, len(shimEnv)+64)
 	set := func(key, value string) {
-		folded := strings.ToUpper(key)
-		if existing, ok := windowsKeys[folded]; ok {
-			merged[existing] = value
-			return
-		}
-		windowsKeys[folded] = key
-		merged[key] = value
+		merged[strings.ToUpper(key)] = value
 	}
 	for _, entry := range os.Environ() {
 		if i := strings.IndexByte(entry, '='); i > 0 {

--- a/muxcore/daemon/daemon.go
+++ b/muxcore/daemon/daemon.go
@@ -39,6 +39,10 @@ import (
 // FR-6 retry pattern that replaced the old recursive d.Spawn(req) calls.
 var errSpawnRetry = errors.New("spawn: retry requested")
 
+// errTemplateRevisionMismatch requests the bounded fresh-template retry path
+// without consuming Spawn's general retry budget.
+var errTemplateRevisionMismatch = errors.New("spawn: template revision mismatch")
+
 var errNoHandoffUpstreams = errors.New("no process-backed owners to hand off")
 
 const snapshotRestartEnv = "MCPMUX_SNAPSHOT_RESTART"
@@ -74,10 +78,12 @@ var ErrOwnerGone = errors.New("owner gone")
 // spawns because shutdown or graceful restart has already begun.
 var ErrDaemonShuttingDown = errors.New("daemon shutting down")
 
-// maxSpawnRetries bounds the retry budget in Spawn. Three iterations handle the
-// realistic cases (stuck placeholder cleanup + one isolated-mode promotion);
-// exhaustion is treated as a hard failure and returned to the caller.
-const maxSpawnRetries = 3
+// maxSpawnRetries bounds general retry requests in Spawn. Template revision
+// mismatches have their own budget so the required cold bypass remains reachable.
+const (
+	maxSpawnRetries               = 3
+	maxTemplateRevisionMismatches = 2
+)
 
 const defaultZeroSessionCleanupDelay = 30 * time.Second
 
@@ -1131,19 +1137,28 @@ func (d *Daemon) waitForOwnerAdmissionThaw(o *owner.Owner) error {
 // ("owner not accepting but has active sessions — retry in isolated mode")
 // called d.Spawn(req) recursively. Two audit agents (code-reviewer H2,
 // bug-hunter BUG-005) flagged the stack-depth risk and the comment-vs-code
-// divergence. spawnOnce now returns errSpawnRetry on those paths; Spawn loops
-// up to maxSpawnRetries times and surfaces an error on exhaustion.
+// divergence. General retries remain bounded by maxSpawnRetries. Template
+// revision mismatches are separately bounded so two mismatches still reach one
+// cold/template-bypass attempt even after an earlier general retry.
 func (d *Daemon) Spawn(req control.Request) (string, string, string, error) {
 	var isolatedRetry int64
 	templateMismatches := 0
 	templateBypass := false
-	for attempt := 0; attempt < maxSpawnRetries; attempt++ {
+	generalRetries := 0
+	for range maxSpawnRetries + maxTemplateRevisionMismatches {
 		ipcPath, sid, token, err := d.spawnOnce(&req, &isolatedRetry, &templateMismatches, &templateBypass)
-		if !errors.Is(err, errSpawnRetry) {
+		switch {
+		case errors.Is(err, errTemplateRevisionMismatch):
+			continue
+		case !errors.Is(err, errSpawnRetry):
 			return ipcPath, sid, token, err
 		}
+		generalRetries++
+		if generalRetries >= maxSpawnRetries {
+			return "", "", "", fmt.Errorf("spawn %s: exhausted retry budget after %d attempts", req.Command, maxSpawnRetries)
+		}
 	}
-	return "", "", "", fmt.Errorf("spawn %s: exhausted retry budget after %d attempts", req.Command, maxSpawnRetries)
+	return "", "", "", fmt.Errorf("spawn %s: exhausted bounded retry loop after %d general retries and %d template revision mismatches", req.Command, generalRetries, templateMismatches)
 }
 
 func (d *Daemon) promoteIsolatedRetry(req *control.Request, entry *OwnerEntry) int64 {
@@ -1665,10 +1680,11 @@ func (d *Daemon) spawnOnce(reqPtr *control.Request, isolatedRetry *int64, templa
 		o.Shutdown()
 		if staleTemplate {
 			*templateMismatches++
-			if *templateMismatches >= 2 {
+			if *templateMismatches >= maxTemplateRevisionMismatches {
 				*templateBypass = true
 			}
 			d.logger.Printf("template revision changed before promotion for %s (revision=%d mismatches=%d bypass=%v)", req.Command, selectedTemplate.revision, *templateMismatches, *templateBypass)
+			return "", "", "", errTemplateRevisionMismatch
 		}
 		return "", "", "", errSpawnRetry
 	}

--- a/muxcore/daemon/daemon.go
+++ b/muxcore/daemon/daemon.go
@@ -6,7 +6,6 @@ package daemon
 import (
 	"context"
 	"crypto/rand"
-	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -25,6 +24,7 @@ import (
 	muxcore "github.com/thebtf/mcp-mux/muxcore"
 	"github.com/thebtf/mcp-mux/muxcore/classify"
 	"github.com/thebtf/mcp-mux/muxcore/control"
+	"github.com/thebtf/mcp-mux/muxcore/internal/envidentity"
 	"github.com/thebtf/mcp-mux/muxcore/owner"
 	"github.com/thebtf/mcp-mux/muxcore/registry"
 	"github.com/thebtf/mcp-mux/muxcore/serverid"
@@ -100,6 +100,35 @@ type OwnerEntry struct {
 	// the cause correctly instead of defaulting to HintNone.
 	// In-memory only — not serialized.
 	terminationHint TerminationHint
+	// snapshotPins leases this entry across restart serialization without
+	// holding d.mu while owner-local locks are acquired. snapshotUnpinned is
+	// closed when the final lease releases so removal paths can retry.
+	snapshotPins     int
+	snapshotUnpinned chan struct{}
+	// removalInProgress prevents restart serialization from pinning an owner
+	// after teardown has begun but before whole-tree finalization is proven.
+	removalInProgress bool
+	removalRetrying   bool
+}
+
+type templateEntry struct {
+	snapshot       mcpsnapshot.OwnerSnapshot
+	classification classify.SharingMode
+	envIdentity    envidentity.Identity
+	canonicalCwd   string
+}
+
+type templateFamily struct {
+	revision uint64
+	entries  map[string]templateEntry
+}
+
+type templateMatch struct {
+	snapshot    mcpsnapshot.OwnerSnapshot
+	key         string
+	scope       string
+	revision    uint64
+	envIdentity envidentity.Identity
 }
 
 // Daemon manages N owners, handles spawn/remove, and implements control.DaemonHandler.
@@ -142,9 +171,27 @@ type Daemon struct {
 	// session disconnects. It uses the same activity gates as the reaper but
 	// does not wait for the coarse reaper interval/ownerIdleTimeout path.
 	zeroSessionCleanupDelay time.Duration
-	idleTimeout             time.Duration                        // daemon-level auto-exit timeout (zero owners + zero sessions)
-	templateCache           map[string]mcpsnapshot.OwnerSnapshot // command+args key → cached init data
+	idleTimeout             time.Duration // daemon-level auto-exit timeout (zero owners + zero sessions)
+	templateCache           map[string]*templateFamily
 
+	// beforeTemplatePromotion is a narrow deterministic test seam. Production
+	// leaves it nil. It runs after a cache-only owner is constructed but before
+	// the template revision is revalidated and the placeholder is promoted.
+	beforeTemplatePromotion func()
+	// beforeOwnerCachePublish is a deterministic test seam for the cold-start
+	// registration barrier. Production leaves it nil.
+	beforeOwnerCachePublish func(*owner.Owner)
+	// beforeColdOwnerPromotion verifies daemon-managed cold owners remain inert
+	// until their exact OwnerEntry can be installed. Production leaves it nil.
+	beforeColdOwnerPromotion func(*owner.Owner)
+	// beforeSnapshotOwnerExport is a narrow deterministic test seam. It runs
+	// while the daemon read lock pins OwnerEntry lifetime during serialization.
+	beforeSnapshotOwnerExport func()
+
+	// restartStaging holds metadata-only snapshot entries that must not bind
+	// owner IPC or start an upstream until control-socket takeover proves the
+	// predecessor has finalized its non-transferred process authority.
+	restartStaging []snapshotRestorePlan
 	// supervisor manages owner lifecycle with exponential backoff on restart.
 	// Owners are added via supervisor.Add in Spawn() and removed via
 	// supervisor.Remove in daemon.Remove. Context-cancelled on Shutdown.
@@ -443,7 +490,7 @@ func New(cfg Config) (*Daemon, error) {
 		isolatedIdleTimeout:     isolatedIdleTimeout,
 		admissionBufferTimeout:  admissionBufferTimeout,
 		idleTimeout:             idleTimeout,
-		templateCache:           make(map[string]mcpsnapshot.OwnerSnapshot),
+		templateCache:           make(map[string]*templateFamily),
 		crashTracker:            make(map[string][]time.Time),
 		supervisorCtx:           supCtx,
 		supervisorCancel:        supCancel,
@@ -483,12 +530,16 @@ func New(cfg Config) (*Daemon, error) {
 		if isSnapshotRestartMode() && !isHandoffMode() {
 			modeLabel = "snapshot restart mode"
 		}
-		if restored := d.loadSnapshot(); restored > 0 {
-			logger.Printf("startup: restored %d owners from snapshot (%s)", restored, modeLabel)
-		}
+		planned := d.loadSnapshot()
 		if err := d.retryControlBind(cfg.ControlPath); err != nil {
-			supCancel()
+			d.shutdown(nil)
 			return nil, fmt.Errorf("daemon: %w", err)
+		}
+		// The control endpoint can bind only after the predecessor has released
+		// it. This is the predecessor-finalized barrier for metadata-only owners.
+		d.activateRestartStaging()
+		if planned > 0 {
+			logger.Printf("startup: restored %d owners from snapshot (%s)", d.OwnerCount(), modeLabel)
 		}
 		logger.Printf("daemon started, control socket: %s (%s)", cfg.ControlPath, modeLabel)
 	} else {
@@ -771,30 +822,167 @@ func generateGeneration(prefix string) (string, error) {
 	return prefix + "_" + token, nil
 }
 
-// Spawn creates or returns an existing owner for the given server identity.
-// Deduplication: if a shared owner for the same command+args already exists
-// templateKey returns a cache key based on command+args only (ignoring cwd/env).
-// All instances of the same server share identical init/tools responses.
+// templateKey identifies a command family. Context compatibility is enforced
+// separately by each revisioned template entry.
 func templateKey(command string, args []string) string {
 	return serverid.GenerateContextKey(serverid.ModeGlobal, command, args, nil, "")
 }
 
-// updateTemplate stores an owner's cached state as a template for future isolated spawns.
-func (d *Daemon) updateTemplate(command string, args []string, snap mcpsnapshot.OwnerSnapshot) {
-	key := templateKey(command, args)
-	d.mu.Lock()
-	d.templateCache[key] = snap
-	d.mu.Unlock()
-	d.logger.Printf("template cache updated for %s (key=%s)", command, key[:8])
+func templateScope(mode classify.SharingMode, cwd, envFingerprint string) (string, bool) {
+	switch mode {
+	case classify.ModeIsolated:
+		return string(mode) + "\x00" + envFingerprint + "\x00" + serverid.CanonicalizePath(cwd), true
+	case classify.ModeShared, classify.ModeSessionAware:
+		return string(mode) + "\x00" + envFingerprint, true
+	default:
+		return "", false
+	}
 }
 
-// getTemplate returns a cached template for the given command+args, if available.
+func cloneTemplateSnapshot(snap mcpsnapshot.OwnerSnapshot) mcpsnapshot.OwnerSnapshot {
+	clone := snap
+	clone.Args = append([]string(nil), snap.Args...)
+	clone.Env = make(map[string]string, len(snap.Env))
+	for key, value := range snap.Env {
+		clone.Env[key] = value
+	}
+	clone.CwdSet = append([]string(nil), snap.CwdSet...)
+	clone.ClassificationReason = append([]string(nil), snap.ClassificationReason...)
+	// A template carries discovery metadata, never live reconnect or process
+	// authority from the owner that published it.
+	clone.BoundTokens = nil
+	clone.UpstreamPID = 0
+	clone.HandoffSocketPath = ""
+	clone.SpawnPgid = 0
+	return clone
+}
+
+// updateTemplate atomically publishes one coherent, context-scoped cache
+// revision. A new verdict for the same effective env replaces any older
+// sharing verdict for that env so stale shared classification cannot survive
+// a later isolated discovery result.
+func (d *Daemon) updateTemplate(command string, args []string, snap mcpsnapshot.OwnerSnapshot) {
+	d.mu.Lock()
+	key, revision, ok := d.updateTemplateLocked(command, args, snap)
+	d.mu.Unlock()
+	if ok {
+		d.logger.Printf("template cache updated for %s (key=%s revision=%d scope=%s)", command, key[:8], revision, snap.Classification)
+	}
+}
+
+// updateTemplateLocked publishes one coherent template while d.mu is held.
+// Keeping owner-entry persistence and the matching template under the same
+// critical section prevents mixed-generation daemon state.
+func (d *Daemon) updateTemplateLocked(command string, args []string, snap mcpsnapshot.OwnerSnapshot) (string, uint64, bool) {
+	effectiveEnv := mergeEnv(snap.Env)
+	envIdentity := envidentity.Build(effectiveEnv)
+	scope, ok := templateScope(snap.Classification, snap.Cwd, envIdentity.Fingerprint)
+	if !ok || snap.CachedInit == "" || snap.CachedTools == "" {
+		return "", 0, false
+	}
+	snap.Command = command
+	snap.Args = append([]string(nil), args...)
+	snap.Env = effectiveEnv
+	snap = cloneTemplateSnapshot(snap)
+	entry := templateEntry{
+		snapshot:       snap,
+		classification: snap.Classification,
+		envIdentity:    envIdentity,
+		canonicalCwd:   serverid.CanonicalizePath(snap.Cwd),
+	}
+	if d.templateCache == nil {
+		d.templateCache = make(map[string]*templateFamily)
+	}
+	key := templateKey(command, args)
+	family := d.templateCache[key]
+	if family == nil {
+		family = &templateFamily{entries: make(map[string]templateEntry)}
+		d.templateCache[key] = family
+	}
+	family.revision++
+	for existingScope, existing := range family.entries {
+		if envidentity.Equal(existing.envIdentity, envIdentity, existing.snapshot.Env, effectiveEnv) && existing.classification != entry.classification {
+			delete(family.entries, existingScope)
+		}
+	}
+	family.entries[scope] = entry
+	return key, family.revision, true
+}
+
+func (d *Daemon) getCompatibleTemplate(command string, args []string, cwd string, effectiveEnv map[string]string) (templateMatch, bool) {
+	key := templateKey(command, args)
+	envIdentity := envidentity.Build(effectiveEnv)
+	canonicalCwd := serverid.CanonicalizePath(cwd)
+	d.mu.RLock()
+	family := d.templateCache[key]
+	if family == nil {
+		d.mu.RUnlock()
+		return templateMatch{}, false
+	}
+	for _, mode := range []classify.SharingMode{classify.ModeIsolated, classify.ModeSessionAware, classify.ModeShared} {
+		scope, _ := templateScope(mode, canonicalCwd, envIdentity.Fingerprint)
+		entry, ok := family.entries[scope]
+		if !ok || !envidentity.Equal(entry.envIdentity, envIdentity, entry.snapshot.Env, effectiveEnv) {
+			continue
+		}
+		match := templateMatch{
+			snapshot:    cloneTemplateSnapshot(entry.snapshot),
+			key:         key,
+			scope:       scope,
+			revision:    family.revision,
+			envIdentity: envIdentity,
+		}
+		d.mu.RUnlock()
+		return match, true
+	}
+	d.mu.RUnlock()
+	return templateMatch{}, false
+}
+
+func (d *Daemon) templateMatchCurrentLocked(match templateMatch) bool {
+	family := d.templateCache[match.key]
+	if family == nil || family.revision != match.revision {
+		return false
+	}
+	entry, ok := family.entries[match.scope]
+	return ok && envidentity.Equal(entry.envIdentity, match.envIdentity, entry.snapshot.Env, match.snapshot.Env)
+}
+
+// getTemplate is retained for package-local readiness tests. Spawn uses the
+// context-authoritative getCompatibleTemplate path above.
 func (d *Daemon) getTemplate(command string, args []string) (mcpsnapshot.OwnerSnapshot, bool) {
 	key := templateKey(command, args)
 	d.mu.RLock()
-	snap, ok := d.templateCache[key]
+	family := d.templateCache[key]
+	if family != nil {
+		for _, entry := range family.entries {
+			snap := cloneTemplateSnapshot(entry.snapshot)
+			d.mu.RUnlock()
+			return snap, true
+		}
+	}
 	d.mu.RUnlock()
-	return snap, ok
+	return mcpsnapshot.OwnerSnapshot{}, false
+}
+
+func (d *Daemon) invalidateTemplate(command string, args []string) {
+	d.mu.Lock()
+	key, existed := d.invalidateTemplateLocked(command, args)
+	d.mu.Unlock()
+	if existed {
+		d.logger.Printf("template cache invalidated for %s (key=%s)", command, key[:8])
+	}
+}
+
+func (d *Daemon) invalidateTemplateLocked(command string, args []string) (string, bool) {
+	key := templateKey(command, args)
+	family := d.templateCache[key]
+	existed := family != nil && len(family.entries) > 0
+	if family != nil {
+		family.revision++
+		family.entries = make(map[string]templateEntry)
+	}
+	return key, existed
 }
 
 // waitForCrossCwdClassify is the CR-002 fresh-consumer admission gate. The
@@ -886,8 +1074,10 @@ func (d *Daemon) warnDeprecatedMode(cmd string, args []string, legacyMode string
 // up to maxSpawnRetries times and surfaces an error on exhaustion.
 func (d *Daemon) Spawn(req control.Request) (string, string, string, error) {
 	var isolatedRetry int64
+	templateMismatches := 0
+	templateBypass := false
 	for attempt := 0; attempt < maxSpawnRetries; attempt++ {
-		ipcPath, sid, token, err := d.spawnOnce(&req, &isolatedRetry)
+		ipcPath, sid, token, err := d.spawnOnce(&req, &isolatedRetry, &templateMismatches, &templateBypass)
 		if !errors.Is(err, errSpawnRetry) {
 			return ipcPath, sid, token, err
 		}
@@ -907,7 +1097,7 @@ func (d *Daemon) promoteIsolatedRetry(req *control.Request, entry *OwnerEntry) i
 // spawnOnce performs one attempt at creating or reusing an owner. It takes req
 // by pointer because some retry paths mutate req.Mode (isolated promotion) and
 // the mutation must persist across iterations of the Spawn retry loop.
-func (d *Daemon) spawnOnce(reqPtr *control.Request, isolatedRetry *int64) (string, string, string, error) {
+func (d *Daemon) spawnOnce(reqPtr *control.Request, isolatedRetry *int64, templateMismatches *int, templateBypass *bool) (string, string, string, error) {
 	req := *reqPtr
 	// CR-002: default Mode flipped from "cwd" → "global". A shim that omits
 	// Mode now gets the global identity (one upstream per (cmd, args)) per the
@@ -940,6 +1130,7 @@ func (d *Daemon) spawnOnce(reqPtr *control.Request, isolatedRetry *int64) (strin
 	if err != nil {
 		return "", "", "", fmt.Errorf("spawn: %w", err)
 	}
+	effectiveEnv := mergeEnv(req.Env)
 
 	// Circuit breaker: reject spawn if the upstream has been crash-looping.
 	// This prevents infinite respawn loops (shim reconnect → spawn → crash → repeat)
@@ -1030,10 +1221,9 @@ func (d *Daemon) spawnOnce(reqPtr *control.Request, isolatedRetry *int64) (strin
 				// returned baseSid. Now we must confirm the new request's env is
 				// compatible; if not, retry so Spawn re-derives the bucketed sid.
 				//
-				// mergeEnv normalizes req.Env to the post-merge form (matches
-				// e.Env's stored form) so envCompatible compares like-for-like
-				// per CodeRabbit PR #121 finding about merge-vs-raw asymmetry.
-				if mode == serverid.ModeGlobal && e.Env != nil && !envCompatible(e.Env, mergeEnv(req.Env)) {
+				// effectiveEnv is the same post-merge form stored on the owner,
+				// so envCompatible compares like-for-like across create waiters.
+				if mode == serverid.ModeGlobal && e.Env != nil && !envCompatible(e.Env, effectiveEnv) {
 					d.logger.Printf("env-incompat after create-wait: owner %s — retrying with bucketed sid", shortServerID(sid))
 					d.mu.Unlock()
 					return "", "", "", errSpawnRetry
@@ -1060,7 +1250,7 @@ func (d *Daemon) spawnOnce(reqPtr *control.Request, isolatedRetry *int64) (strin
 						e.Owner.AddCwd(req.Cwd)
 					}
 				}
-				if !e.Owner.PreRegister(token, req.Cwd, req.Env) {
+				if !e.Owner.PreRegister(token, req.Cwd, effectiveEnv) {
 					if e.Owner.IsClassifiedIsolated() {
 						*isolatedRetry = d.promoteIsolatedRetry(reqPtr, e)
 					}
@@ -1121,7 +1311,7 @@ func (d *Daemon) spawnOnce(reqPtr *control.Request, isolatedRetry *int64) (strin
 				// entry. Without this, concurrent spawns with different
 				// credentials can collapse onto one upstream during startup
 				// storms, defeating the credentials-boundary guarantee.
-				if mode == serverid.ModeGlobal && current.Env != nil && !envCompatible(current.Env, mergeEnv(req.Env)) {
+				if mode == serverid.ModeGlobal && current.Env != nil && !envCompatible(current.Env, effectiveEnv) {
 					d.logger.Printf("env-incompat after CAS on fast path: owner %s — retrying with bucketed sid", shortServerID(probeSID))
 					d.mu.Unlock()
 					return "", "", "", errSpawnRetry
@@ -1147,7 +1337,7 @@ func (d *Daemon) spawnOnce(reqPtr *control.Request, isolatedRetry *int64) (strin
 						probeOwner.AddCwd(req.Cwd)
 					}
 				}
-				if !probeOwner.PreRegister(token, req.Cwd, req.Env) {
+				if !probeOwner.PreRegister(token, req.Cwd, effectiveEnv) {
 					if probeOwner.IsClassifiedIsolated() {
 						*isolatedRetry = d.promoteIsolatedRetry(reqPtr, current)
 					}
@@ -1214,7 +1404,7 @@ func (d *Daemon) spawnOnce(reqPtr *control.Request, isolatedRetry *int64) (strin
 	//    across different CWDs — every process has exactly one CWD, so sharing an
 	//    unclassified server with a different CWD risks context leaks.
 	if mode == serverid.ModeCwd {
-		if existing := d.findSharedOwnerLocked(req.Command, req.Args, req.Env, req.Cwd); existing != nil {
+		if existing := d.findSharedOwnerLocked(req.Command, req.Args, effectiveEnv, req.Cwd); existing != nil {
 			existing.LastSession = time.Now()
 			existingSID := existing.ServerID
 			d.mu.Unlock()
@@ -1223,7 +1413,7 @@ func (d *Daemon) spawnOnce(reqPtr *control.Request, isolatedRetry *int64) (strin
 				// Dedup hot path is silent — logging every reuse produced 500+ lines/minute.
 				existing.Owner.AddCwd(req.Cwd)
 			}
-			if !existing.Owner.PreRegister(token, req.Cwd, req.Env) {
+			if !existing.Owner.PreRegister(token, req.Cwd, effectiveEnv) {
 				if existing.Owner.IsClassifiedIsolated() {
 					*isolatedRetry = d.promoteIsolatedRetry(reqPtr, existing)
 				}
@@ -1263,7 +1453,7 @@ func (d *Daemon) spawnOnce(reqPtr *control.Request, isolatedRetry *int64) (strin
 	// fail with "No GitHub token available for session ...". Merging from the
 	// daemon's own os.Environ() (which was snapshotted at daemon start from the
 	// user env) fills the gap without overriding anything the shim did send.
-	sessionEnv := mergeEnv(req.Env)
+	sessionEnv := effectiveEnv
 	if len(sessionEnv) > 0 {
 		// Log presence (NOT values) of common credential keys so env-passthrough
 		// regressions remain visible. `shim_vars` is the pre-merge count — that
@@ -1279,70 +1469,74 @@ func (d *Daemon) spawnOnce(reqPtr *control.Request, isolatedRetry *int64) (strin
 
 	// Build the shared owner config (used by both template and fresh paths).
 	controlPath := serverid.ControlPath("", d.namespace, sid)
+	materializationPolicy := owner.MaterializationEager
+	if d.persistent {
+		materializationPolicy = owner.MaterializationPersistent
+	}
 	ownerCfg := owner.OwnerConfig{
-		Command:          req.Command,
-		Args:             req.Args,
-		Env:              sessionEnv,
-		Cwd:              req.Cwd,
-		IPCPath:          ipcPath,
-		ControlPath:      controlPath,
-		ServerID:         sid,
-		TokenHandshake:   true, // daemon-managed owners: shims send a handshake token
-		HandlerFunc:      d.handlerFunc,
-		SessionHandler:   d.sessionHandler,
-		AuthorizeSession: d.authorizeSession,
-		OnFrameReceived:  d.onFrameReceived,
-		OnZeroSessions: func(serverID string) {
-			d.onZeroSessions(serverID)
+		Command:                     req.Command,
+		Args:                        req.Args,
+		Env:                         sessionEnv,
+		Cwd:                         req.Cwd,
+		IPCPath:                     ipcPath,
+		ControlPath:                 controlPath,
+		ServerID:                    sid,
+		TokenHandshake:              true, // daemon-managed owners: shims send a handshake token
+		MaterializationPolicy:       materializationPolicy,
+		DeferInitialMaterialization: true,
+		PersistentRequired:          d.persistent,
+		HandlerFunc:                 d.handlerFunc,
+		SessionHandler:              d.sessionHandler,
+		AuthorizeSession:            d.authorizeSession,
+		OnFrameReceived:             d.onFrameReceived,
+		OnZeroSessions:              d.onZeroSessions,
+		OnUpstreamExit:              d.onUpstreamExit,
+		OnPersistentDetected: func(expected *owner.Owner) {
+			d.setOwnerPersistent(expected, true)
 		},
-		OnUpstreamExit: func(serverID string) {
-			d.onUpstreamExit(serverID)
-		},
-		OnPersistentDetected: func(serverID string) {
-			d.SetPersistent(serverID, true)
-		},
-		OnCacheReady: func(serverID string) {
-			d.mu.RLock()
-			entry, ok := d.owners[serverID]
-			var cachedOwner *owner.Owner
-			if ok {
-				cachedOwner = entry.Owner
-			}
-			d.mu.RUnlock()
-			if !ok || cachedOwner == nil {
-				return
-			}
-			snap := cachedOwner.ExportSnapshot()
-			d.updateTemplate(req.Command, req.Args, snap)
-		},
-		Logger: log.New(d.logger.Writer(), fmt.Sprintf("[mcp-mux:%s] ", sid[:8]), log.LstdFlags|log.Lmicroseconds),
+		OnPersistentResolved: d.resolveOwnerPersistent,
+		OnCacheReady:         d.publishOwnerCache,
+		OnCacheInvalidated:   d.invalidateOwnerTemplate,
+		Logger:               log.New(d.logger.Writer(), fmt.Sprintf("[mcp-mux:%s] ", sid[:8]), log.LstdFlags|log.Lmicroseconds),
 	}
 
-	// Try template-based spawn: if the daemon has seen this server before,
-	// create the owner from cached init data (instant response to CC) and
-	// start the real upstream process in the background.
+	// Template-backed owners stay cache-only until a cache miss, explicit
+	// persistent policy, or another owner-local materialization trigger occurs.
 	var o *owner.Owner
 	var ownerErr error
+	var selectedTemplate templateMatch
 	fromTemplate := false
-	if tmpl, ok := d.getTemplate(req.Command, req.Args); ok {
-		// Adapt template for this specific owner instance
-		tmpl.ServerID = sid
-		tmpl.Cwd = req.Cwd
-		tmpl.CwdSet = []string{req.Cwd}
-		tmpl.Env = sessionEnv
-		tmpl.Mode = req.Mode
+	templatePersistent := false
+	if !*templateBypass {
+		if match, ok := d.getCompatibleTemplate(req.Command, req.Args, req.Cwd, sessionEnv); ok {
+			tmpl := match.snapshot
+			// Adapt only instance identity. Compatibility was already decided
+			// from the template's original normalized env and sharing scope.
+			tmpl.ServerID = sid
+			tmpl.Cwd = req.Cwd
+			tmpl.CwdSet = []string{req.Cwd}
+			tmpl.Env = sessionEnv
+			tmpl.Mode = req.Mode
+			templatePersistent = d.persistent || tmpl.Persistent
 
-		o, ownerErr = owner.NewOwnerFromSnapshot(ownerCfg, tmpl)
-		if ownerErr != nil {
-			d.logger.Printf("template spawn failed for %s: %v, falling back to fresh spawn", sid[:8], ownerErr)
-			o = nil // fall through to fresh spawn
-		} else {
-			fromTemplate = true
-			d.logger.Printf("spawned owner %s from template cache (instant init) for %s", sid[:8], req.Command)
+			templateCfg := ownerCfg
+			templateCfg.PersistentPending = false
+			if templatePersistent {
+				templateCfg.MaterializationPolicy = owner.MaterializationPersistent
+			} else {
+				templateCfg.MaterializationPolicy = owner.MaterializationOnDemand
+			}
+			o, ownerErr = owner.NewOwnerFromSnapshot(templateCfg, tmpl)
+			if ownerErr != nil {
+				d.logger.Printf("template spawn failed for %s: %v, falling back to fresh spawn", sid[:8], ownerErr)
+				o = nil // fall through to fresh spawn
+			} else {
+				selectedTemplate = match
+				fromTemplate = true
+				d.logger.Printf("spawned owner %s from compatible template cache revision=%d for %s", sid[:8], match.revision, req.Command)
+			}
 		}
 	}
-
-	// Fresh spawn: no template available, or template spawn failed.
 	if o == nil {
 		o, ownerErr = owner.NewOwner(ownerCfg)
 		if ownerErr != nil {
@@ -1360,6 +1554,13 @@ func (d *Daemon) spawnOnce(reqPtr *control.Request, isolatedRetry *int64) (strin
 	if d.sessionHandler != nil {
 		o.MarkClassifiedAs(classify.ModeShared)
 	}
+	if !fromTemplate && d.beforeColdOwnerPromotion != nil {
+		d.beforeColdOwnerPromotion(o)
+	}
+
+	if fromTemplate && d.beforeTemplatePromotion != nil {
+		d.beforeTemplatePromotion()
+	}
 
 	// Register owner with the supervisor for lifecycle management.
 	// Suture will call owner.Serve(ctx) in its own goroutine and handle
@@ -1371,21 +1572,47 @@ func (d *Daemon) spawnOnce(reqPtr *control.Request, isolatedRetry *int64) (strin
 	// checks see the same credential-complete view that the upstream and
 	// session already got. Otherwise a daemon restart would round-trip
 	// trimmed env through the snapshot and re-surface the original bug.
+	effectivePersistent := d.persistent || templatePersistent
 	d.mu.Lock()
+	if d.owners[sid] != placeholder || (fromTemplate && !d.templateMatchCurrentLocked(selectedTemplate)) {
+		staleTemplate := fromTemplate && !d.templateMatchCurrentLocked(selectedTemplate)
+		if d.owners[sid] == placeholder {
+			d.deleteOwnerEntryLocked(sid)
+			if placeholder.creating != nil {
+				close(placeholder.creating)
+				placeholder.creating = nil
+			}
+		}
+		d.mu.Unlock()
+		d.supervisor.Remove(serviceToken)
+		o.Shutdown()
+		if staleTemplate {
+			*templateMismatches++
+			if *templateMismatches >= 2 {
+				*templateBypass = true
+			}
+			d.logger.Printf("template revision changed before promotion for %s (revision=%d mismatches=%d bypass=%v)", req.Command, selectedTemplate.revision, *templateMismatches, *templateBypass)
+		}
+		return "", "", "", errSpawnRetry
+	}
 	placeholder.Owner = o
 	placeholder.Mode = req.Mode
 	placeholder.Env = sessionEnv
 	placeholder.LastSession = time.Now()
 	placeholder.IdleTimeout = d.ownerIdleTimeout
 	placeholder.serviceToken = serviceToken
-	placeholder.Persistent = d.persistent
+	placeholder.Persistent = effectivePersistent
 	close(placeholder.creating)
 	placeholder.creating = nil // no longer a placeholder
 	d.mu.Unlock()
+	if !fromTemplate {
+		if startErr := o.StartInitialMaterialization(); startErr != nil {
+			_, removalErr := d.removeOwnerIfCurrent(sid, placeholder, ownerRemovalReasonRestoreFailed, false)
+			return "", "", "", errors.Join(fmt.Errorf("spawn %s: start upstream: %w", req.Command, startErr), removalErr)
+		}
+	}
 
-	// For template-spawned owners, start the upstream process in the background.
-	// The owner already serves cached responses; upstream refreshes caches when ready.
-	if fromTemplate {
+	if fromTemplate && templatePersistent {
 		o.SpawnUpstreamBackground()
 	}
 
@@ -1844,8 +2071,9 @@ func (d *Daemon) HandleGracefulRestartWithOptions(opts control.GracefulRestartOp
 	}
 
 	// Serialize snapshot first — needed for FR-8 fallback and successor seed
-	// regardless of whether handoff succeeds.
-	snapshotPath, err := d.SerializeSnapshot()
+	// regardless of whether handoff succeeds. Owner restart pins remain held
+	// until the predecessor has shut down after the control response is flushed.
+	snapshotPath, restartLease, err := d.serializeSnapshotPinned()
 	if err != nil {
 		d.shuttingDown.Store(false)
 		return "", nil, fmt.Errorf("snapshot: %w", err)
@@ -1865,18 +2093,24 @@ func (d *Daemon) HandleGracefulRestartWithOptions(opts control.GracefulRestartOp
 	// silent to the control-plane caller (it still gets a valid snapshot path).
 	if handoffErr := d.attemptHandoff(opts.SuccessorExe); handoffErr != nil {
 		if errors.Is(handoffErr, errNoHandoffUpstreams) {
-			return snapshotPath, d.afterSnapshotOnlyRestart(opts.SuccessorExe), nil
+			return snapshotPath, d.afterSnapshotOnlyRestart(opts.SuccessorExe, restartLease), nil
 		}
 		d.stats.fallback.Add(1)
 		d.logger.Printf("handoff.fallback reason=%v — using legacy shutdown+respawn", handoffErr)
 	}
 
-	return snapshotPath, func() { go d.Shutdown() }, nil
+	return snapshotPath, func() {
+		go func() {
+			defer restartLease.Release()
+			d.Shutdown()
+		}()
+	}, nil
 }
 
-func (d *Daemon) afterSnapshotOnlyRestart(successorExe string) func() {
+func (d *Daemon) afterSnapshotOnlyRestart(successorExe string, restartLease *snapshotRestartLease) func() {
 	return func() {
 		go func() {
+			defer restartLease.Release()
 			d.shutdown(func() {
 				d.logger.Printf("snapshot_restart.spawn_successor exe=%q flag=%q", successorExe, d.daemonFlag)
 				if err := spawnSnapshotSuccessorForRestart(successorExe, d.daemonFlag); err != nil {
@@ -1956,6 +2190,12 @@ func (d *Daemon) handleCanSuspend(prevToken, serverID string) (control.SuspendCh
 	if !ok || current != entry {
 		return control.SuspendCheckResponse{}, ErrOwnerGone
 	}
+	if entry.Owner.PersistentPending() {
+		return control.SuspendCheckResponse{Reason: "pending_persistent"}, nil
+	}
+	if entry.Owner.MaterializationBlocksEviction() {
+		return control.SuspendCheckResponse{Reason: "materializing"}, nil
+	}
 	if entry.Owner.PendingRequests() > 0 {
 		return control.SuspendCheckResponse{Reason: "pending_requests"}, nil
 	}
@@ -1970,40 +2210,63 @@ func (d *Daemon) handleCanSuspend(prevToken, serverID string) (control.SuspendCh
 
 // HandleStatus implements control.CommandHandler.
 func (d *Daemon) HandleStatus() map[string]any {
+	type statusOwner struct {
+		serverID                    string
+		owner                       *owner.Owner
+		persistent                  bool
+		ownerGeneration             string
+		restoredFromOwnerGeneration string
+		restoreSource               string
+		lastSession                 time.Time
+		idleTimeout                 time.Duration
+	}
 	d.mu.RLock()
-	defer d.mu.RUnlock()
-
-	servers := make([]map[string]any, 0, len(d.owners))
+	ownerViews := make([]statusOwner, 0, len(d.owners))
 	for sid, entry := range d.owners {
 		if entry.Owner == nil {
-			continue // placeholder still being created
+			continue
 		}
-		s := entry.Owner.Status()
-		s["server_id"] = sid
-		s["persistent"] = entry.Persistent
-		s["owner_generation"] = entry.OwnerGeneration
-		if entry.RestoredFromOwnerGeneration != "" {
-			s["restored_from_owner_generation"] = entry.RestoredFromOwnerGeneration
+		ownerViews = append(ownerViews, statusOwner{
+			serverID:                    sid,
+			owner:                       entry.Owner,
+			persistent:                  entry.Persistent,
+			ownerGeneration:             entry.OwnerGeneration,
+			restoredFromOwnerGeneration: entry.RestoredFromOwnerGeneration,
+			restoreSource:               entry.RestoreSource,
+			lastSession:                 entry.LastSession,
+			idleTimeout:                 entry.IdleTimeout,
+		})
+	}
+	removalStatus := d.ownerRemoval.statusMap()
+	zombieSpawn := d.zombieDetectedSpawn
+	zombieRestore := d.zombieDetectedRestore
+	d.mu.RUnlock()
+
+	servers := make([]map[string]any, 0, len(ownerViews))
+	for _, view := range ownerViews {
+		s := view.owner.Status()
+		s["server_id"] = view.serverID
+		s["persistent"] = view.persistent
+		s["owner_generation"] = view.ownerGeneration
+		if view.restoredFromOwnerGeneration != "" {
+			s["restored_from_owner_generation"] = view.restoredFromOwnerGeneration
 		}
-		if entry.RestoreSource != "" {
-			s["restore_source"] = entry.RestoreSource
+		if view.restoreSource != "" {
+			s["restore_source"] = view.restoreSource
 		} else {
 			s["restore_source"] = "fresh"
 		}
-		s["last_session"] = entry.LastSession.Format(time.RFC3339)
-		// Prefer the per-owner override from x-mux.idleTimeout capability
-		// (set via Owner.SetIdleTimeout after init); fall back to the
-		// daemon-wide default captured at spawn time.
-		effectiveIdleTimeout := entry.IdleTimeout
-		if override := entry.Owner.IdleTimeout(); override > 0 {
+		s["last_session"] = view.lastSession.Format(time.RFC3339)
+		effectiveIdleTimeout := view.idleTimeout
+		if override := view.owner.IdleTimeout(); override > 0 {
 			effectiveIdleTimeout = override
 		}
 		s["idle_timeout_s"] = effectiveIdleTimeout.Seconds()
-		if !entry.Owner.LastActivity().IsZero() {
-			s["last_activity"] = entry.Owner.LastActivity().Format(time.RFC3339)
+		if !view.owner.LastActivity().IsZero() {
+			s["last_activity"] = view.owner.LastActivity().Format(time.RFC3339)
 		}
-		s["active_progress_tokens"] = entry.Owner.ActiveProgressTokens()
-		s["busy"] = entry.Owner.HasActiveBusyWork()
+		s["active_progress_tokens"] = view.owner.ActiveProgressTokens()
+		s["busy"] = view.owner.HasActiveBusyWork()
 		servers = append(servers, s)
 	}
 
@@ -2013,17 +2276,17 @@ func (d *Daemon) HandleStatus() map[string]any {
 		"shutting_down":                   d.shuttingDown.Load(),
 		"pid":                             os.Getpid(),
 		"daemon_generation":               d.daemonGeneration,
-		"reaped_owner_count":              d.ownerRemoval.ByReason[ownerRemovalReasonIdle],
-		"owner_removal":                   d.ownerRemoval.statusMap(),
-		"owner_count":                     len(servers), // excludes placeholders still being created
+		"reaped_owner_count":              removalStatus["by_reason"].(map[string]uint64)[string(ownerRemovalReasonIdle)],
+		"owner_removal":                   removalStatus,
+		"owner_count":                     len(servers),
 		"servers":                         servers,
 		"owner_idle_timeout":              d.ownerIdleTimeout.String(),
 		"idle_timeout":                    d.idleTimeout.String(),
 		"shim_reconnect_refreshed":        d.reconnectRefreshed.Load(),
 		"shim_reconnect_fallback_spawned": d.reconnectFallbackSpawned.Load(),
 		"shim_reconnect_gave_up":          d.reconnectGaveUp.Load(),
-		"zombie_detections_spawn":         d.zombieDetectedSpawn,
-		"zombie_detections_restore":       d.zombieDetectedRestore,
+		"zombie_detections_spawn":         zombieSpawn,
+		"zombie_detections_restore":       zombieRestore,
 		"handoff": map[string]any{
 			"attempted":                      d.stats.attempted.Load(),
 			"transferred":                    d.stats.transferred.Load(),
@@ -2043,42 +2306,45 @@ func (d *Daemon) HandleStatus() map[string]any {
 // (Owner == nil) are excluded. Satisfies control.DaemonHandler.
 func (d *Daemon) HandleListOwners(req control.Request) (control.ListOwnersResponse, error) {
 	const maxOwners = 200
+	type listOwner struct {
+		serverID   string
+		owner      *owner.Owner
+		command    string
+		args       []string
+		persistent bool
+	}
 	d.mu.RLock()
-	defer d.mu.RUnlock()
-
-	// Collect server IDs, skipping placeholder entries.
-	sids := make([]string, 0, len(d.owners))
+	views := make([]listOwner, 0, len(d.owners))
 	for sid, entry := range d.owners {
-		if entry.Owner == nil {
-			continue
-		}
-		sids = append(sids, sid)
-	}
-	sort.Strings(sids)
-
-	truncated := false
-	if len(sids) > maxOwners {
-		sids = sids[:maxOwners]
-		truncated = true
-	}
-
-	owners := make([]control.OwnerInfo, 0, len(sids))
-	for _, sid := range sids {
-		entry := d.owners[sid]
 		if entry == nil || entry.Owner == nil {
 			continue
 		}
-		s := entry.Owner.Status()
+		views = append(views, listOwner{
+			serverID:   sid,
+			owner:      entry.Owner,
+			command:    entry.Command,
+			args:       append([]string(nil), entry.Args...),
+			persistent: entry.Persistent,
+		})
+	}
+	d.mu.RUnlock()
+	sort.Slice(views, func(i, j int) bool { return views[i].serverID < views[j].serverID })
+	truncated := false
+	if len(views) > maxOwners {
+		views = views[:maxOwners]
+		truncated = true
+	}
 
+	owners := make([]control.OwnerInfo, 0, len(views))
+	for _, view := range views {
+		s := view.owner.Status()
 		cwd, _ := s["cwd"].(string)
 		muxVer, _ := s["mux_version"].(string)
 		classification, _ := s["auto_classification"].(string)
 		classificationSource, _ := s["classification_source"].(string)
-
 		sessions := statusInt(s["session_count"])
 		pending := statusInt(s["pending_requests"])
 		upstreamPID := statusInt(s["upstream_pid"])
-
 		var cwdSet []string
 		switch v := s["cwd_set"].(type) {
 		case []string:
@@ -2090,7 +2356,6 @@ func (d *Daemon) HandleListOwners(req control.Request) (control.ListOwnersRespon
 				}
 			}
 		}
-
 		var classificationReason []string
 		switch v := s["classification_reason"].(type) {
 		case []string:
@@ -2102,17 +2367,15 @@ func (d *Daemon) HandleListOwners(req control.Request) (control.ListOwnersRespon
 				}
 			}
 		}
-
 		cachedInit, _ := s["cached_init"].(bool)
 		cachedTools, _ := s["cached_tools"].(bool)
 		cachedPrompts, _ := s["cached_prompts"].(bool)
 		cachedResources, _ := s["cached_resources"].(bool)
-
 		owners = append(owners, control.OwnerInfo{
-			ServerID:             sid,
+			ServerID:             view.serverID,
 			EngineName:           d.name,
-			Command:              entry.Command,
-			Args:                 entry.Args,
+			Command:              view.command,
+			Args:                 view.args,
 			Cwd:                  cwd,
 			CwdSet:               cwdSet,
 			Sessions:             sessions,
@@ -2122,14 +2385,13 @@ func (d *Daemon) HandleListOwners(req control.Request) (control.ListOwnersRespon
 			ClassificationSource: classificationSource,
 			ClassificationReason: classificationReason,
 			MuxVersion:           muxVer,
-			Persistent:           entry.Persistent,
+			Persistent:           view.persistent,
 			CachedInit:           cachedInit,
 			CachedTools:          cachedTools,
 			CachedPrompts:        cachedPrompts,
 			CachedResources:      cachedResources,
 		})
 	}
-
 	return control.ListOwnersResponse{Owners: owners, Truncated: truncated}, nil
 }
 
@@ -2231,13 +2493,87 @@ func shortServerID(serverID string) string {
 }
 
 // SetPersistent marks an owner as persistent (survives zero-session periods).
+// Operator calls intentionally address the current server ID; owner callbacks
+// use the exact-owner fenced variants below.
 func (d *Daemon) SetPersistent(serverID string, persistent bool) {
 	d.mu.Lock()
-	if entry, ok := d.owners[serverID]; ok {
-		entry.Persistent = persistent
-		d.logger.Printf("owner %s persistent=%v", serverID[:8], persistent)
+	_, ok := d.owners[serverID]
+	if ok {
+		d.owners[serverID].Persistent = persistent
 	}
 	d.mu.Unlock()
+	if ok {
+		d.logger.Printf("owner %s persistent=%v", shortServerID(serverID), persistent)
+	}
+}
+
+func (d *Daemon) setOwnerPersistent(expected *owner.Owner, persistent bool) bool {
+	if expected == nil {
+		return false
+	}
+	serverID := expected.ServerID()
+	d.mu.Lock()
+	entry, ok := d.owners[serverID]
+	ok = ok && entry != nil && entry.Owner == expected
+	if ok {
+		entry.Persistent = persistent
+	}
+	d.mu.Unlock()
+	if ok {
+		d.logger.Printf("owner %s persistent=%v", shortServerID(serverID), persistent)
+	}
+	return ok
+}
+
+func (d *Daemon) resolveOwnerPersistent(expected *owner.Owner, reported bool) {
+	effective := d.persistent || reported
+	if d.setOwnerPersistent(expected, effective) {
+		expected.ResolvePersistent(effective)
+		d.logger.Printf("owner %s persistent=%v (reported=%v)", shortServerID(expected.ServerID()), effective, reported)
+	}
+}
+
+func (d *Daemon) publishOwnerCache(expected *owner.Owner, snap mcpsnapshot.OwnerSnapshot) bool {
+	if expected == nil {
+		return false
+	}
+	if d.beforeOwnerCachePublish != nil {
+		d.beforeOwnerCachePublish(expected)
+	}
+	serverID := expected.ServerID()
+	d.mu.Lock()
+	entry, ok := d.owners[serverID]
+	if !ok || entry == nil || entry.Owner != expected {
+		d.mu.Unlock()
+		return false
+	}
+	snap.Persistent = d.persistent || snap.Persistent
+	entry.Persistent = snap.Persistent
+	key, revision, published := d.updateTemplateLocked(entry.Command, entry.Args, snap)
+	d.mu.Unlock()
+	if published {
+		d.logger.Printf("template cache updated for %s (key=%s revision=%d scope=%s)", entry.Command, key[:8], revision, snap.Classification)
+	}
+	return published
+}
+
+func (d *Daemon) invalidateOwnerTemplate(expected *owner.Owner) {
+	if expected == nil {
+		return
+	}
+	serverID := expected.ServerID()
+	d.mu.Lock()
+	entry, ok := d.owners[serverID]
+	if !ok || entry == nil || entry.Owner != expected {
+		d.mu.Unlock()
+		return
+	}
+	command := entry.Command
+	key, existed := d.invalidateTemplateLocked(command, entry.Args)
+	d.mu.Unlock()
+	if existed {
+		d.logger.Printf("template cache invalidated for %s (key=%s)", command, key[:8])
+	}
 }
 
 // findSharedOwnerLocked looks for an accepting owner that matches the requested
@@ -2455,41 +2791,7 @@ func mergeEnv(shimEnv map[string]string) map[string]string {
 // the key with different values. Presence in only one env remains compatible so
 // optional config defaults do not fragment owners by themselves.
 func envCompatible(a, b map[string]string) bool {
-	for k, va := range a {
-		if envTransient(k) {
-			continue
-		}
-		if !envIdentityKey(k) {
-			continue
-		}
-		vb, ok := b[k]
-		if !ok {
-			if envCredentialKey(k) {
-				return false
-			}
-			continue
-		}
-		if va != vb {
-			return false
-		}
-	}
-	// Symmetric check: a credential key present in b but missing in a
-	// must also split. The loop over a alone cannot see keys unique to b.
-	for k := range b {
-		if envTransient(k) {
-			continue
-		}
-		if !envIdentityKey(k) {
-			continue
-		}
-		if _, ok := a[k]; ok {
-			continue
-		}
-		if envCredentialKey(k) {
-			return false
-		}
-	}
-	return true
+	return envidentity.Compatible(a, b)
 }
 
 // envCredentialKey returns true if the key likely carries an authentication
@@ -2500,43 +2802,7 @@ func envCompatible(a, b map[string]string) bool {
 // uniquely-named "fake credential" var; false negatives leak real
 // credentials across sessions. The trade-off prefers the former.
 func envCredentialKey(key string) bool {
-	upper := strings.ToUpper(key)
-	switch {
-	case strings.HasSuffix(upper, "_TOKEN"):
-		return true
-	case strings.HasSuffix(upper, "_KEY"):
-		return true
-	case strings.HasSuffix(upper, "_API_KEY"):
-		return true
-	case strings.HasSuffix(upper, "_SECRET"):
-		return true
-	case strings.HasSuffix(upper, "_PASSWORD"):
-		return true
-	case strings.HasSuffix(upper, "_PASSWD"):
-		return true
-	case strings.HasSuffix(upper, "_CREDENTIALS"):
-		return true
-	case strings.HasSuffix(upper, "_AUTH"):
-		return true
-	// Exact-match keys that don't fit the suffix pattern.
-	case upper == "GH_TOKEN" || upper == "GITHUB_TOKEN":
-		return true
-	case upper == "GITHUB_PERSONAL_ACCESS_TOKEN":
-		return true
-	case upper == "OPENAI_API_KEY" || upper == "ANTHROPIC_API_KEY":
-		return true
-	case upper == "TAVILY_API_KEY" || upper == "GOOGLE_API_KEY":
-		return true
-	case upper == "AWS_ACCESS_KEY_ID" || upper == "AWS_SECRET_ACCESS_KEY":
-		return true
-	case upper == "AWS_SESSION_TOKEN":
-		return true
-	case upper == "SSH_AUTH_SOCK" || upper == "SSH_AGENT_PID":
-		return true
-	case upper == "DOCKER_AUTH_CONFIG":
-		return true
-	}
-	return false
+	return envidentity.IsCredentialKey(key)
 }
 
 // envIdentityKey returns true for env vars that should partition a global
@@ -2546,53 +2812,7 @@ func envCredentialKey(key string) bool {
 // remain identity keys via envCredentialKey; non-secret configuration keys use
 // conservative suffix/exact matches.
 func envIdentityKey(key string) bool {
-	if envCredentialKey(key) {
-		return true
-	}
-	upper := strings.ToUpper(key)
-	switch {
-	case strings.HasSuffix(upper, "_CONFIG"):
-		return true
-	case strings.HasSuffix(upper, "_CONFIG_FILE"):
-		return true
-	case strings.HasSuffix(upper, "_CONFIG_PATH"):
-		return true
-	case strings.HasSuffix(upper, "_CONFIG_DIR"):
-		return true
-	case strings.HasSuffix(upper, "_ENDPOINT"):
-		return true
-	case strings.HasSuffix(upper, "_BASE_URL"):
-		return true
-	case strings.HasSuffix(upper, "_URL"):
-		return true
-	case strings.HasSuffix(upper, "_HOST"):
-		return true
-	case strings.HasSuffix(upper, "_PORT"):
-		return true
-	case strings.HasSuffix(upper, "_REGION"):
-		return true
-	case strings.HasSuffix(upper, "_PROFILE"):
-		return true
-	case strings.HasSuffix(upper, "_CERT_PATH") || strings.HasSuffix(upper, "_CERT_FILE"):
-		return true
-	case upper == "CONFIG" || upper == "CONFIG_FILE" || upper == "CONFIG_PATH" || upper == "CONFIG_DIR":
-		return true
-	case upper == "HOST" || upper == "PORT" || upper == "URL" || upper == "BASE_URL" || upper == "ENDPOINT":
-		return true
-	case upper == "REGION" || upper == "PROFILE":
-		return true
-	case upper == "KUBECONFIG" || upper == "NODE_EXTRA_CA_CERTS" || upper == "CERT_PATH" || upper == "CERT_FILE":
-		return true
-	case upper == "HTTP_PROXY" || upper == "HTTPS_PROXY" || upper == "ALL_PROXY" || upper == "NO_PROXY":
-		return true
-	case strings.HasPrefix(upper, "NPM_CONFIG_"):
-		return true
-	case upper == "SSL_CERT_FILE" || upper == "SSL_CERT_DIR":
-		return true
-	case upper == "REQUESTS_CA_BUNDLE" || upper == "CURL_CA_BUNDLE":
-		return true
-	}
-	return false
+	return envidentity.IsIdentityKey(key)
 }
 
 // semanticEnvHash returns a stable 8-hex-char hash of env entries that
@@ -2601,31 +2821,7 @@ func envIdentityKey(key string) bool {
 // when env-incompat sessions need distinct owners under global-first
 // identity (CR-002 AC8). Empty / nil env returns "00000000".
 func semanticEnvHash(env map[string]string) string {
-	if len(env) == 0 {
-		return "00000000"
-	}
-	h := sha256.New()
-	keys := make([]string, 0, len(env))
-	for k := range env {
-		if envTransient(k) {
-			continue
-		}
-		if !envIdentityKey(k) {
-			continue
-		}
-		keys = append(keys, k)
-	}
-	if len(keys) == 0 {
-		return "00000000"
-	}
-	sort.Strings(keys)
-	for _, k := range keys {
-		h.Write([]byte{0})
-		h.Write([]byte(k))
-		h.Write([]byte{0})
-		h.Write([]byte(env[k]))
-	}
-	return hex.EncodeToString(h.Sum(nil))[:8]
+	return envidentity.ShortHash(env)
 }
 
 // deriveEnvBucketedSid (CR-002 AC8) preserves the credentials-partition
@@ -2697,57 +2893,7 @@ func (d *Daemon) deriveEnvBucketedSid(baseSid string, reqEnv map[string]string) 
 // envTransient returns true for env vars that are per-session/transient
 // and should NOT affect dedup decisions.
 func envTransient(key string) bool {
-	switch {
-	// Claude Code-specific session vars
-	case strings.HasPrefix(key, "CLAUDE_CODE_"):
-		return true
-	case strings.HasPrefix(key, "CLAUDE_AUTO"):
-		return true
-	case key == "CLAUDE_CODE_ENTRYPOINT":
-		return true
-	// Windows Terminal / WSL session vars
-	case strings.HasPrefix(key, "WT_"):
-		return true
-	case key == "SESSIONNAME" || key == "WSLENV":
-		return true
-	// CR-002 codex PR #121 fix: cwd-derived vars MUST be transient so
-	// env-bucketing under global-first does not fragment owners across
-	// per-session working directories. Without this, two sessions with
-	// identical credentials from different cwds get different env-bucket
-	// sids because PWD/OLDPWD/INIT_CWD differ — defeating the global-first
-	// dedup goal and recreating per-cwd owner fan-out the spec explicitly
-	// targets (Engram #244 Bug 1).
-	case key == "PWD" || key == "OLDPWD" || key == "INIT_CWD":
-		return true
-	// npm launch-noise vars (per-script/cwd, not semantic to MCP identity).
-	// Per CodeRabbit PR #121: narrow from blanket `npm_*` prefix so
-	// credential-bearing keys like npm_config_registry / npm_config_token
-	// REMAIN part of identity — two sessions with different registries
-	// must NOT collapse onto a shared owner.
-	case strings.HasPrefix(key, "npm_lifecycle_"):
-		return true
-	case strings.HasPrefix(key, "npm_package_"):
-		return true
-	case key == "npm_execpath" || key == "npm_node_execpath" || key == "npm_command":
-		return true
-	// Terminal/shell-derived vars (per-shim-launch transients, not semantic
-	// to the upstream MCP server's identity).
-	case key == "TERM" || key == "TERM_PROGRAM" || key == "TERM_PROGRAM_VERSION":
-		return true
-	case key == "COLORTERM" || key == "LINES" || key == "COLUMNS":
-		return true
-	case key == "_" || key == "SHLVL" || key == "SHELL":
-		return true
-	// SSH session metadata (per-connection transients). Per CodeRabbit
-	// PR #121: do NOT match SSH_AUTH_SOCK / SSH_AGENT_PID — those bind
-	// credentials to the upstream and must stay in identity.
-	case key == "SSH_CLIENT" || key == "SSH_CONNECTION" || key == "SSH_TTY":
-		return true
-	// X11/Wayland display vars (per-session transients on Linux desktops).
-	case key == "DISPLAY" || key == "XAUTHORITY" || key == "WAYLAND_DISPLAY":
-		return true
-	}
-	return false
+	return envidentity.IsTransient(key)
 }
 
 // Shutdown gracefully stops all owners and the daemon.
@@ -2785,19 +2931,30 @@ func (d *Daemon) shutdown(beforeDone func()) {
 			}
 		}
 
-		// Shutdown all owners
-		d.mu.Lock()
-		owners := make([]*owner.Owner, 0, len(d.owners))
-		for _, e := range d.owners {
-			if e.Owner != nil {
-				owners = append(owners, e.Owner)
-			}
+		// Finalize each owner before deleting its registry entry. Placeholders own
+		// no process authority and may be removed directly.
+		type shutdownOwner struct {
+			serverID string
+			entry    *OwnerEntry
 		}
-		d.owners = make(map[string]*OwnerEntry)
-		d.mu.Unlock()
-
-		for _, o := range owners {
-			o.Shutdown()
+		d.mu.RLock()
+		owners := make([]shutdownOwner, 0, len(d.owners))
+		for serverID, entry := range d.owners {
+			owners = append(owners, shutdownOwner{serverID: serverID, entry: entry})
+		}
+		d.mu.RUnlock()
+		for _, item := range owners {
+			if item.entry == nil || item.entry.Owner == nil {
+				d.mu.Lock()
+				if d.owners[item.serverID] == item.entry {
+					d.deleteOwnerEntryLocked(item.serverID)
+				}
+				d.mu.Unlock()
+				continue
+			}
+			if _, err := d.finalizeAndRemoveOwner(item.serverID, item.entry, ownerRemovalReasonOperatorHard, false, nil, false); err != nil {
+				d.logger.Printf("owner %s shutdown finalization blocked: %v", shortServerID(item.serverID), err)
+			}
 		}
 
 		if beforeDone != nil {
@@ -2835,30 +2992,28 @@ func (d *Daemon) Entry(serverID string) *OwnerEntry {
 }
 
 // onZeroSessions is called by an owner when its last session disconnects.
-func (d *Daemon) onZeroSessions(serverID string) {
-	var (
-		entry  *OwnerEntry
-		zeroAt time.Time
-		delay  time.Duration
-	)
+func (d *Daemon) onZeroSessions(expected *owner.Owner) {
+	if expected == nil {
+		return
+	}
+	serverID := expected.ServerID()
+	delay := d.zeroSessionCleanupDelay
+	if override := expected.IdleTimeout(); override > 0 {
+		delay = override
+	}
+	zeroAt := time.Now()
 	d.mu.Lock()
 	entry, ok := d.owners[serverID]
+	ok = ok && entry != nil && entry.Owner == expected
 	if ok {
-		zeroAt = time.Now()
 		entry.LastSession = zeroAt
-		delay = d.zeroSessionCleanupDelay
-		if entry.Owner != nil {
-			if override := entry.Owner.IdleTimeout(); override > 0 {
-				delay = override
-			}
-		}
 	}
 	d.mu.Unlock()
-
-	if ok {
-		d.logger.Printf("owner %s: zero sessions (cleanup delay %s)", serverID[:8], delay)
-		d.scheduleZeroSessionCleanup(serverID, entry, zeroAt, delay)
+	if !ok {
+		return
 	}
+	d.logger.Printf("owner %s: zero sessions (cleanup delay %s)", shortServerID(serverID), delay)
+	d.scheduleZeroSessionCleanup(serverID, entry, zeroAt, delay)
 }
 
 func (d *Daemon) scheduleZeroSessionCleanup(serverID string, entry *OwnerEntry, zeroAt time.Time, delay time.Duration) {
@@ -2890,49 +3045,41 @@ func (d *Daemon) scheduleZeroSessionCleanup(serverID string, entry *OwnerEntry, 
 }
 
 // onUpstreamExit is called by an owner when its upstream process exits.
-func (d *Daemon) onUpstreamExit(serverID string) {
+func (d *Daemon) onUpstreamExit(expected *owner.Owner) {
+	if expected == nil {
+		return
+	}
+	serverID := expected.ServerID()
 	d.mu.Lock()
 	entry, ok := d.owners[serverID]
-
-	// If the current entry is a placeholder for a different pending owner
-	// creation (entry.Owner == nil), this callback is from a PRIOR owner
-	// whose entry was already replaced in the registry — typically via the
-	// FR-4 zombie-spawn tear-down path which deletes the entry under d.mu
-	// and then calls Shutdown outside the lock, after which a concurrent
-	// shim can install a fresh placeholder at the same serverID. Acting on
-	// the placeholder here would panic on entry.Owner.Shutdown() and would
-	// incorrectly delete the placeholder belonging to a completely different
-	// spawn goroutine. Skip cleanly — the prior owner's tear-down path is
-	// already draining it, and the placeholder will resolve on its own.
-	if ok && entry.Owner == nil {
+	if !ok || entry == nil || entry.Owner != expected {
 		d.mu.Unlock()
 		return
 	}
-
-	if ok {
-		// Record crash for circuit breaker before any other action.
-		cmdKey := entry.Command + " " + strings.Join(entry.Args, " ")
-		d.recordCrash(cmdKey)
-
-		if entry.Persistent {
-			d.mu.Unlock()
-			d.logger.Printf("owner %s: upstream exited, will re-spawn (persistent)", serverID[:8])
-			// Reaper handles re-spawn for persistent owners
-			return
-		}
-		d.mu.Unlock()
-		d.forgetOwnerIfCurrent(serverID, entry, ownerRemovalReasonUpstreamExit)
-		entry.Owner.Shutdown()
-		d.logger.Printf("owner %s: upstream exited, removed", shortServerID(serverID))
-		return
-	}
+	cmdKey := entry.Command + " " + strings.Join(entry.Args, " ")
+	d.recordCrash(cmdKey)
+	persistent := entry.Persistent
 	d.mu.Unlock()
+	if persistent {
+		d.logger.Printf("owner %s: upstream exited; owner-local persistent recovery remains authoritative", shortServerID(serverID))
+		return
+	}
+	result, err := d.removeOwnerIfCurrent(serverID, entry, ownerRemovalReasonUpstreamExit, false)
+	if err != nil {
+		d.logger.Printf("owner %s: upstream-exit removal blocked: %v", shortServerID(serverID), err)
+		return
+	}
+	if result.Removed {
+		d.logger.Printf("owner %s: upstream exited, removed", shortServerID(serverID))
+	}
 }
 
 // crashWindow is the time window for crash counting. If an upstream crashes
 // crashThreshold times within this window, further spawns are rejected.
-const crashWindow = 60 * time.Second
-const crashThreshold = 5
+const (
+	crashWindow    = 60 * time.Second
+	crashThreshold = 5
+)
 
 // concurrentCreateWaitTimeout is the maximum time a Spawn / findSharedOwner
 // goroutine will wait for another goroutine that is currently creating the

--- a/muxcore/daemon/daemon.go
+++ b/muxcore/daemon/daemon.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -892,9 +893,9 @@ func cloneTemplateSnapshot(snap mcpsnapshot.OwnerSnapshot) mcpsnapshot.OwnerSnap
 }
 
 // updateTemplate atomically publishes one coherent, context-scoped cache
-// revision. A new verdict for the same effective env replaces any older
-// sharing verdict for that env so stale shared classification cannot survive
-// a later isolated discovery result.
+// revision. A new isolated verdict removes older relaxed verdicts for the same
+// effective env, while existing per-CWD isolation boundaries survive later
+// shared or session-aware publications.
 func (d *Daemon) updateTemplate(command string, args []string, snap mcpsnapshot.OwnerSnapshot) {
 	d.mu.Lock()
 	key, revision, ok := d.updateTemplateLocked(command, args, snap)
@@ -935,9 +936,13 @@ func (d *Daemon) updateTemplateLocked(command string, args []string, snap mcpsna
 	}
 	family.revision++
 	for existingScope, existing := range family.entries {
-		if envidentity.Equal(existing.envIdentity, envIdentity, existing.snapshot.Env, effectiveEnv) && existing.classification != entry.classification {
-			delete(family.entries, existingScope)
+		if !envidentity.Equal(existing.envIdentity, envIdentity, existing.snapshot.Env, effectiveEnv) || existing.classification == entry.classification {
+			continue
 		}
+		if existing.classification == classify.ModeIsolated && entry.classification != classify.ModeIsolated {
+			continue
+		}
+		delete(family.entries, existingScope)
 	}
 	family.entries[scope] = entry
 	return key, family.revision, true
@@ -2911,9 +2916,9 @@ func argsEqual(a, b []string) bool {
 }
 
 // mergeEnv combines a shim-supplied env with the daemon's own os.Environ().
-// Shim-supplied entries win on key collision (per-session credentials and cwd
-// vars must override anything inherited by the daemon). Any key missing from
-// the shim env is filled from the daemon env.
+// Shim-supplied entries win on key collision (case-insensitively on Windows)
+// so launch and cache identity observe the same effective environment. Any key
+// missing from the shim env is filled from the daemon env.
 //
 // Why: some shim launch paths arrive with a drastically trimmed environment
 // (observed in CC sessions started in certain worktree layouts: ~18-25 vars
@@ -2926,13 +2931,40 @@ func argsEqual(a, b []string) bool {
 // returned directly.
 func mergeEnv(shimEnv map[string]string) map[string]string {
 	merged := make(map[string]string, len(shimEnv)+64)
-	for _, e := range os.Environ() {
-		if i := strings.IndexByte(e, '='); i > 0 {
-			merged[e[:i]] = e[i+1:]
+	if runtime.GOOS != "windows" {
+		for _, entry := range os.Environ() {
+			if i := strings.IndexByte(entry, '='); i > 0 {
+				merged[entry[:i]] = entry[i+1:]
+			}
+		}
+		for key, value := range shimEnv {
+			merged[key] = value
+		}
+		return merged
+	}
+
+	windowsKeys := make(map[string]string, len(shimEnv)+64)
+	set := func(key, value string) {
+		folded := strings.ToUpper(key)
+		if existing, ok := windowsKeys[folded]; ok {
+			merged[existing] = value
+			return
+		}
+		windowsKeys[folded] = key
+		merged[key] = value
+	}
+	for _, entry := range os.Environ() {
+		if i := strings.IndexByte(entry, '='); i > 0 {
+			set(entry[:i], entry[i+1:])
 		}
 	}
-	for k, v := range shimEnv {
-		merged[k] = v
+	shimKeys := make([]string, 0, len(shimEnv))
+	for key := range shimEnv {
+		shimKeys = append(shimKeys, key)
+	}
+	sort.Strings(shimKeys)
+	for _, key := range shimKeys {
+		set(key, shimEnv[key])
 	}
 	return merged
 }

--- a/muxcore/daemon/daemon.go
+++ b/muxcore/daemon/daemon.go
@@ -125,7 +125,10 @@ type OwnerEntry struct {
 	snapshotUnpinned chan struct{}
 	// removalInProgress prevents restart serialization from pinning an owner
 	// after teardown has begun but before whole-tree finalization is proven.
+	// removalDone closes when that exact attempt settles so concurrent removers
+	// serialize instead of finalizing the same process authority twice.
 	removalInProgress bool
+	removalDone       chan struct{}
 	removalRetrying   bool
 }
 
@@ -2110,17 +2113,18 @@ func (d *Daemon) attemptHandoff(successorExe string) error {
 		err  error
 	}
 	connCh := make(chan connResult, 1)
-	go func() {
-		conn, err := listenHandoff(socketPath, handoffAcceptTimeout)
+	acceptTimeout := handoffAcceptTimeout
+	go func(timeout time.Duration) {
+		conn, err := listenHandoff(socketPath, timeout)
 		connCh <- connResult{conn, err}
-	}()
+	}(acceptTimeout)
 
 	// Spawn successor with handoff credentials and retain process authority until
 	// the protocol either commits or the failed successor is proven stopped.
 	successor, spawnErr := spawnHandoffSuccessorForRestart(tokenPath, socketPath, d.daemonFlag, successorExe)
 	if spawnErr != nil {
 		// Do NOT drain connCh here — the listener goroutine will self-terminate
-		// once handoffAcceptTimeout expires (buffered channel prevents leakage).
+		// once acceptTimeout expires (buffered channel prevents leakage).
 		return fmt.Errorf("spawn successor: %w", spawnErr)
 	}
 
@@ -2702,8 +2706,10 @@ func (d *Daemon) publishOwnerCache(expected *owner.Owner, snap mcpsnapshot.Owner
 		return false
 	}
 	snap.Persistent = d.persistent || snap.Persistent
-	entry.Persistent = snap.Persistent
 	key, revision, published := d.updateTemplateLocked(entry.Command, entry.Args, snap)
+	if published {
+		entry.Persistent = snap.Persistent
+	}
 	d.mu.Unlock()
 	if published {
 		d.logger.Printf("template cache updated for %s (key=%s revision=%d scope=%s)", entry.Command, key[:8], revision, snap.Classification)

--- a/muxcore/daemon/daemon.go
+++ b/muxcore/daemon/daemon.go
@@ -42,7 +42,24 @@ var errNoHandoffUpstreams = errors.New("no process-backed owners to hand off")
 
 const snapshotRestartEnv = "MCPMUX_SNAPSHOT_RESTART"
 
-var spawnSnapshotSuccessorForRestart = spawnSnapshotSuccessor
+var (
+	spawnSnapshotSuccessorForRestart = spawnSnapshotSuccessor
+	spawnHandoffSuccessorForRestart  = spawnSuccessor
+)
+
+type handoffSnapshotFallbackError struct {
+	err        error
+	backupSafe bool
+}
+
+func (e *handoffSnapshotFallbackError) Error() string { return e.err.Error() }
+func (e *handoffSnapshotFallbackError) Unwrap() error { return e.err }
+
+func handoffSnapshotFallback(err error) (*handoffSnapshotFallbackError, bool) {
+	var fallbackErr *handoffSnapshotFallbackError
+	ok := errors.As(err, &fallbackErr)
+	return fallbackErr, ok
+}
 
 // ErrUnknownToken indicates that the daemon does not recognize a reconnect
 // token presented through the refresh-token control-plane path.
@@ -192,6 +209,9 @@ type Daemon struct {
 	// owner IPC or start an upstream until control-socket takeover proves the
 	// predecessor has finalized its non-transferred process authority.
 	restartStaging []snapshotRestorePlan
+	// restartRecoverySnapshot retains exactly the owner/session subset that a
+	// successor must rewrite if staged activation cannot complete after takeover.
+	restartRecoverySnapshot *DaemonSnapshot
 	// supervisor manages owner lifecycle with exponential backoff on restart.
 	// Owners are added via supervisor.Add in Spawn() and removed via
 	// supervisor.Remove in daemon.Remove. Context-cancelled on Shutdown.
@@ -537,7 +557,21 @@ func New(cfg Config) (*Daemon, error) {
 		}
 		// The control endpoint can bind only after the predecessor has released
 		// it. This is the predecessor-finalized barrier for metadata-only owners.
-		d.activateRestartStaging()
+		if _, err := d.activateRestartStaging(); err != nil {
+			recoveryPath, recoveryErr := d.rewriteRestartRecoverySnapshot()
+			if recoveryErr != nil {
+				logger.Printf("snapshot: failed to preserve restart recovery after activation error: %v", recoveryErr)
+			} else if recoveryPath != "" {
+				logger.Printf("snapshot: preserved restart recovery at %s after activation error", recoveryPath)
+			}
+			d.shutdown(nil)
+			activationErr := fmt.Errorf("daemon: activate restart staging: %w", err)
+			if recoveryErr != nil {
+				return nil, errors.Join(activationErr, fmt.Errorf("preserve restart recovery: %w", recoveryErr))
+			}
+			return nil, activationErr
+		}
+		d.ctlSrv.Start()
 		if planned > 0 {
 			logger.Printf("startup: restored %d owners from snapshot (%s)", d.OwnerCount(), modeLabel)
 		}
@@ -1057,6 +1091,23 @@ func (d *Daemon) warnDeprecatedMode(cmd string, args []string, legacyMode string
 	)
 }
 
+func (d *Daemon) waitForOwnerAdmissionThaw(o *owner.Owner) error {
+	ticker := time.NewTicker(5 * time.Millisecond)
+	timer := time.NewTimer(d.admissionBufferTimeout)
+	defer ticker.Stop()
+	defer timer.Stop()
+	for o.AdmissionFrozen() {
+		select {
+		case <-o.Done():
+			return ErrOwnerGone
+		case <-ticker.C:
+		case <-timer.C:
+			return fmt.Errorf("admission gate: timeout after %s waiting for owner %s cache commit", d.admissionBufferTimeout, shortServerID(o.ServerID()))
+		}
+	}
+	return nil
+}
+
 // Spawn creates or reuses an owner for the given command. If a compatible owner
 // already exists (same command+args+cwd, or globally shareable), it is reused —
 // stateless servers don't need per-project copies. Returns the IPC path, server
@@ -1214,6 +1265,14 @@ func (d *Daemon) spawnOnce(reqPtr *control.Request, isolatedRetry *int64, templa
 			}
 			d.mu.Lock()
 			// Re-check: creation may have succeeded or failed.
+			if e, still := d.owners[sid]; still && e.Owner != nil && e.Owner.AdmissionFrozen() {
+				frozenOwner := e.Owner
+				d.mu.Unlock()
+				if waitErr := d.waitForOwnerAdmissionThaw(frozenOwner); waitErr != nil && !errors.Is(waitErr, ErrOwnerGone) {
+					return "", "", "", fmt.Errorf("spawn %s: %w", req.Command, waitErr)
+				}
+				return "", "", "", errSpawnRetry
+			}
 			if e, still := d.owners[sid]; still && e.Owner != nil && e.Owner.IsAccepting() {
 				// CR-002 AC8: re-validate env compatibility now that the owner is
 				// fully created and e.Env is populated. At the time deriveEnvBucketedSid
@@ -1270,6 +1329,14 @@ func (d *Daemon) spawnOnce(reqPtr *control.Request, isolatedRetry *int64, templa
 			d.mu.Unlock()
 			if retryEntry != nil && retryOwner != nil && retryOwner.IsClassifiedIsolated() {
 				*isolatedRetry = d.promoteIsolatedRetry(reqPtr, retryEntry)
+			}
+			return "", "", "", errSpawnRetry
+		}
+		if entry.Owner.AdmissionFrozen() {
+			frozenOwner := entry.Owner
+			d.mu.Unlock()
+			if waitErr := d.waitForOwnerAdmissionThaw(frozenOwner); waitErr != nil && !errors.Is(waitErr, ErrOwnerGone) {
+				return "", "", "", fmt.Errorf("spawn %s: %w", req.Command, waitErr)
 			}
 			return "", "", "", errSpawnRetry
 		}
@@ -1706,11 +1773,17 @@ func (d *Daemon) HandleSpawnResponseFailure(serverID, token string) {
 
 // HandleRemove implements control.DaemonHandler.
 func (d *Daemon) HandleRemove(serverID string) error {
+	if d.shuttingDown.Load() {
+		return ErrDaemonShuttingDown
+	}
 	return d.Remove(serverID)
 }
 
 // HandleStopOwner implements the optional control.OwnerStopHandler extension.
 func (d *Daemon) HandleStopOwner(req control.Request) (string, error) {
+	if d.shuttingDown.Load() {
+		return "", ErrDaemonShuttingDown
+	}
 	serverID := req.ServerID
 	if serverID == "" {
 		serverID = req.Command
@@ -1811,7 +1884,7 @@ func waitBeforeSnapshotRestartControlBind(logger *log.Logger) {
 // that and completes the bind.
 func (d *Daemon) retryControlBind(socketPath string) error {
 	for i := range controlBindMaxAttempts {
-		ctlSrv, err := control.NewServer(socketPath, d, d.logger)
+		ctlSrv, err := control.NewPausedServer(socketPath, d, d.logger)
 		if err == nil {
 			d.ctlSrv = ctlSrv
 			if i > 0 {
@@ -1830,14 +1903,49 @@ func (d *Daemon) retryControlBind(socketPath string) error {
 		controlBindMaxAttempts, time.Duration(controlBindMaxAttempts)*controlBindRetryInterval)
 }
 
+type handoffSuccessor interface {
+	Done() <-chan struct{}
+	Stop() error
+}
+
+type execHandoffSuccessor struct {
+	cmd  *exec.Cmd
+	done chan struct{}
+}
+
+func (s *execHandoffSuccessor) Done() <-chan struct{} { return s.done }
+
+func (s *execHandoffSuccessor) Stop() error {
+	if s == nil || s.cmd == nil || s.cmd.Process == nil {
+		return nil
+	}
+	select {
+	case <-s.done:
+		return nil
+	default:
+	}
+	killErr := s.cmd.Process.Kill()
+	if errors.Is(killErr, os.ErrProcessDone) {
+		killErr = nil
+	}
+	timer := time.NewTimer(5 * time.Second)
+	defer timer.Stop()
+	select {
+	case <-s.done:
+		return killErr
+	case <-timer.C:
+		return errors.Join(killErr, errors.New("handoff successor did not exit after termination"))
+	}
+}
+
 // spawnSuccessor forks the current binary as a detached background process,
 // injecting MCPMUX_HANDOFF_TOKEN_PATH and MCPMUX_HANDOFF_SOCKET so the successor
 // daemon can locate the handoff socket and authenticate (FR-11). The caller does
 // NOT wait for the process — it runs independently and will dial back.
-func spawnSuccessor(tokenPath, socketPath, daemonFlag, successorExe string) error {
+func spawnSuccessor(tokenPath, socketPath, daemonFlag, successorExe string) (handoffSuccessor, error) {
 	exe, err := successorExecutableFor(successorExe)
 	if err != nil {
-		return fmt.Errorf("handoff: resolve executable: %w", err)
+		return nil, fmt.Errorf("handoff: resolve executable: %w", err)
 	}
 	cmd := exec.Command(exe, daemonFlag)
 	cmd.Env = append(os.Environ(),
@@ -1851,12 +1959,14 @@ func spawnSuccessor(tokenPath, socketPath, daemonFlag, successorExe string) erro
 	// It mirrors engine.setDetached; importing engine from daemon would be a cycle.
 	setSuccessorDetached(cmd)
 	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("handoff: spawn successor: %w", err)
+		return nil, fmt.Errorf("handoff: spawn successor: %w", err)
 	}
-	if err := cmd.Process.Release(); err != nil {
-		return fmt.Errorf("handoff: release successor: %w", err)
-	}
-	return nil
+	successor := &execHandoffSuccessor{cmd: cmd, done: make(chan struct{})}
+	go func() {
+		_ = cmd.Wait()
+		close(successor.done)
+	}()
+	return successor, nil
 }
 
 func spawnSnapshotSuccessor(successorExe, daemonFlag string) error {
@@ -1961,18 +2071,10 @@ func (d *Daemon) hasHandoffUpstreamOwners() bool {
 }
 
 // attemptHandoff runs the old-daemon side of the two-daemon handoff protocol.
-// Returns nil if the protocol completed (transferred or FR-7 per-upstream abort).
-// Returns non-nil on any protocol-level failure — the caller logs "handoff.fallback"
-// and falls back to the legacy kill-and-respawn path (FR-8).
-//
-// FR-8 fallback trigger set (all route through the returned error):
-//   - Token write failure (crypto/rand unavailable, disk full, permission denied)
-//   - Socket bind / accept failure (path collision, permission denied)
-//   - Accept timeout exceeded (successor never connected)
-//   - Successor spawn failure (os.Executable error, exec.Start error)
-//   - ErrTokenMismatch (successor presented wrong token — FR-11)
-//   - ErrProtocolVersionMismatch (binary skew — FR-6)
-//   - Any other performHandoff protocol error (conn drop, JSON decode failure)
+// Returns nil after a complete transfer. Failures after exact version/token
+// Hello return handoffSnapshotFallbackError only after the failed successor has
+// exited, making one fresh snapshot successor safe. Listener/spawn/accept and
+// all Hello failures are pre-detach aborts that preserve the predecessor.
 func (d *Daemon) attemptHandoff(successorExe string) error {
 	d.stats.attempted.Add(1)
 	startedAt := time.Now()
@@ -2008,19 +2110,20 @@ func (d *Daemon) attemptHandoff(successorExe string) error {
 		connCh <- connResult{conn, err}
 	}()
 
-	// Spawn successor with handoff credentials.
-	if spawnErr := spawnSuccessor(tokenPath, socketPath, d.daemonFlag, successorExe); spawnErr != nil {
+	// Spawn successor with handoff credentials and retain process authority until
+	// the protocol either commits or the failed successor is proven stopped.
+	successor, spawnErr := spawnHandoffSuccessorForRestart(tokenPath, socketPath, d.daemonFlag, successorExe)
+	if spawnErr != nil {
 		// Do NOT drain connCh here — the listener goroutine will self-terminate
-		// once handoffAcceptTimeout expires (buffered channel prevents goroutine
-		// leak; the accepted conn, if any arrives despite the spawn failure, is
-		// closed when connCh is garbage-collected after nobody reads it).
+		// once handoffAcceptTimeout expires (buffered channel prevents leakage).
 		return fmt.Errorf("spawn successor: %w", spawnErr)
 	}
 
 	// Wait for successor to connect (or timeout to expire).
 	cr := <-connCh
 	if cr.err != nil {
-		return fmt.Errorf("accept: %w", cr.err)
+		acceptErr := fmt.Errorf("accept: %w", cr.err)
+		return errors.Join(acceptErr, successor.Stop())
 	}
 	conn := cr.conn
 	defer conn.Close() //nolint:errcheck
@@ -2029,11 +2132,14 @@ func (d *Daemon) attemptHandoff(successorExe string) error {
 	stopDeadline := bindHandoffContext(ctx, conn)
 	defer stopDeadline()
 
-	// Version/token negotiation happens before detaching any owner. A v1 peer
-	// therefore falls back to one bounded cold respawn without losing authority.
+	// Version/token negotiation happens before detaching any owner. Every Hello
+	// failure therefore stops the uncommitted successor and preserves predecessor
+	// process/session authority without snapshot fallback.
 	if err := acceptHandoffHello(conn, token); err != nil {
-		return fmt.Errorf("protocol hello: %w", handoffContextError(ctx, err))
+		helloErr := fmt.Errorf("protocol hello: %w", handoffContextError(ctx, err))
+		return errors.Join(helloErr, successor.Stop())
 	}
+	d.markPlannedHandoff()
 
 	// Detach only after the successor proved it speaks the exact v2 schema.
 	// Each entry carries abort/commit operations retained until final adoption.
@@ -2041,7 +2147,11 @@ func (d *Daemon) attemptHandoff(successorExe string) error {
 
 	result, err := performHandoffAfterHello(ctx, conn, upstreams)
 	if err != nil {
-		return fmt.Errorf("protocol error: %w", err)
+		protocolErr := fmt.Errorf("protocol error: %w", err)
+		if stopErr := successor.Stop(); stopErr != nil {
+			return &handoffSnapshotFallbackError{err: errors.Join(protocolErr, fmt.Errorf("stop failed successor: %w", stopErr))}
+		}
+		return &handoffSnapshotFallbackError{err: protocolErr, backupSafe: true}
 	}
 
 	d.stats.transferred.Add(uint64(len(result.Transferred)))
@@ -2052,13 +2162,44 @@ func (d *Daemon) attemptHandoff(successorExe string) error {
 	return nil
 }
 
-// HandleGracefulRestart implements control.DaemonHandler.
-// Serializes a state snapshot (used as FR-8 fallback seed and successor
-// cold-start seed), then attempts FD-passing handoff to the successor daemon
-// (FR-1/FR-2/FR-3). Process-backed handoff failures emit the "handoff.fallback"
-// log line and fall through to legacy kill-and-respawn (FR-8). SessionHandler-
-// only configurations have no upstream FDs to hand off and use snapshot-only
-// restart as their healthy path.
+func (d *Daemon) markPlannedHandoff() {
+	d.mu.Lock()
+	for _, entry := range d.owners {
+		entry.terminationHint = HintPlannedHandoff
+	}
+	d.mu.Unlock()
+}
+
+func (d *Daemon) abortGracefulRestart(snapshotPath string, restartLease *snapshotRestartLease, restartErr error) (string, func(), error) {
+	restartLease.Release()
+	d.mu.Lock()
+	for _, entry := range d.owners {
+		if entry.terminationHint == HintPlannedHandoff {
+			entry.terminationHint = HintNone
+		}
+	}
+	d.mu.Unlock()
+	d.shuttingDown.Store(false)
+	if snapshotPath != "" {
+		if err := os.Remove(snapshotPath); err != nil && !os.IsNotExist(err) {
+			d.logger.Printf("graceful-restart: remove aborted snapshot %q: %v", snapshotPath, err)
+		}
+	}
+	d.logger.Printf("handoff.abort reason=%v predecessor_retained=true", restartErr)
+	return "", nil, restartErr
+}
+
+func (d *Daemon) blockPostDetachRestart(snapshotPath string, restartLease *snapshotRestartLease, restartErr error) (string, func(), error) {
+	restartLease.Release()
+	d.logger.Printf("handoff.fallback_blocked reason=%v predecessor_closed=true snapshot=%q", restartErr, snapshotPath)
+	return snapshotPath, nil, restartErr
+}
+
+// HandleGracefulRestart implements control.DaemonHandler. It snapshots and
+// pins the predecessor, proves a successor path, and only then returns the
+// post-response shutdown callback. Every pre-Hello failure aborts with the
+// predecessor intact. A post-Hello failure stops that successor, rewrites the
+// retained snapshot, and pre-starts exactly one clean fallback successor.
 func (d *Daemon) HandleGracefulRestart(drainTimeoutMs int) (string, func(), error) {
 	return d.HandleGracefulRestartWithOptions(control.GracefulRestartOptions{DrainTimeoutMs: drainTimeoutMs})
 }
@@ -2070,55 +2211,63 @@ func (d *Daemon) HandleGracefulRestartWithOptions(opts control.GracefulRestartOp
 		d.logger.Printf("graceful-restart: successor_exe=%q", successorExe)
 	}
 
-	// Serialize snapshot first — needed for FR-8 fallback and successor seed
-	// regardless of whether handoff succeeds. Owner restart pins remain held
-	// until the predecessor has shut down after the control response is flushed.
+	// Serialize snapshot first so any proven successor can restore the same
+	// metadata generation. Restart pins stay held until shutdown or abort.
 	snapshotPath, restartLease, err := d.serializeSnapshotPinned()
 	if err != nil {
 		d.shuttingDown.Store(false)
 		return "", nil, fmt.Errorf("snapshot: %w", err)
 	}
 
-	// Tag owners BEFORE attemptHandoff. collectHandoffUpstreams (inside
-	// attemptHandoff) detaches owners → supervisor fires termination events
-	// → event hook acquires d.mu. Tagging after attemptHandoff deadlocks
-	// because this goroutine also needs d.mu (#99).
-	d.mu.Lock()
-	for _, entry := range d.owners {
-		entry.terminationHint = HintPlannedHandoff
+	handoffErr := d.attemptHandoff(opts.SuccessorExe)
+	if errors.Is(handoffErr, errNoHandoffUpstreams) {
+		afterFn, spawnErr := d.prepareSnapshotRestart(opts.SuccessorExe, restartLease, "no_process_backed_owners")
+		if spawnErr != nil {
+			return d.abortGracefulRestart(snapshotPath, restartLease, spawnErr)
+		}
+		return snapshotPath, afterFn, nil
 	}
-	d.mu.Unlock()
-
-	// Attempt FD-passing handoff. Callers never see a handoff error — FR-8 is
-	// silent to the control-plane caller (it still gets a valid snapshot path).
-	if handoffErr := d.attemptHandoff(opts.SuccessorExe); handoffErr != nil {
-		if errors.Is(handoffErr, errNoHandoffUpstreams) {
-			return snapshotPath, d.afterSnapshotOnlyRestart(opts.SuccessorExe, restartLease), nil
+	if handoffErr != nil {
+		fallbackErr, ok := handoffSnapshotFallback(handoffErr)
+		if !ok {
+			return d.abortGracefulRestart(snapshotPath, restartLease, handoffErr)
+		}
+		if !fallbackErr.backupSafe {
+			return d.blockPostDetachRestart(snapshotPath, restartLease, handoffErr)
+		}
+		rewrittenPath, rewriteErr := restartLease.RewriteSnapshot()
+		if rewriteErr != nil {
+			return d.blockPostDetachRestart(snapshotPath, restartLease, fmt.Errorf("rewrite post-handoff snapshot: %w", rewriteErr))
+		}
+		afterFn, spawnErr := d.prepareSnapshotRestart(opts.SuccessorExe, restartLease, "post_handoff_failure")
+		if spawnErr != nil {
+			return d.blockPostDetachRestart(rewrittenPath, restartLease, spawnErr)
 		}
 		d.stats.fallback.Add(1)
-		d.logger.Printf("handoff.fallback reason=%v — using legacy shutdown+respawn", handoffErr)
+		d.logger.Printf("handoff.fallback reason=%v — clean successor pre-started from rewritten snapshot", handoffErr)
+		return rewrittenPath, afterFn, nil
 	}
 
-	return snapshotPath, func() {
-		go func() {
-			defer restartLease.Release()
-			d.Shutdown()
-		}()
-	}, nil
+	return snapshotPath, d.afterGracefulRestart(restartLease), nil
 }
 
-func (d *Daemon) afterSnapshotOnlyRestart(successorExe string, restartLease *snapshotRestartLease) func() {
+func (d *Daemon) prepareSnapshotRestart(successorExe string, restartLease *snapshotRestartLease, reason string) (func(), error) {
+	d.logger.Printf("snapshot_restart.spawn_successor reason=%s exe=%q flag=%q", reason, successorExe, d.daemonFlag)
+	if err := spawnSnapshotSuccessorForRestart(successorExe, d.daemonFlag); err != nil {
+		d.logger.Printf("snapshot_restart.successor_spawn_failed reason=%s err=%v", reason, err)
+		return nil, err
+	}
+	d.logger.Printf("snapshot_restart.successor_spawned reason=%s", reason)
+	d.markPlannedHandoff()
+	return d.afterGracefulRestart(restartLease), nil
+}
+
+func (d *Daemon) afterGracefulRestart(restartLease *snapshotRestartLease) func() {
 	return func() {
 		go func() {
-			defer restartLease.Release()
-			d.shutdown(func() {
-				d.logger.Printf("snapshot_restart.spawn_successor exe=%q flag=%q", successorExe, d.daemonFlag)
-				if err := spawnSnapshotSuccessorForRestart(successorExe, d.daemonFlag); err != nil {
-					d.logger.Printf("snapshot_restart.successor_spawn_failed reason=no_process_backed_owners err=%v", err)
-					return
-				}
-				d.logger.Printf("snapshot_restart.successor_spawned reason=no_process_backed_owners")
-			})
+			restartLease.ReleaseRegistryPins()
+			defer restartLease.ReleaseOwnerPins()
+			d.Shutdown()
 		}()
 	}
 }
@@ -2622,9 +2771,10 @@ func (d *Daemon) findSharedOwnerLocked(command string, args []string, env map[st
 	for {
 		// Phase 1: scan live entries for a concrete match.
 		var (
-			match        *OwnerEntry
-			placeholder  chan struct{}
-			classifyWait <-chan struct{} // in-flight classification of a matching entry
+			match         *OwnerEntry
+			placeholder   chan struct{}
+			classifyWait  <-chan struct{} // in-flight classification of a matching entry
+			admissionWait *owner.Owner    // short cache-commit admission freeze
 		)
 		for _, entry := range d.owners {
 			if entry.Command != command {
@@ -2643,6 +2793,12 @@ func (d *Daemon) findSharedOwnerLocked(command string, args []string, env map[st
 			}
 			// Skip owners with incompatible env — different API keys, tokens, etc.
 			if !envCompatible(entry.Env, mergedEnv) {
+				continue
+			}
+			if entry.Owner.AdmissionFrozen() {
+				if admissionWait == nil {
+					admissionWait = entry.Owner
+				}
 				continue
 			}
 			if !entry.Owner.IsAccepting() {
@@ -2682,6 +2838,12 @@ func (d *Daemon) findSharedOwnerLocked(command string, args []string, env map[st
 			select {
 			case <-entry.Owner.Classified():
 				// Classification known — re-check IsAccepting (may have closed listener)
+				if entry.Owner.AdmissionFrozen() {
+					if admissionWait == nil {
+						admissionWait = entry.Owner
+					}
+					continue
+				}
 				if !entry.Owner.IsAccepting() {
 					continue
 				}
@@ -2697,10 +2859,10 @@ func (d *Daemon) findSharedOwnerLocked(command string, args []string, env map[st
 			return match
 		}
 
-		// No concrete match. If a placeholder or in-flight classification was
-		// seen and we have wait budget, release the lock, wait for it (or
-		// time out), re-acquire, and rescan. Otherwise give up.
-		if placeholder == nil && classifyWait == nil {
+		// No concrete match. If creation, classification, or a cache-commit
+		// admission freeze is in flight, release the lock and wait once before
+		// rescanning. Otherwise give up.
+		if placeholder == nil && classifyWait == nil && admissionWait == nil {
 			return nil
 		}
 		if waitsDone >= maxWaits {
@@ -2709,21 +2871,24 @@ func (d *Daemon) findSharedOwnerLocked(command string, args []string, env map[st
 		waitsDone++
 
 		d.mu.Unlock()
-		// Build a select that blocks on whichever signals we collected.
-		// Using nil channels in a select case blocks forever, so a single
-		// select with nil branches safely waits only on non-nil ones.
-		// Invariant: at least one of placeholder/classifyWait is non-nil (guard
-		// at line ~998 ensures this). Nil-channel cases in a select are never
-		// selected, so time.After is the fallback for the non-nil branch.
-		select {
-		case <-placeholder:
-			// Creation resolved (success or failure) — rescan.
-		case <-classifyWait:
-			// Classification resolved — rescan; owner may now be shareable.
-		case <-time.After(concurrentCreateWaitTimeout):
-			// Timed out. Re-acquire and return — caller will create new.
-			d.mu.Lock()
-			return nil
+		if admissionWait != nil {
+			if err := d.waitForOwnerAdmissionThaw(admissionWait); err != nil && !errors.Is(err, ErrOwnerGone) {
+				d.mu.Lock()
+				return nil
+			}
+		} else {
+			// Nil-channel cases in a select are disabled, so this waits for the
+			// concrete creation/classification signal that was observed above.
+			select {
+			case <-placeholder:
+				// Creation resolved (success or failure) — rescan.
+			case <-classifyWait:
+				// Classification resolved — rescan; owner may now be shareable.
+			case <-time.After(concurrentCreateWaitTimeout):
+				// Timed out. Re-acquire and return — caller will create new.
+				d.mu.Lock()
+				return nil
+			}
 		}
 		d.mu.Lock()
 		// Loop: fresh scan on the now-mutated map.
@@ -2920,8 +3085,47 @@ func (d *Daemon) shutdown(beforeDone func()) {
 				d.logger.Printf("supervisor did not exit within 2s, proceeding anyway")
 			}
 		}
+		// Finalize every concrete owner before releasing the control namespace.
+		// A successor may bind and activate only after all non-transferred process
+		// trees have proven retirement; blocked finalizers keep this predecessor
+		// alive and authoritative instead of allowing a competing generation.
+		type shutdownOwner struct {
+			serverID string
+			entry    *OwnerEntry
+		}
+		ownersShutDown := 0
+		for {
+			d.mu.Lock()
+			owners := make([]shutdownOwner, 0, len(d.owners))
+			for serverID, entry := range d.owners {
+				if entry == nil || entry.Owner == nil {
+					d.deleteOwnerEntryLocked(serverID)
+					continue
+				}
+				owners = append(owners, shutdownOwner{serverID: serverID, entry: entry})
+			}
+			d.mu.Unlock()
+			if len(owners) == 0 {
+				break
+			}
 
-		// Close control server
+			removedThisPass := 0
+			for _, item := range owners {
+				result, err := d.finalizeAndRemoveOwner(item.serverID, item.entry, ownerRemovalReasonOperatorHard, false, nil, false)
+				if result.Removed {
+					removedThisPass++
+					ownersShutDown++
+				}
+				if err != nil && !result.Removed {
+					d.logger.Printf("owner %s shutdown finalization blocked: %v", shortServerID(item.serverID), err)
+				}
+			}
+			if removedThisPass == 0 {
+				time.Sleep(100 * time.Millisecond)
+			}
+		}
+
+		// Only now may a waiting successor acquire the fixed control namespace.
 		if d.ctlSrv != nil {
 			d.ctlSrv.Close()
 		}
@@ -2931,37 +3135,11 @@ func (d *Daemon) shutdown(beforeDone func()) {
 			}
 		}
 
-		// Finalize each owner before deleting its registry entry. Placeholders own
-		// no process authority and may be removed directly.
-		type shutdownOwner struct {
-			serverID string
-			entry    *OwnerEntry
-		}
-		d.mu.RLock()
-		owners := make([]shutdownOwner, 0, len(d.owners))
-		for serverID, entry := range d.owners {
-			owners = append(owners, shutdownOwner{serverID: serverID, entry: entry})
-		}
-		d.mu.RUnlock()
-		for _, item := range owners {
-			if item.entry == nil || item.entry.Owner == nil {
-				d.mu.Lock()
-				if d.owners[item.serverID] == item.entry {
-					d.deleteOwnerEntryLocked(item.serverID)
-				}
-				d.mu.Unlock()
-				continue
-			}
-			if _, err := d.finalizeAndRemoveOwner(item.serverID, item.entry, ownerRemovalReasonOperatorHard, false, nil, false); err != nil {
-				d.logger.Printf("owner %s shutdown finalization blocked: %v", shortServerID(item.serverID), err)
-			}
-		}
-
 		if beforeDone != nil {
 			beforeDone()
 		}
 
-		d.logger.Printf("daemon stopped (%d owners shut down)", len(owners))
+		d.logger.Printf("daemon stopped (%d owners shut down)", ownersShutDown)
 		close(d.done)
 	})
 }

--- a/muxcore/daemon/daemon.go
+++ b/muxcore/daemon/daemon.go
@@ -912,7 +912,9 @@ func (d *Daemon) updateTemplate(command string, args []string, snap mcpsnapshot.
 // Keeping owner-entry persistence and the matching template under the same
 // critical section prevents mixed-generation daemon state.
 func (d *Daemon) updateTemplateLocked(command string, args []string, snap mcpsnapshot.OwnerSnapshot) (string, uint64, bool) {
-	effectiveEnv := mergeEnv(snap.Env)
+	// OwnerSnapshot.Env is already the pinned daemon-normalized effective launch
+	// environment. Re-merging here would forge successor-only identity fields.
+	effectiveEnv := cloneSnapshotStringMap(snap.Env)
 	envIdentity := envidentity.Build(effectiveEnv)
 	scope, ok := templateScope(snap.Classification, snap.Cwd, envIdentity.Fingerprint)
 	if !ok || snap.CachedInit == "" || snap.CachedTools == "" {

--- a/muxcore/daemon/daemon_test.go
+++ b/muxcore/daemon/daemon_test.go
@@ -812,21 +812,48 @@ func TestHandleSpawnRejectsAfterShutdownBegins(t *testing.T) {
 
 func TestGracefulRestartSnapshotFailureReopensSpawn(t *testing.T) {
 	d := testDaemon(t)
+	command := "restart-snapshot-failure-owner"
+	d.updateTemplate(command, nil, daemonMaterializationSnapshot(false))
+	path, sid, token, err := d.Spawn(control.Request{Command: command, Mode: "global", Cwd: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	entry := d.Entry(sid)
 
 	badTemp := filepath.Join(t.TempDir(), "temp-is-file")
-	if err := os.WriteFile(badTemp, []byte("not a directory"), 0600); err != nil {
+	if err := os.WriteFile(badTemp, []byte("not a directory"), 0o600); err != nil {
 		t.Fatalf("WriteFile bad temp: %v", err)
 	}
 	t.Setenv("TMP", badTemp)
 	t.Setenv("TEMP", badTemp)
 	t.Setenv("TMPDIR", badTemp)
 
-	_, _, err := d.HandleGracefulRestart(0)
+	_, _, err = d.HandleGracefulRestart(0)
 	if err == nil {
 		t.Fatal("HandleGracefulRestart() error = nil, want snapshot failure")
 	}
 	if d.shuttingDown.Load() {
 		t.Fatal("shuttingDown stayed true after snapshot failure")
+	}
+	if got := entry.Owner.Status()["restart_pin_count"]; got != int64(0) {
+		t.Fatalf("owner restart pin count after snapshot failure = %v, want 0", got)
+	}
+	d.mu.RLock()
+	registryPins := entry.snapshotPins
+	d.mu.RUnlock()
+	if registryPins != 0 {
+		t.Fatalf("daemon snapshot pin count after snapshot failure = %d, want 0", registryPins)
+	}
+	if !entry.Owner.IsAccepting() {
+		t.Fatal("predecessor owner stopped accepting after snapshot failure")
+	}
+	conn, scanner := connectSpawnedOwner(t, path, token)
+	defer conn.Close()
+	if _, err := fmt.Fprintln(conn, `{"jsonrpc":"2.0","id":99,"method":"tools/list","params":{}}`); err != nil {
+		t.Fatalf("write cached tools request: %v", err)
+	}
+	if response := readDaemonResponseID(t, scanner, "99"); !strings.Contains(string(response), "cached-tool") {
+		t.Fatalf("predecessor cached response after snapshot failure = %s", response)
 	}
 }
 
@@ -1453,10 +1480,10 @@ func TestCleanStaleSocketsNameScope(t *testing.T) {
 	// Seed files: one owned by "aimux-test", one owned by "mcp-mux".
 	aimuxSocket := filepath.Join(tmpDir, "aimux-test-abc12345.ctl.sock")
 	mcpMuxSocket := filepath.Join(tmpDir, "mcp-mux-stale-1.ctl.sock")
-	if err := os.WriteFile(aimuxSocket, []byte("placeholder"), 0600); err != nil {
+	if err := os.WriteFile(aimuxSocket, []byte("placeholder"), 0o600); err != nil {
 		t.Fatalf("seed aimux socket: %v", err)
 	}
-	if err := os.WriteFile(mcpMuxSocket, []byte("placeholder"), 0600); err != nil {
+	if err := os.WriteFile(mcpMuxSocket, []byte("placeholder"), 0o600); err != nil {
 		t.Fatalf("seed mcp-mux socket: %v", err)
 	}
 
@@ -1964,7 +1991,7 @@ func TestDaemonNew_HandoffMode_DefersControlBind(t *testing.T) {
 
 	// Set handoff env vars so daemon.New enters handoff mode.
 	tokenPath := filepath.Join(t.TempDir(), "handoff-token")
-	os.WriteFile(tokenPath, []byte("test-token"), 0600)
+	os.WriteFile(tokenPath, []byte("test-token"), 0o600)
 	socketPath := filepath.Join(t.TempDir(), "handoff.sock")
 	t.Setenv("MCPMUX_HANDOFF_TOKEN_PATH", tokenPath)
 	t.Setenv("MCPMUX_HANDOFF_SOCKET", socketPath)

--- a/muxcore/daemon/daemon_test.go
+++ b/muxcore/daemon/daemon_test.go
@@ -1280,6 +1280,17 @@ func TestMergeEnv(t *testing.T) {
 	})
 }
 
+func TestMergeEnvPreservesUnixCaseSensitiveKeys(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix environment keys are case-sensitive")
+	}
+	t.Setenv("CONFIG_PATH", "A")
+	got := mergeEnv(map[string]string{"config_path": "B"})
+	if got["CONFIG_PATH"] != "A" || got["config_path"] != "B" {
+		t.Fatalf("mergeEnv collapsed case-distinct Unix keys: CONFIG_PATH=%q config_path=%q", got["CONFIG_PATH"], got["config_path"])
+	}
+}
+
 func TestEnvTransient(t *testing.T) {
 	testCases := []struct {
 		name string

--- a/muxcore/daemon/daemon_windows_test.go
+++ b/muxcore/daemon/daemon_windows_test.go
@@ -6,12 +6,14 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"reflect"
 	"strings"
 	"syscall"
 	"testing"
 	"time"
 
 	"github.com/thebtf/mcp-mux/muxcore/control"
+	"github.com/thebtf/mcp-mux/muxcore/internal/envidentity"
 )
 
 func TestDetachedDevNullDaemonAcceptsParentStatus(t *testing.T) {
@@ -93,6 +95,71 @@ func TestDetachedDaemonControlHelper(t *testing.T) {
 	time.Sleep(500 * time.Millisecond)
 	_ = os.WriteFile(resultPath, []byte("ok"), 0600)
 	os.Exit(0)
+}
+
+func TestWindowsEffectiveEnvUsesShimOverrideForIdentityTemplateAndLaunch(t *testing.T) {
+	t.Setenv("CONFIG_PATH", "A")
+	shimEnv := map[string]string{"config_path": "B"}
+
+	assertNormalized := func(label string, env map[string]string) {
+		t.Helper()
+		matches := 0
+		for key, value := range env {
+			if strings.EqualFold(key, "CONFIG_PATH") {
+				matches++
+				if value != "B" {
+					t.Fatalf("%s %q=%q, want shim value B", label, key, value)
+				}
+			}
+		}
+		if matches != 1 {
+			t.Fatalf("%s has %d case-insensitive CONFIG_PATH keys, want 1", label, matches)
+		}
+	}
+
+	effectiveEnv := mergeEnv(shimEnv)
+	assertNormalized("effective env", effectiveEnv)
+	identity := envidentity.Build(effectiveEnv)
+	secondEffectiveEnv := mergeEnv(shimEnv)
+	assertNormalized("second effective env", secondEffectiveEnv)
+	if second := envidentity.Build(secondEffectiveEnv); second != identity {
+		t.Fatalf("effective env identity changed across identical merges: first=%q second=%q", identity.Fingerprint, second.Fingerprint)
+	}
+
+	d := testDaemon(t)
+	command := "windows-case-insensitive-effective-env"
+	cwd := t.TempDir()
+	template := daemonMaterializationSnapshot(false)
+	template.Cwd = cwd
+	template.Env = shimEnv
+	d.updateTemplate(command, nil, template)
+
+	match, ok := d.getCompatibleTemplate(command, nil, cwd, effectiveEnv)
+	if !ok {
+		t.Fatal("normalized effective env did not authorize its template")
+	}
+	assertNormalized("template env", match.snapshot.Env)
+	if !reflect.DeepEqual(match.snapshot.Env, effectiveEnv) {
+		t.Fatal("template authorization did not retain the normalized effective env")
+	}
+
+	_, sid, _, err := d.Spawn(control.Request{Command: command, Mode: "global", Cwd: cwd, Env: shimEnv})
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	entry := d.Entry(sid)
+	if entry == nil || entry.Owner == nil {
+		t.Fatalf("spawned owner %q missing", sid)
+	}
+	assertNormalized("owner env", entry.Env)
+	if !reflect.DeepEqual(entry.Env, effectiveEnv) {
+		t.Fatal("owner launch context did not receive the normalized effective env")
+	}
+	launchSnapshot := entry.Owner.ExportSnapshot()
+	assertNormalized("owner snapshot env", launchSnapshot.Env)
+	if !reflect.DeepEqual(launchSnapshot.Env, effectiveEnv) {
+		t.Fatal("owner snapshot did not preserve the normalized launch env")
+	}
 }
 
 func waitForDaemonFile(t *testing.T, path string, timeout time.Duration) {

--- a/muxcore/daemon/daemon_windows_test.go
+++ b/muxcore/daemon/daemon_windows_test.go
@@ -131,7 +131,7 @@ func TestWindowsEffectiveEnvUsesShimOverrideForIdentityTemplateAndLaunch(t *test
 	cwd := t.TempDir()
 	template := daemonMaterializationSnapshot(false)
 	template.Cwd = cwd
-	template.Env = shimEnv
+	template.Env = effectiveEnv
 	d.updateTemplate(command, nil, template)
 
 	match, ok := d.getCompatibleTemplate(command, nil, cwd, effectiveEnv)

--- a/muxcore/daemon/daemon_windows_test.go
+++ b/muxcore/daemon/daemon_windows_test.go
@@ -84,16 +84,16 @@ func TestDetachedDaemonControlHelper(t *testing.T) {
 		Logger:       log.New(os.Stderr, "[daemon-helper] ", log.LstdFlags),
 	})
 	if err != nil {
-		_ = os.WriteFile(resultPath, []byte("daemon: "+err.Error()), 0600)
+		_ = os.WriteFile(resultPath, []byte("daemon: "+err.Error()), 0o600)
 		os.Exit(0)
 	}
 	defer d.Shutdown()
-	if err := os.WriteFile(readyPath, []byte("ready"), 0600); err != nil {
-		_ = os.WriteFile(resultPath, []byte("ready: "+err.Error()), 0600)
+	if err := os.WriteFile(readyPath, []byte("ready"), 0o600); err != nil {
+		_ = os.WriteFile(resultPath, []byte("ready: "+err.Error()), 0o600)
 		os.Exit(0)
 	}
 	time.Sleep(500 * time.Millisecond)
-	_ = os.WriteFile(resultPath, []byte("ok"), 0600)
+	_ = os.WriteFile(resultPath, []byte("ok"), 0o600)
 	os.Exit(0)
 }
 
@@ -159,6 +159,38 @@ func TestWindowsEffectiveEnvUsesShimOverrideForIdentityTemplateAndLaunch(t *test
 	assertNormalized("owner snapshot env", launchSnapshot.Env)
 	if !reflect.DeepEqual(launchSnapshot.Env, effectiveEnv) {
 		t.Fatal("owner snapshot did not preserve the normalized launch env")
+	}
+}
+
+func TestWindowsMergeEnvCanonicalizesIdentityKeyCase(t *testing.T) {
+	const canonicalKey = "MCPMUX_TEST_CASE_VARIANT_CONFIG_PATH"
+	previous, present := os.LookupEnv(canonicalKey)
+	if err := os.Unsetenv(canonicalKey); err != nil {
+		t.Fatalf("unset %s: %v", canonicalKey, err)
+	}
+	t.Cleanup(func() {
+		if present {
+			if err := os.Setenv(canonicalKey, previous); err != nil {
+				t.Errorf("restore %s: %v", canonicalKey, err)
+			}
+			return
+		}
+		if err := os.Unsetenv(canonicalKey); err != nil {
+			t.Errorf("clear %s: %v", canonicalKey, err)
+		}
+	})
+
+	lowerKey := strings.ToLower(canonicalKey)
+	lower := mergeEnv(map[string]string{lowerKey: "A"})
+	upper := mergeEnv(map[string]string{canonicalKey: "B"})
+	if got := lower[canonicalKey]; got != "A" {
+		t.Fatalf("canonical lower-case merge value = %q, want A", got)
+	}
+	if _, ok := lower[lowerKey]; ok {
+		t.Fatalf("lower-case key %q survived Windows canonicalization", lowerKey)
+	}
+	if envCompatible(lower, upper) {
+		t.Fatal("case variants with conflicting config values remained compatible")
 	}
 }
 

--- a/muxcore/daemon/dedup_storm_test.go
+++ b/muxcore/daemon/dedup_storm_test.go
@@ -167,7 +167,7 @@ func completeStormTemplate(classification classify.SharingMode, cwd string, env 
 	snap := daemonMaterializationSnapshot(false)
 	snap.Classification = classification
 	snap.Cwd = cwd
-	snap.Env = env
+	snap.Env = mergeEnv(env)
 	snap.CachedPrompts = base64.StdEncoding.EncodeToString([]byte(`{"jsonrpc":"2.0","id":"cached-prompts","result":{"prompts":[{"name":"cached-prompt"}]}}`))
 	snap.CachedResources = base64.StdEncoding.EncodeToString([]byte(`{"jsonrpc":"2.0","id":"cached-resources","result":{"resources":[{"uri":"file:///cached"}]}}`))
 	snap.CachedResourceTemplates = base64.StdEncoding.EncodeToString([]byte(`{"jsonrpc":"2.0","id":"cached-resource-templates","result":{"resourceTemplates":[{"uriTemplate":"file:///{path}"}]}}`))

--- a/muxcore/daemon/dedup_storm_test.go
+++ b/muxcore/daemon/dedup_storm_test.go
@@ -1,13 +1,25 @@
 package daemon
 
 import (
+	"bufio"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
 	"path/filepath"
+	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/thebtf/mcp-mux/muxcore/classify"
 	"github.com/thebtf/mcp-mux/muxcore/control"
+	"github.com/thebtf/mcp-mux/muxcore/owner"
 	"github.com/thebtf/mcp-mux/muxcore/serverid"
+	mcpsnapshot "github.com/thebtf/mcp-mux/muxcore/snapshot"
 )
 
 // mockServerAbsPath returns the absolute path to the mock server source so
@@ -67,15 +79,14 @@ func TestSpawn_ParallelStormSharedConverges(t *testing.T) {
 	// on Windows. Otherwise the subprocess's open cwd handle fails the
 	// rm-rf and marks the test FAIL post-assertions.
 	cwds := make([]string, N)
-	for i := 0; i < N; i++ {
+	for i := range N {
 		cwds[i] = t.TempDir()
 	}
 
 	d := testDaemon(t)
 
-	for i := 0; i < N; i++ {
+	for i := range N {
 		wg.Add(1)
-		i := i
 		go func() {
 			defer wg.Done()
 			<-start
@@ -141,5 +152,270 @@ func TestSpawn_ParallelStormSharedConverges(t *testing.T) {
 		if _, ok := wantCwds[cwd]; !ok {
 			t.Fatalf("shared owner cwdSet contains unexpected root %q; want %v", cwd, wantCwds)
 		}
+	}
+}
+
+type templateStormEndpoint struct {
+	path    string
+	sid     string
+	token   string
+	conn    net.Conn
+	scanner *bufio.Scanner
+}
+
+func completeStormTemplate(classification classify.SharingMode, cwd string, env map[string]string) mcpsnapshot.OwnerSnapshot {
+	snap := daemonMaterializationSnapshot(false)
+	snap.Classification = classification
+	snap.Cwd = cwd
+	snap.Env = env
+	snap.CachedPrompts = base64.StdEncoding.EncodeToString([]byte(`{"jsonrpc":"2.0","id":"cached-prompts","result":{"prompts":[{"name":"cached-prompt"}]}}`))
+	snap.CachedResources = base64.StdEncoding.EncodeToString([]byte(`{"jsonrpc":"2.0","id":"cached-resources","result":{"resources":[{"uri":"file:///cached"}]}}`))
+	snap.CachedResourceTemplates = base64.StdEncoding.EncodeToString([]byte(`{"jsonrpc":"2.0","id":"cached-resource-templates","result":{"resourceTemplates":[{"uriTemplate":"file:///{path}"}]}}`))
+	return snap
+}
+
+func stormMaterializationHandler(starts *atomic.Int32, classification classify.SharingMode) func(context.Context, io.Reader, io.Writer) error {
+	return func(_ context.Context, stdin io.Reader, stdout io.Writer) error {
+		starts.Add(1)
+		scanner := bufio.NewScanner(stdin)
+		for scanner.Scan() {
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+				return err
+			}
+			var result string
+			switch req.Method {
+			case "initialize":
+				result = fmt.Sprintf(`{"protocolVersion":"2025-11-25","capabilities":{"x-mux":{"sharing":%q}},"serverInfo":{"name":"storm","version":"1"}}`, classification)
+			case "tools/list":
+				result = `{"tools":[{"name":"live-tool"}]}`
+			case "prompts/list":
+				result = `{"prompts":[]}`
+			case "resources/list":
+				result = `{"resources":[]}`
+			case "resources/templates/list":
+				result = `{"resourceTemplates":[]}`
+			case "custom/wake":
+				result = `{"woke":true}`
+			default:
+				continue
+			}
+			if err := writeDaemonResponse(stdout, req.ID, result); err != nil {
+				return err
+			}
+		}
+		return scanner.Err()
+	}
+}
+
+func writeStormDiscoveryBurst(t *testing.T, conn io.Writer, base int) {
+	t.Helper()
+	frames := []string{
+		fmt.Sprintf(`{"jsonrpc":"2.0","id":%d,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"codex","version":"1"}}}`, base),
+		`{"jsonrpc":"2.0","method":"notifications/initialized"}`,
+		fmt.Sprintf(`{"jsonrpc":"2.0","id":%d,"method":"tools/list","params":{}}`, base+1),
+		fmt.Sprintf(`{"jsonrpc":"2.0","id":%d,"method":"prompts/list","params":{}}`, base+2),
+		fmt.Sprintf(`{"jsonrpc":"2.0","id":%d,"method":"resources/list","params":{}}`, base+3),
+		fmt.Sprintf(`{"jsonrpc":"2.0","id":%d,"method":"resources/templates/list","params":{}}`, base+4),
+	}
+	for _, frame := range frames {
+		if _, err := fmt.Fprintln(conn, frame); err != nil {
+			t.Fatalf("write discovery burst: %v", err)
+		}
+	}
+}
+
+func readStormDiscoveryBurst(t *testing.T, scanner *bufio.Scanner, base int) {
+	t.Helper()
+	for offset := range 5 {
+		readDaemonResponseID(t, scanner, fmt.Sprintf("%d", base+offset))
+	}
+}
+
+func countLiveStormProcesses(d *Daemon) int {
+	d.mu.RLock()
+	owners := make([]*owner.Owner, 0, len(d.owners))
+	for _, entry := range d.owners {
+		if entry != nil && entry.Owner != nil {
+			owners = append(owners, entry.Owner)
+		}
+	}
+	d.mu.RUnlock()
+	live := 0
+	for _, o := range owners {
+		if value, _ := o.Status()["upstream_live"].(bool); value {
+			live++
+		}
+	}
+	return live
+}
+
+func TestTemplateBackedIsolatedStormMaterializesOnlyDemandedOwner(t *testing.T) {
+	const n = 8
+	const command = "isolated-template-storm"
+	env := map[string]string{"STORM_CONFIG_PATH": "/cfg/isolated"}
+	var starts atomic.Int32
+	d := testDaemon(t)
+	d.handlerFunc = stormMaterializationHandler(&starts, "isolated")
+	cwds := make([]string, n)
+	for i := range cwds {
+		cwds[i] = t.TempDir()
+		d.updateTemplate(command, nil, completeStormTemplate("isolated", cwds[i], env))
+	}
+
+	results := make([]templateStormEndpoint, n)
+	errs := make([]error, n)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := range results {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			results[i].path, results[i].sid, results[i].token, errs[i] = d.Spawn(control.Request{Command: command, Mode: "isolated", Cwd: cwds[i], Env: env})
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+	seen := make(map[string]struct{}, n)
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("isolated Spawn %d: %v", i, err)
+		}
+		seen[results[i].sid] = struct{}{}
+		results[i].conn, results[i].scanner = connectSpawnedOwner(t, results[i].path, results[i].token)
+		defer results[i].conn.Close()
+		writeStormDiscoveryBurst(t, results[i].conn, 100+i*10)
+	}
+	for i := range results {
+		readStormDiscoveryBurst(t, results[i].scanner, 100+i*10)
+	}
+	if len(seen) != n || d.OwnerCount() != n {
+		t.Fatalf("isolated storm owners: sids=%d count=%d, want %d", len(seen), d.OwnerCount(), n)
+	}
+	if starts.Load() != 0 || countLiveStormProcesses(d) != 0 {
+		t.Fatalf("handshake-only isolated storm started upstreams: starts=%d live=%d", starts.Load(), countLiveStormProcesses(d))
+	}
+
+	target := results[n/2]
+	if _, err := fmt.Fprintln(target.conn, `{"jsonrpc":"2.0","id":999,"method":"custom/wake","params":{}}`); err != nil {
+		t.Fatalf("write wake: %v", err)
+	}
+	if got := readDaemonResponseID(t, target.scanner, "999"); !strings.Contains(string(got), `"woke":true`) {
+		t.Fatalf("wake response=%s", got)
+	}
+	waitForDaemonCondition(t, time.Second, func() bool { return starts.Load() == 1 && countLiveStormProcesses(d) == 1 }, "isolated demand did not materialize exactly one owner")
+	for _, endpoint := range results {
+		entry := d.Entry(endpoint.sid)
+		if entry == nil || entry.Owner == nil {
+			t.Fatalf("missing isolated owner %s", endpoint.sid)
+		}
+		generation := entry.Owner.Status()["materialization_generation"].(uint64)
+		if endpoint.sid == target.sid && generation != 1 {
+			t.Fatalf("demanded owner generation=%d, want 1", generation)
+		}
+		if endpoint.sid != target.sid && generation != 0 {
+			t.Fatalf("unused owner %s generation=%d, want 0", endpoint.sid, generation)
+		}
+	}
+}
+
+func TestTemplateBackedSharedStormConvergesOneOwnerOneGeneration(t *testing.T) {
+	const n = 8
+	const command = "shared-template-storm"
+	env := map[string]string{"STORM_CONFIG_PATH": "/cfg/shared"}
+	var starts atomic.Int32
+	cwds := make([]string, n)
+	for i := range cwds {
+		cwds[i] = t.TempDir()
+	}
+	d := testDaemon(t)
+	d.handlerFunc = stormMaterializationHandler(&starts, "shared")
+	d.updateTemplate(command, nil, completeStormTemplate("shared", cwds[0], env))
+
+	results := make([]templateStormEndpoint, n)
+	errs := make([]error, n)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := range results {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			results[i].path, results[i].sid, results[i].token, errs[i] = d.Spawn(control.Request{Command: command, Mode: "global", Cwd: cwds[i], Env: env})
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("shared Spawn %d: %v", i, err)
+		}
+		if results[i].sid != results[0].sid {
+			t.Fatalf("shared storm sid[%d]=%s, want %s", i, results[i].sid, results[0].sid)
+		}
+		results[i].conn, results[i].scanner = connectSpawnedOwner(t, results[i].path, results[i].token)
+		defer results[i].conn.Close()
+		writeStormDiscoveryBurst(t, results[i].conn, 300+i*10)
+	}
+	for i := range results {
+		readStormDiscoveryBurst(t, results[i].scanner, 300+i*10)
+	}
+	if d.OwnerCount() != 1 || starts.Load() != 0 || countLiveStormProcesses(d) != 0 {
+		t.Fatalf("shared handshake storm owners=%d starts=%d live=%d, want 1/0/0", d.OwnerCount(), starts.Load(), countLiveStormProcesses(d))
+	}
+	if _, err := fmt.Fprintln(results[0].conn, `{"jsonrpc":"2.0","id":777,"method":"custom/wake","params":{}}`); err != nil {
+		t.Fatalf("write shared wake: %v", err)
+	}
+	readDaemonResponseID(t, results[0].scanner, "777")
+	waitForDaemonCondition(t, time.Second, func() bool { return starts.Load() == 1 && countLiveStormProcesses(d) == 1 }, "shared storm did not converge to one live generation")
+	entry := d.Entry(results[0].sid)
+	if got := entry.Owner.Status()["materialization_generation"]; got != uint64(1) {
+		t.Fatalf("shared owner generation=%v, want 1", got)
+	}
+}
+
+func TestCodexEightEntryHandshakeBurstSameTransportWake(t *testing.T) {
+	const n = 8
+	env := map[string]string{"CODEX_CONFIG_PATH": "/cfg/codex"}
+	var starts atomic.Int32
+	d := testDaemon(t)
+	d.handlerFunc = stormMaterializationHandler(&starts, "shared")
+	endpoints := make([]templateStormEndpoint, n)
+	for i := range endpoints {
+		command := fmt.Sprintf("codex-entry-%d", i)
+		cwd := t.TempDir()
+		d.updateTemplate(command, nil, completeStormTemplate("shared", cwd, env))
+		path, sid, token, err := d.Spawn(control.Request{Command: command, Mode: "global", Cwd: cwd, Env: env})
+		if err != nil {
+			t.Fatalf("Spawn entry %d: %v", i, err)
+		}
+		endpoints[i] = templateStormEndpoint{path: path, sid: sid, token: token}
+		endpoints[i].conn, endpoints[i].scanner = connectSpawnedOwner(t, path, token)
+		defer endpoints[i].conn.Close()
+		writeStormDiscoveryBurst(t, endpoints[i].conn, 500+i*10)
+	}
+	for i := range endpoints {
+		readStormDiscoveryBurst(t, endpoints[i].scanner, 500+i*10)
+	}
+	beforeOwners, beforeProcesses := d.OwnerCount(), countLiveStormProcesses(d)
+	if beforeOwners != n || beforeProcesses != 0 || starts.Load() != 0 {
+		t.Fatalf("Codex burst before wake owners=%d processes=%d starts=%d, want %d/0/0", beforeOwners, beforeProcesses, starts.Load(), n)
+	}
+
+	target := &endpoints[3]
+	if _, err := fmt.Fprintln(target.conn, `{"jsonrpc":"2.0","id":909,"method":"custom/wake","params":{}}`); err != nil {
+		t.Fatalf("same-transport wake write: %v", err)
+	}
+	response := readDaemonResponseID(t, target.scanner, "909")
+	if !strings.Contains(string(response), `"woke":true`) {
+		t.Fatalf("same-transport wake response=%s", response)
+	}
+	afterOwners, afterProcesses := d.OwnerCount(), countLiveStormProcesses(d)
+	if afterOwners != n || afterProcesses != 1 || starts.Load() != 1 {
+		t.Fatalf("Codex burst after wake owners=%d processes=%d starts=%d, want %d/1/1", afterOwners, afterProcesses, starts.Load(), n)
 	}
 }

--- a/muxcore/daemon/env_incompat_test.go
+++ b/muxcore/daemon/env_incompat_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/thebtf/mcp-mux/muxcore/control"
+	"github.com/thebtf/mcp-mux/muxcore/owner"
 )
 
 // TestGlobalFirst_EnvIncompatibleOwnersDistinct proves spec AC8 (CR-002):
@@ -368,6 +369,42 @@ func TestDeriveEnvBucketedSid_NoExistingEntry(t *testing.T) {
 	got := d.deriveEnvBucketedSid(base, map[string]string{"GITHUB_TOKEN": "x"})
 	if got != base {
 		t.Errorf("no existing entry: got %q, want %q", got, base)
+	}
+}
+
+func TestReusedOwnerPreRegisterKeepsEffectiveEnv(t *testing.T) {
+	const inheritedKey = "MCPMUX_REUSE_CONFIG_PATH"
+	t.Setenv(inheritedKey, "daemon-config")
+
+	d := testDaemon(t)
+	command := "reuse-effective-env"
+	snap := daemonMaterializationSnapshot(false)
+	d.updateTemplate(command, nil, snap)
+	cwd := t.TempDir()
+
+	_, sid, _, err := d.Spawn(control.Request{Command: command, Mode: "global", Cwd: cwd})
+	if err != nil {
+		t.Fatalf("first Spawn: %v", err)
+	}
+	_, reusedSID, token, err := d.Spawn(control.Request{Command: command, Mode: "global", Cwd: cwd})
+	if err != nil {
+		t.Fatalf("reused Spawn: %v", err)
+	}
+	if reusedSID != sid {
+		t.Fatalf("reused Spawn sid = %q, want %q", reusedSID, sid)
+	}
+
+	entry := d.Entry(sid)
+	if entry == nil || entry.Owner == nil {
+		t.Fatalf("owner %q missing after reuse", sid)
+	}
+	session := &owner.Session{ID: 991}
+	entry.Owner.SessionMgr().RegisterSession(session, "")
+	if !entry.Owner.SessionMgr().Bind(token, sid, session) {
+		t.Fatal("reused token did not bind")
+	}
+	if got := session.Env[inheritedKey]; got != "daemon-config" {
+		t.Fatalf("reused session effective env %s = %q, want daemon-config", inheritedKey, got)
 	}
 }
 

--- a/muxcore/daemon/generation_handoff_parity_test.go
+++ b/muxcore/daemon/generation_handoff_parity_test.go
@@ -87,6 +87,9 @@ func TestGenerationHandoffParityStatusRejectsFreshSpawnEvidence(t *testing.T) {
 	if restored := d.loadSnapshot(); restored != 1 {
 		t.Fatalf("loadSnapshot() restored %d owners, want 1", restored)
 	}
+	if activated := d.activateRestartStaging(); activated != 1 {
+		t.Fatalf("activateRestartStaging() activated %d owners, want 1", activated)
+	}
 
 	status := d.HandleStatus()
 	handoff, ok := status["handoff"].(map[string]any)

--- a/muxcore/daemon/generation_handoff_parity_test.go
+++ b/muxcore/daemon/generation_handoff_parity_test.go
@@ -87,7 +87,11 @@ func TestGenerationHandoffParityStatusRejectsFreshSpawnEvidence(t *testing.T) {
 	if restored := d.loadSnapshot(); restored != 1 {
 		t.Fatalf("loadSnapshot() restored %d owners, want 1", restored)
 	}
-	if activated := d.activateRestartStaging(); activated != 1 {
+	activated, err := d.activateRestartStaging()
+	if err != nil {
+		t.Fatalf("activateRestartStaging() error: %v", err)
+	}
+	if activated != 1 {
 		t.Fatalf("activateRestartStaging() activated %d owners, want 1", activated)
 	}
 

--- a/muxcore/daemon/graceful_restart_response_test.go
+++ b/muxcore/daemon/graceful_restart_response_test.go
@@ -31,6 +31,7 @@ func TestGracefulRestart_ResponseDelivery(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New(): %v", err)
 	}
+	t.Cleanup(d.Shutdown)
 	seedProcessBackedOwner(t, d)
 
 	// Send graceful-restart via the real control client — same code path
@@ -86,6 +87,7 @@ func TestGracefulRestart_ResponseDelivery_WithOwner(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New(): %v", err)
 	}
+	t.Cleanup(d.Shutdown)
 
 	// Spawn a mock owner so Shutdown has real work.
 	_, _, _, err = d.Spawn(control.Request{
@@ -143,6 +145,7 @@ func TestGracefulRestart_BackToBack(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Phase %d: New(): %v", i, err)
 		}
+		t.Cleanup(d.Shutdown)
 		seedProcessBackedOwner(t, d)
 
 		resp, err := control.SendWithTimeout(ctlPath, control.Request{

--- a/muxcore/daemon/graceful_restart_response_test.go
+++ b/muxcore/daemon/graceful_restart_response_test.go
@@ -17,6 +17,7 @@ import (
 // Regression test for #99 (response lost on Windows AF_UNIX).
 func TestGracefulRestart_ResponseDelivery(t *testing.T) {
 	setupTestHandoffTimeouts(t)
+	spawnedFallbacks := setupPostHelloFailureSuccessors(t)
 
 	ctlPath := shortSocketPath(t, "gr-response.ctl.sock")
 	d, err := New(Config{
@@ -48,6 +49,9 @@ func TestGracefulRestart_ResponseDelivery(t *testing.T) {
 		t.Errorf("message = %q, want %q", resp.Message, "snapshot written, shutting down")
 	}
 	t.Logf("response received: ok=%v message=%q", resp.OK, resp.Message)
+	if *spawnedFallbacks != 1 {
+		t.Fatalf("snapshot fallback successor starts = %d, want 1", *spawnedFallbacks)
+	}
 
 	// Verify daemon shuts down within a reasonable time.
 	select {
@@ -68,6 +72,7 @@ func TestGracefulRestart_ResponseDelivery(t *testing.T) {
 // Shutdown has actual work to do (close owners, stop supervisor).
 func TestGracefulRestart_ResponseDelivery_WithOwner(t *testing.T) {
 	setupTestHandoffTimeouts(t)
+	spawnedFallbacks := setupPostHelloFailureSuccessors(t)
 
 	ctlPath := shortSocketPath(t, "gr-owner.ctl.sock")
 	d, err := New(Config{
@@ -104,6 +109,9 @@ func TestGracefulRestart_ResponseDelivery_WithOwner(t *testing.T) {
 		t.Fatalf("response not OK: %s", resp.Message)
 	}
 	t.Logf("response received: ok=%v message=%q (with live owner)", resp.OK, resp.Message)
+	if *spawnedFallbacks != 1 {
+		t.Fatalf("snapshot fallback successor starts = %d, want 1", *spawnedFallbacks)
+	}
 
 	select {
 	case <-d.Done():
@@ -120,6 +128,7 @@ func TestGracefulRestart_ResponseDelivery_WithOwner(t *testing.T) {
 // pattern observed in aimux testing.
 func TestGracefulRestart_BackToBack(t *testing.T) {
 	setupTestHandoffTimeouts(t)
+	spawnedFallbacks := setupPostHelloFailureSuccessors(t)
 
 	for i := 1; i <= 2; i++ {
 		ctlPath := shortSocketPath(t, "gr-b2b.ctl.sock")
@@ -147,6 +156,9 @@ func TestGracefulRestart_BackToBack(t *testing.T) {
 			t.Fatalf("Phase %d: response not OK: %s", i, resp.Message)
 		}
 		t.Logf("Phase %d: response received: ok=%v", i, resp.OK)
+		if *spawnedFallbacks != i {
+			t.Fatalf("Phase %d: snapshot fallback successor starts = %d, want %d", i, *spawnedFallbacks, i)
+		}
 
 		select {
 		case <-d.Done():

--- a/muxcore/daemon/handoff_dup_unix_test.go
+++ b/muxcore/daemon/handoff_dup_unix_test.go
@@ -16,3 +16,29 @@ func dupFDForHandoff(t *testing.T, f *os.File) uintptr {
 	}
 	return uintptr(fd)
 }
+
+func dupRawHandoffHandle(t *testing.T, handle uintptr) uintptr {
+	t.Helper()
+	if handle == 0 {
+		return 0
+	}
+	fd, err := syscall.Dup(int(handle))
+	if err != nil {
+		t.Fatalf("dup raw handoff fd: %v", err)
+	}
+	return uintptr(fd)
+}
+
+func closeRawHandoffHandle(handle uintptr) {
+	if handle != 0 {
+		_ = syscall.Close(int(handle))
+	}
+}
+
+func daemonTestProcessAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	err := syscall.Kill(pid, 0)
+	return err == nil || err == syscall.EPERM
+}

--- a/muxcore/daemon/handoff_dup_windows_test.go
+++ b/muxcore/daemon/handoff_dup_windows_test.go
@@ -25,3 +25,42 @@ func dupFDForHandoff(t *testing.T, f *os.File) uintptr {
 	}
 	return uintptr(dup)
 }
+
+func dupRawHandoffHandle(t *testing.T, handle uintptr) uintptr {
+	t.Helper()
+	if handle == 0 {
+		return 0
+	}
+	var dup windows.Handle
+	if err := windows.DuplicateHandle(
+		windows.CurrentProcess(),
+		windows.Handle(handle),
+		windows.CurrentProcess(),
+		&dup,
+		0,
+		false,
+		windows.DUPLICATE_SAME_ACCESS,
+	); err != nil {
+		t.Fatalf("duplicate raw handoff handle: %v", err)
+	}
+	return uintptr(dup)
+}
+
+func closeRawHandoffHandle(handle uintptr) {
+	if handle != 0 {
+		_ = windows.CloseHandle(windows.Handle(handle))
+	}
+}
+
+func daemonTestProcessAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	handle, err := windows.OpenProcess(windows.SYNCHRONIZE, false, uint32(pid))
+	if err != nil {
+		return false
+	}
+	defer windows.CloseHandle(handle)
+	status, err := windows.WaitForSingleObject(handle, 0)
+	return err == nil && status == uint32(windows.WAIT_TIMEOUT)
+}

--- a/muxcore/daemon/handoff_fallback_test.go
+++ b/muxcore/daemon/handoff_fallback_test.go
@@ -142,7 +142,7 @@ func registerGracefulRestartCleanup(t *testing.T, d *Daemon, afterFn func()) {
 		t.Fatal("graceful restart afterFn is nil")
 	}
 	t.Cleanup(func() {
-		afterFn()
+		go afterFn()
 		select {
 		case <-d.Done():
 		case <-time.After(5 * time.Second):

--- a/muxcore/daemon/handoff_fallback_test.go
+++ b/muxcore/daemon/handoff_fallback_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/thebtf/mcp-mux/muxcore/control"
+	"github.com/thebtf/mcp-mux/muxcore/owner"
 )
 
 // setupTestHandoffTimeouts overrides the package-level handoff timeout
@@ -27,7 +28,7 @@ func setupTestHandoffTimeouts(t *testing.T) {
 
 func seedProcessBackedOwner(t *testing.T, d *Daemon) {
 	t.Helper()
-	_, _, _, err := d.Spawn(control.Request{
+	_, sid, _, err := d.Spawn(control.Request{
 		Cmd:     "spawn",
 		Command: "go",
 		Args:    []string{"run", "../../testdata/mock_server.go"},
@@ -37,6 +38,10 @@ func seedProcessBackedOwner(t *testing.T, d *Daemon) {
 	if err != nil {
 		t.Fatalf("Spawn() process-backed owner: %v", err)
 	}
+	waitForDaemonCondition(t, 5*time.Second, func() bool {
+		entry := d.Entry(sid)
+		return entry != nil && entry.Owner != nil && entry.Owner.MaterializationState() == owner.MaterializationReady
+	}, "process-backed owner did not finish eager materialization")
 }
 
 // TestHandoffFallbackOnAcceptTimeout verifies that HandleGracefulRestart returns

--- a/muxcore/daemon/handoff_fallback_test.go
+++ b/muxcore/daemon/handoff_fallback_test.go
@@ -1,8 +1,11 @@
 package daemon
 
 import (
+	"errors"
 	"os"
+	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -26,6 +29,128 @@ func setupTestHandoffTimeouts(t *testing.T) {
 	})
 }
 
+type fakeHandoffSuccessor struct {
+	done chan struct{}
+	once sync.Once
+}
+
+func newFakeHandoffSuccessor() *fakeHandoffSuccessor {
+	return &fakeHandoffSuccessor{done: make(chan struct{})}
+}
+
+func (s *fakeHandoffSuccessor) Done() <-chan struct{} { return s.done }
+func (s *fakeHandoffSuccessor) Stop() error {
+	s.once.Do(func() { close(s.done) })
+	return nil
+}
+
+func setupVersionSkewSuccessor(t *testing.T) {
+	t.Helper()
+	origSpawn := spawnHandoffSuccessorForRestart
+	spawnHandoffSuccessorForRestart = func(tokenPath, socketPath, _, _ string) (handoffSuccessor, error) {
+		token, err := readHandoffToken(tokenPath)
+		if err != nil {
+			return nil, err
+		}
+		conn, err := dialHandoff(socketPath, time.Second)
+		if err != nil {
+			return nil, err
+		}
+		defer conn.Close()
+		if err := conn.WriteJSON(HelloMsg{
+			Type:            MsgHello,
+			ProtocolVersion: HandoffProtocolVersion - 1,
+			Token:           token,
+		}); err != nil {
+			return nil, err
+		}
+		return newFakeHandoffSuccessor(), nil
+	}
+	t.Cleanup(func() { spawnHandoffSuccessorForRestart = origSpawn })
+}
+
+func setupPostHelloFailureSuccessors(t *testing.T) *int {
+	t.Helper()
+	origHandoffSpawn := spawnHandoffSuccessorForRestart
+	origSnapshotSpawn := spawnSnapshotSuccessorForRestart
+	spawnedFallbacks := new(int)
+	spawnHandoffSuccessorForRestart = func(tokenPath, socketPath, _, _ string) (handoffSuccessor, error) {
+		token, err := readHandoffToken(tokenPath)
+		if err != nil {
+			return nil, err
+		}
+		conn, err := dialHandoff(socketPath, time.Second)
+		if err != nil {
+			return nil, err
+		}
+		defer conn.Close()
+		if err := conn.WriteJSON(NewHelloMsgWithPID(token, os.Getpid())); err != nil {
+			return nil, err
+		}
+		return newFakeHandoffSuccessor(), nil
+	}
+	spawnSnapshotSuccessorForRestart = func(string, string) error {
+		*spawnedFallbacks++
+		return nil
+	}
+	t.Cleanup(func() {
+		spawnHandoffSuccessorForRestart = origHandoffSpawn
+		spawnSnapshotSuccessorForRestart = origSnapshotSpawn
+	})
+	return spawnedFallbacks
+}
+
+func TestRetryControlBindStaysPausedUntilRestartStagingActivation(t *testing.T) {
+	d := &Daemon{logger: testLogger(t)}
+	path := shortSocketPath(t, "paused-restart-control.ctl.sock")
+	if err := d.retryControlBind(path); err != nil {
+		t.Fatalf("retryControlBind: %v", err)
+	}
+	defer d.ctlSrv.Close()
+
+	result := make(chan error, 1)
+	go func() {
+		resp, err := control.SendWithTimeout(path, control.Request{Cmd: "ping"}, 2*time.Second)
+		if err == nil && !resp.OK {
+			err = os.ErrInvalid
+		}
+		result <- err
+	}()
+	select {
+	case err := <-result:
+		t.Fatalf("restart control dispatched before staging activation: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	if _, err := d.activateRestartStaging(); err != nil {
+		t.Fatalf("activateRestartStaging() error: %v", err)
+	}
+	d.ctlSrv.Start()
+	select {
+	case err := <-result:
+		if err != nil {
+			t.Fatalf("ping after staging activation: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("restart control did not dispatch after staging activation")
+	}
+}
+
+func registerGracefulRestartCleanup(t *testing.T, d *Daemon, afterFn func()) {
+	t.Helper()
+	if afterFn == nil {
+		t.Fatal("graceful restart afterFn is nil")
+	}
+	t.Cleanup(func() {
+		afterFn()
+		select {
+		case <-d.Done():
+		case <-time.After(5 * time.Second):
+			t.Error("daemon did not shut down after graceful restart afterFn")
+		}
+	})
+}
+
 func seedProcessBackedOwner(t *testing.T, d *Daemon) {
 	t.Helper()
 	_, sid, _, err := d.Spawn(control.Request{
@@ -44,38 +169,153 @@ func seedProcessBackedOwner(t *testing.T, d *Daemon) {
 	}, "process-backed owner did not finish eager materialization")
 }
 
-// TestHandoffFallbackOnAcceptTimeout verifies that HandleGracefulRestart returns
-// a valid snapshot path and nil error even when no successor daemon connects
-// within the accept timeout — i.e. the FR-8 fallback path is transparent to
-// the control-plane caller.
-//
-// Failure mode simulated: listenHandoff accept times out because spawnSuccessor
-// forks a real binary with the configured DaemonFlag but the binary in the test
-// environment is the test binary itself, which does not implement the successor
-// handshake. The accept timeout (overridden to 50 ms) fires before any connection arrives.
-//
-// This test asserts:
-//  1. HandleGracefulRestart returns (snapshotPath, nil, nil) — not an error.
-//  2. snapshotPath is non-empty — snapshot serialization succeeded.
-//  3. The daemon continues to the Shutdown path (go d.Shutdown()) regardless.
-func TestHandoffFallbackOnAcceptTimeout(t *testing.T) {
+// TestHandoffAcceptTimeoutKeepsPredecessorServing verifies that a successor
+// which never reaches Hello cannot authorize predecessor teardown.
+func TestHandoffAcceptTimeoutKeepsPredecessorServing(t *testing.T) {
 	setupTestHandoffTimeouts(t)
+	_ = os.Remove(SnapshotPath())
+	t.Cleanup(func() { _ = os.Remove(SnapshotPath()) })
 
-	d := testDaemon(t) // helper defined in daemon_test.go
+	d := testDaemon(t)
+	seedProcessBackedOwner(t, d)
+	d.mu.RLock()
+	var entry *OwnerEntry
+	for _, candidate := range d.owners {
+		entry = candidate
+		break
+	}
+	d.mu.RUnlock()
+
+	snapshotPath, afterFn, err := d.HandleGracefulRestart(0)
+	if err == nil || !strings.Contains(err.Error(), "accept") {
+		t.Fatalf("HandleGracefulRestart() error = %v, want accept failure", err)
+	}
+	if snapshotPath != "" || afterFn != nil {
+		t.Fatalf("aborted restart returned path=%q afterFn=%v", snapshotPath, afterFn != nil)
+	}
+	if d.shuttingDown.Load() {
+		t.Fatal("daemon remained in shutting-down state after aborted restart")
+	}
+	if entry == nil || entry.Owner == nil || !entry.Owner.IsAccepting() {
+		t.Fatal("accept failure stopped the predecessor owner")
+	}
+	if got := entry.Owner.Status()["restart_pin_count"]; got != int64(0) {
+		t.Fatalf("restart pin count = %v, want 0", got)
+	}
+	if entry.terminationHint != HintNone {
+		t.Fatalf("termination hint = %v, want none", entry.terminationHint)
+	}
+	if _, statErr := os.Stat(SnapshotPath()); !os.IsNotExist(statErr) {
+		t.Fatalf("aborted snapshot still exists: %v", statErr)
+	}
+}
+
+func TestProtocolVersionMismatchKeepsPredecessorServing(t *testing.T) {
+	setupTestHandoffTimeouts(t)
+	setupVersionSkewSuccessor(t)
+	origSnapshotSpawn := spawnSnapshotSuccessorForRestart
+	fallbackSpawns := 0
+	spawnSnapshotSuccessorForRestart = func(string, string) error {
+		fallbackSpawns++
+		return nil
+	}
+	t.Cleanup(func() { spawnSnapshotSuccessorForRestart = origSnapshotSpawn })
+	_ = os.Remove(SnapshotPath())
+	t.Cleanup(func() { _ = os.Remove(SnapshotPath()) })
+
+	d, logs := testDaemonWithLog(t)
+	seedProcessBackedOwner(t, d)
+	d.mu.RLock()
+	var entry *OwnerEntry
+	for _, candidate := range d.owners {
+		entry = candidate
+		break
+	}
+	d.mu.RUnlock()
+	beforeFallback := d.stats.fallback.Load()
+
+	snapshotPath, afterFn, err := d.HandleGracefulRestart(0)
+	if !errors.Is(err, ErrProtocolVersionMismatch) {
+		t.Fatalf("HandleGracefulRestart() error = %v, want ErrProtocolVersionMismatch", err)
+	}
+	if snapshotPath != "" || afterFn != nil {
+		t.Fatalf("version mismatch returned path=%q afterFn=%v", snapshotPath, afterFn != nil)
+	}
+	if fallbackSpawns != 0 || d.stats.fallback.Load() != beforeFallback {
+		t.Fatalf("version mismatch started fallback=%d or advanced counter", fallbackSpawns)
+	}
+	if d.shuttingDown.Load() || entry == nil || entry.Owner == nil || !entry.Owner.IsAccepting() {
+		t.Fatal("version mismatch did not preserve the predecessor")
+	}
+	if got := entry.Owner.Status()["restart_pin_count"]; got != int64(0) {
+		t.Fatalf("restart pin count = %v, want 0", got)
+	}
+	if entry.terminationHint != HintNone {
+		t.Fatalf("termination hint = %v, want none", entry.terminationHint)
+	}
+	if _, statErr := os.Stat(SnapshotPath()); !os.IsNotExist(statErr) {
+		t.Fatalf("aborted snapshot still exists: %v", statErr)
+	}
+	if !strings.Contains(logs.String(), "handoff.abort") || strings.Contains(logs.String(), "handoff.fallback") {
+		t.Fatalf("version mismatch logs did not record abort-only behavior:\n%s", logs.String())
+	}
+}
+
+func TestAttemptHandoffSuccessorStartFailureLeavesPredecessorServing(t *testing.T) {
+	setupTestHandoffTimeouts(t)
+	d := testDaemon(t)
 	seedProcessBackedOwner(t, d)
 
-	// HandleGracefulRestart MUST succeed (FR-8 fallback is transparent to caller).
-	snapshotPath, _, err := d.HandleGracefulRestart(0)
-	if err != nil {
-		t.Fatalf("HandleGracefulRestart() returned error %v; want nil (FR-8 fallback should be transparent)", err)
+	d.mu.RLock()
+	var entry *OwnerEntry
+	for _, candidate := range d.owners {
+		entry = candidate
+		break
 	}
-	if snapshotPath == "" {
-		t.Error("HandleGracefulRestart() returned empty snapshot path; want non-empty")
+	d.mu.RUnlock()
+	if entry == nil || entry.Owner == nil {
+		t.Fatal("process-backed predecessor owner missing")
 	}
+	beforePID := entry.Owner.Status()["upstream_pid"]
+	missingSuccessor := filepath.Join(t.TempDir(), "missing-successor.exe")
+	if err := d.attemptHandoff(missingSuccessor); err == nil || !strings.Contains(err.Error(), "spawn successor") {
+		t.Fatalf("attemptHandoff error = %v, want successor start failure", err)
+	}
+	if d.Entry(entry.ServerID) != entry {
+		t.Fatal("successor start failure replaced or removed predecessor owner")
+	}
+	if !entry.Owner.IsAccepting() {
+		t.Fatal("successor start failure stopped predecessor listener")
+	}
+	if afterPID := entry.Owner.Status()["upstream_pid"]; afterPID != beforePID {
+		t.Fatalf("successor start failure changed predecessor pid from %v to %v", beforePID, afterPID)
+	}
+}
 
-	// Cleanup snapshot file produced by SerializeSnapshot.
-	if snapshotPath != "" {
-		os.Remove(snapshotPath)
+func TestGracefulRestartSuccessorStartFailureLeavesPredecessorServing(t *testing.T) {
+	d := testDaemon(t)
+	seedProcessBackedOwner(t, d)
+	d.mu.RLock()
+	var entry *OwnerEntry
+	for _, candidate := range d.owners {
+		entry = candidate
+		break
+	}
+	d.mu.RUnlock()
+
+	missingSuccessor := filepath.Join(t.TempDir(), "missing-successor.exe")
+	snapshotPath, afterFn, err := d.HandleGracefulRestartWithOptions(control.GracefulRestartOptions{SuccessorExe: missingSuccessor})
+	if err == nil || !strings.Contains(err.Error(), "spawn successor") {
+		t.Fatalf("HandleGracefulRestartWithOptions() error = %v, want successor start failure", err)
+	}
+	if snapshotPath != "" || afterFn != nil {
+		t.Fatalf("aborted restart returned path=%q afterFn=%v", snapshotPath, afterFn != nil)
+	}
+	if d.shuttingDown.Load() || entry == nil || entry.Owner == nil || !entry.Owner.IsAccepting() {
+		t.Fatal("successor start failure did not preserve the predecessor")
+	}
+	if got := entry.Owner.Status()["restart_pin_count"]; got != int64(0) {
+		t.Fatalf("restart pin count = %v, want 0", got)
 	}
 }
 
@@ -121,7 +361,7 @@ func TestAttemptHandoffSkipsSessionHandlerOnlyOwners(t *testing.T) {
 	}
 }
 
-func TestGracefulRestartSessionHandlerOnlySpawnsSnapshotSuccessorAfterShutdown(t *testing.T) {
+func TestGracefulRestartSessionHandlerOnlySpawnsSnapshotSuccessorBeforeShutdown(t *testing.T) {
 	origSpawn := spawnSnapshotSuccessorForRestart
 	spawned := make(chan struct{})
 	var gotExe, gotFlag string
@@ -148,40 +388,31 @@ func TestGracefulRestartSessionHandlerOnlySpawnsSnapshotSuccessorAfterShutdown(t
 		t.Fatalf("New(): %v", err)
 	}
 
-	_, sid, _, err := d.Spawn(control.Request{
-		Cmd:  "spawn",
-		Cwd:  t.TempDir(),
-		Mode: "global",
-	})
+	_, sid, _, err := d.Spawn(control.Request{Cmd: "spawn", Cwd: t.TempDir(), Mode: "global"})
 	if err != nil {
 		t.Fatalf("Spawn() SessionHandler owner: %v", err)
 	}
 	waitOwnerAccepting(t, d, sid)
 
 	beforeFallback := d.stats.fallback.Load()
-	snapshotPath, afterFn, err := d.HandleGracefulRestartWithOptions(control.GracefulRestartOptions{
-		SuccessorExe: "next-engine.exe",
-	})
+	snapshotPath, afterFn, err := d.HandleGracefulRestartWithOptions(control.GracefulRestartOptions{SuccessorExe: "next-engine.exe"})
 	if err != nil {
-		t.Fatalf("HandleGracefulRestartWithOptions() error = %v, want nil", err)
-	}
-	if snapshotPath == "" {
-		t.Fatal("snapshot path is empty")
+		t.Fatalf("HandleGracefulRestartWithOptions() error = %v", err)
 	}
 	t.Cleanup(func() { _ = os.Remove(snapshotPath) })
-	if afterFn == nil {
-		t.Fatal("afterFn is nil; predecessor would not shut down after response")
-	}
 	select {
 	case <-spawned:
-		t.Fatal("snapshot successor spawned before restart response afterFn")
 	default:
+		t.Fatal("snapshot successor was not started before restart returned")
 	}
-	if !d.shuttingDown.Load() {
-		t.Fatal("daemon is not marked shuttingDown while restart response is pending")
+	if afterFn == nil || !d.shuttingDown.Load() {
+		t.Fatal("successful snapshot restart did not arm predecessor shutdown")
 	}
 	if got := d.stats.fallback.Load() - beforeFallback; got != 0 {
-		t.Fatalf("handoff fallback delta = %d, want 0 for SessionHandler-only snapshot restart", got)
+		t.Fatalf("handoff fallback delta = %d, want 0", got)
+	}
+	if gotExe != "next-engine.exe" || gotFlag != "--fixture-daemon" {
+		t.Fatalf("snapshot successor = (%q, %q), want (next-engine.exe, --fixture-daemon)", gotExe, gotFlag)
 	}
 
 	afterFn()
@@ -190,13 +421,49 @@ func TestGracefulRestartSessionHandlerOnlySpawnsSnapshotSuccessorAfterShutdown(t
 	case <-time.After(5 * time.Second):
 		t.Fatal("daemon did not shut down after snapshot restart afterFn")
 	}
-	select {
-	case <-spawned:
-	case <-time.After(5 * time.Second):
-		t.Fatal("snapshot successor did not spawn after daemon shutdown")
+}
+
+func TestGracefulRestartSessionHandlerSuccessorStartFailurePreservesPredecessor(t *testing.T) {
+	origSpawn := spawnSnapshotSuccessorForRestart
+	spawnSnapshotSuccessorForRestart = func(string, string) error { return os.ErrNotExist }
+	t.Cleanup(func() { spawnSnapshotSuccessorForRestart = origSpawn })
+	_ = os.Remove(SnapshotPath())
+	t.Cleanup(func() { _ = os.Remove(SnapshotPath()) })
+
+	ctlPath := shortSocketPath(t, "sessionhandler-snapshot-failure.ctl.sock")
+	d, err := New(Config{
+		Name:           "test-daemon",
+		ControlPath:    ctlPath,
+		SkipSnapshot:   true,
+		SessionHandler: noopSessionHandler{},
+		Logger:         testLogger(t),
+	})
+	if err != nil {
+		t.Fatalf("New(): %v", err)
 	}
-	if gotExe != "next-engine.exe" || gotFlag != "--fixture-daemon" {
-		t.Fatalf("snapshot successor = (%q, %q), want (next-engine.exe, --fixture-daemon)", gotExe, gotFlag)
+	t.Cleanup(func() { d.Shutdown() })
+	_, sid, _, err := d.Spawn(control.Request{Cmd: "spawn", Cwd: t.TempDir(), Mode: "global"})
+	if err != nil {
+		t.Fatalf("Spawn() SessionHandler owner: %v", err)
+	}
+	waitOwnerAccepting(t, d, sid)
+
+	snapshotPath, afterFn, err := d.HandleGracefulRestartWithOptions(control.GracefulRestartOptions{SuccessorExe: "missing.exe"})
+	if err == nil {
+		t.Fatal("snapshot successor start failure returned nil error")
+	}
+	if snapshotPath != "" || afterFn != nil || d.shuttingDown.Load() {
+		t.Fatalf("aborted snapshot restart path=%q afterFn=%v shuttingDown=%v", snapshotPath, afterFn != nil, d.shuttingDown.Load())
+	}
+	entry := d.Entry(sid)
+	if entry == nil || entry.Owner == nil || !entry.Owner.IsAccepting() {
+		t.Fatal("snapshot successor start failure stopped predecessor owner")
+	}
+	if got := entry.Owner.Status()["restart_pin_count"]; got != int64(0) {
+		t.Fatalf("restart pin count = %v, want 0", got)
+	}
+	if _, statErr := os.Stat(SnapshotPath()); !os.IsNotExist(statErr) {
+		t.Fatalf("aborted snapshot still exists: %v", statErr)
 	}
 }
 
@@ -208,15 +475,20 @@ func TestGracefulRestartSessionHandlerOnlySpawnsSnapshotSuccessorAfterShutdown(t
 // log output into a thread-safe buffer and grep it after the call returns.
 func TestHandoffFallback_LogMarker(t *testing.T) {
 	setupTestHandoffTimeouts(t)
+	spawnedFallbacks := setupPostHelloFailureSuccessors(t)
 
 	d, logBuf := testDaemonWithLog(t)
 	seedProcessBackedOwner(t, d)
 
-	snapshotPath, _, err := d.HandleGracefulRestart(0)
+	snapshotPath, afterFn, err := d.HandleGracefulRestart(0)
 	if err != nil {
 		t.Fatalf("HandleGracefulRestart: %v", err)
 	}
 	t.Cleanup(func() { _ = os.Remove(snapshotPath) })
+	registerGracefulRestartCleanup(t, d, afterFn)
+	if *spawnedFallbacks != 1 {
+		t.Fatalf("snapshot fallback successor starts = %d, want exactly 1", *spawnedFallbacks)
+	}
 
 	logs := logBuf.String()
 
@@ -241,15 +513,12 @@ func TestHandoffFallback_LogMarker(t *testing.T) {
 }
 
 // TestHandoffFallback_CounterIncrement verifies that the handoff_fallback
-// atomic counter advances by exactly 1 per fallback attempt, enabling the
-// verify-handoff.sh / .ps1 post-deploy scripts (T036) to distinguish
-// successful handoffs from FR-8 legacy-path falls.
-//
-// Mechanism mirrors TestHandoffFallbackOnAcceptTimeout (accept timeout),
-// but asserts the counter delta in HandleStatus output rather than log
-// content.
+// atomic counter advances by exactly 1 after an exact-Hello protocol failure,
+// enabling post-deploy scripts to distinguish live handoff from bounded
+// snapshot fallback.
 func TestHandoffFallback_CounterIncrement(t *testing.T) {
 	setupTestHandoffTimeouts(t)
+	spawnedFallbacks := setupPostHelloFailureSuccessors(t)
 
 	d := testDaemon(t)
 	seedProcessBackedOwner(t, d)
@@ -258,11 +527,15 @@ func TestHandoffFallback_CounterIncrement(t *testing.T) {
 	before := d.stats.fallback.Load()
 	beforeAttempted := d.stats.attempted.Load()
 
-	snapshotPath, _, err := d.HandleGracefulRestart(0)
+	snapshotPath, afterFn, err := d.HandleGracefulRestart(0)
 	if err != nil {
 		t.Fatalf("HandleGracefulRestart: %v", err)
 	}
 	t.Cleanup(func() { _ = os.Remove(snapshotPath) })
+	registerGracefulRestartCleanup(t, d, afterFn)
+	if *spawnedFallbacks != 1 {
+		t.Fatalf("snapshot fallback successor starts = %d, want exactly 1", *spawnedFallbacks)
+	}
 
 	afterAttempted := d.stats.attempted.Load()
 	after := d.stats.fallback.Load()
@@ -274,13 +547,12 @@ func TestHandoffFallback_CounterIncrement(t *testing.T) {
 			afterAttempted-beforeAttempted)
 	}
 
-	// fallback MUST increase by exactly 1 on this failure path.
+	// fallback MUST increase by exactly 1 only after exact Hello and detach.
 	if after-before != 1 {
-		t.Errorf("handoff_fallback delta: got %d, want 1 (accept timeout should be a fallback, not a success)",
-			after-before)
+		t.Errorf("handoff_fallback delta: got %d, want 1 for post-Hello failure", after-before)
 	}
 
-	// transferred + aborted MUST remain zero — no handoff protocol ran.
+	// transferred + aborted remain zero because no owner transfer began.
 	if got := d.stats.transferred.Load(); got != 0 {
 		t.Errorf("handoff_transferred on fallback path: got %d, want 0", got)
 	}
@@ -293,6 +565,7 @@ func TestHandoffFallback_CounterIncrement(t *testing.T) {
 // HandleStatus output (the API verify-handoff.sh / .ps1 rely on).
 func TestHandoffFallback_StatusCountersExposed(t *testing.T) {
 	setupTestHandoffTimeouts(t)
+	spawnedFallbacks := setupPostHelloFailureSuccessors(t)
 
 	d := testDaemon(t)
 	seedProcessBackedOwner(t, d)
@@ -309,11 +582,15 @@ func TestHandoffFallback_StatusCountersExposed(t *testing.T) {
 		}
 	}
 
-	snapshotPath, _, err := d.HandleGracefulRestart(0)
+	snapshotPath, afterFn, err := d.HandleGracefulRestart(0)
 	if err != nil {
 		t.Fatalf("HandleGracefulRestart: %v", err)
 	}
 	t.Cleanup(func() { _ = os.Remove(snapshotPath) })
+	registerGracefulRestartCleanup(t, d, afterFn)
+	if *spawnedFallbacks != 1 {
+		t.Fatalf("snapshot fallback successor starts = %d, want exactly 1", *spawnedFallbacks)
+	}
 
 	after := d.HandleStatus()
 	hoff1, ok := after["handoff"].(map[string]any)
@@ -339,15 +616,20 @@ func TestHandoffFallback_StatusCountersExposed(t *testing.T) {
 // requests AND the cached init/tools templates.
 func TestHandoffFallback_SnapshotAlwaysWritten(t *testing.T) {
 	setupTestHandoffTimeouts(t)
+	spawnedFallbacks := setupPostHelloFailureSuccessors(t)
 
 	d := testDaemon(t)
 	seedProcessBackedOwner(t, d)
 
-	snapshotPath, _, err := d.HandleGracefulRestart(0)
+	snapshotPath, afterFn, err := d.HandleGracefulRestart(0)
 	if err != nil {
 		t.Fatalf("HandleGracefulRestart: %v", err)
 	}
 	t.Cleanup(func() { _ = os.Remove(snapshotPath) })
+	registerGracefulRestartCleanup(t, d, afterFn)
+	if *spawnedFallbacks != 1 {
+		t.Fatalf("snapshot fallback successor starts = %d, want exactly 1", *spawnedFallbacks)
+	}
 
 	info, statErr := os.Stat(snapshotPath)
 	if statErr != nil {

--- a/muxcore/daemon/handoff_final_ack_linux_test.go
+++ b/muxcore/daemon/handoff_final_ack_linux_test.go
@@ -1,0 +1,583 @@
+//go:build linux
+
+package daemon
+
+import (
+	"bufio"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/thebtf/mcp-mux/muxcore/classify"
+	"github.com/thebtf/mcp-mux/muxcore/owner"
+	mcpsnapshot "github.com/thebtf/mcp-mux/muxcore/snapshot"
+	"github.com/thebtf/mcp-mux/muxcore/upstream"
+	"golang.org/x/sys/unix"
+)
+
+type failFinalAckUnixConn struct {
+	fdConn
+	received []uintptr
+	objects  []unix.Stat_t
+}
+
+func (c *failFinalAckUnixConn) RecvFDs() ([]uintptr, []byte, error) {
+	fds, header, err := c.fdConn.RecvFDs()
+	if err != nil {
+		return nil, nil, err
+	}
+	for _, fd := range fds {
+		var stat unix.Stat_t
+		if err := unix.Fstat(int(fd), &stat); err != nil {
+			return nil, nil, err
+		}
+		c.received = append(c.received, fd)
+		c.objects = append(c.objects, stat)
+	}
+	return fds, header, nil
+}
+
+func (c *failFinalAckUnixConn) WriteJSON(v any) error {
+	switch v.(type) {
+	case HandoffAckMsg, *HandoffAckMsg:
+		_ = c.fdConn.Close()
+		return io.ErrClosedPipe
+	default:
+		return c.fdConn.WriteJSON(v)
+	}
+}
+
+func TestHandoffUnix_FinalAckDisconnectClosesTransferredFDsAndStartsOneFallback(t *testing.T) {
+	const roleEnv = "MCPMUX_TEST_FINAL_ACK_ROLLBACK_UNIX_ROLE"
+	const pidsEnv = "MCPMUX_TEST_FINAL_ACK_ROLLBACK_UNIX_PIDS"
+	const snapshotEnv = "MCPMUX_TEST_FINAL_ACK_ROLLBACK_UNIX_SNAPSHOT"
+	const oldPIDEnv = "MCPMUX_TEST_FINAL_ACK_ROLLBACK_UNIX_OLD_PID"
+	switch os.Getenv(roleEnv) {
+	case "upstream":
+		pidFile, err := os.OpenFile(os.Getenv(pidsEnv), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+		if err != nil {
+			t.Fatalf("open pid file: %v", err)
+		}
+		_, _ = fmt.Fprintln(pidFile, os.Getpid())
+		_ = pidFile.Close()
+		go func() {
+			for range time.NewTicker(10 * time.Millisecond).C {
+				_, _ = fmt.Fprintln(os.Stdout, `{"jsonrpc":"2.0","method":"notifications/message","params":{"level":"info","data":"handoff"}}`)
+			}
+		}()
+		_, _ = io.Copy(io.Discard, os.Stdin)
+		return
+	case "successor":
+		snapshotData, err := base64.StdEncoding.DecodeString(os.Getenv(snapshotEnv))
+		if err != nil {
+			t.Fatalf("decode snapshot: %v", err)
+		}
+		if err := os.WriteFile(SnapshotPath(), snapshotData, 0o600); err != nil {
+			t.Fatalf("write successor snapshot: %v", err)
+		}
+		oldPID, err := strconv.Atoi(os.Getenv(oldPIDEnv))
+		if err != nil {
+			t.Fatalf("parse predecessor pid: %v", err)
+		}
+		origWindow := restoreHealthGateWindow
+		restoreHealthGateWindow = time.Hour
+		defer func() { restoreHealthGateWindow = origWindow }()
+
+		var failedConn *failFinalAckUnixConn
+		origHook := dialHandoffHook
+		dialHandoffHook = func(name string, timeout time.Duration) (fdConn, error) {
+			conn, err := dialHandoffUnix(name, timeout)
+			if err != nil {
+				return nil, err
+			}
+			failedConn = &failFinalAckUnixConn{fdConn: conn}
+			return failedConn, nil
+		}
+		defer func() { dialHandoffHook = origHook }()
+
+		d, logs := testDaemonWithLog(t)
+		if restored := d.loadSnapshot(); restored != 1 {
+			t.Fatalf("loadSnapshot() restored %d owners, want 1", restored)
+		}
+		if activated := d.activateRestartStaging(); activated != 1 {
+			t.Fatalf("activateRestartStaging()=%d, want 1; logs:\n%s", activated, logs.String())
+		}
+		entry := d.Entry("aabbccdd-final-ack-rollback-unix")
+		if entry == nil || entry.Owner == nil {
+			t.Fatalf("fallback owner missing after final ACK failure; logs:\n%s", logs.String())
+		}
+		if entry.RestoreSource != "snapshot_fallback" {
+			t.Fatalf("restore_source=%q, want snapshot_fallback after final ACK failure; logs:\n%s", entry.RestoreSource, logs.String())
+		}
+		if !entry.Owner.CacheReady() {
+			t.Fatalf("fallback owner lost cached discovery state; logs:\n%s", logs.String())
+		}
+		if state := entry.Owner.MaterializationState(); state == owner.MaterializationCacheOnly {
+			t.Fatalf("fallback materialization state=%s after predecessor barrier, want eager restore", state)
+		}
+		var newPIDs []int
+		waitForDaemonCondition(t, 2*time.Second, func() bool {
+			pidData, _ := os.ReadFile(os.Getenv(pidsEnv))
+			seen := make(map[int]struct{})
+			for _, field := range strings.Fields(string(pidData)) {
+				pid, _ := strconv.Atoi(field)
+				if pid > 0 && pid != oldPID {
+					seen[pid] = struct{}{}
+				}
+			}
+			newPIDs = newPIDs[:0]
+			for pid := range seen {
+				newPIDs = append(newPIDs, pid)
+			}
+			return len(newPIDs) == 1
+		}, "rollback fallback did not start exactly one fresh upstream generation")
+		if pid, _ := entry.Owner.Status()["upstream_pid"].(int); pid != newPIDs[0] {
+			t.Fatalf("fallback upstream pid=%d, want sole fresh pid %d", pid, newPIDs[0])
+		}
+		if failedConn == nil || len(failedConn.received) != 3 {
+			t.Fatalf("received fds=%v, want stdin/stdout/stderr", failedConn)
+		}
+		for i, fd := range failedConn.received {
+			var current unix.Stat_t
+			if err := unix.Fstat(int(fd), &current); err == nil && current.Dev == failedConn.objects[i].Dev && current.Ino == failedConn.objects[i].Ino {
+				t.Fatalf("rolled-back fd %d still refers to transferred object", fd)
+			}
+		}
+		return
+	}
+
+	_ = os.Remove(SnapshotPath())
+	t.Cleanup(func() { _ = os.Remove(SnapshotPath()) })
+	const sid = "aabbccdd-final-ack-rollback-unix"
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	args := []string{"-test.run=^TestHandoffUnix_FinalAckDisconnectClosesTransferredFDsAndStartsOneFallback$"}
+	pidPath := filepath.Join(t.TempDir(), "pids")
+	upstreamEnv := map[string]string{roleEnv: "upstream", pidsEnv: pidPath}
+	proc, err := upstream.Start(exe, args, upstreamEnv, t.TempDir(), nil)
+	if err != nil {
+		t.Fatalf("start predecessor upstream: %v", err)
+	}
+	t.Cleanup(func() { _ = proc.AbortDetach() })
+	oldPID, stdinFD, stdoutFD, stderrFD, _, err := proc.DetachWithAuthority()
+	if err != nil {
+		t.Fatalf("DetachWithAuthority: %v", err)
+	}
+
+	snap := DaemonSnapshot{
+		Version:   mcpsnapshot.SnapshotVersion,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Owners: []mcpsnapshot.OwnerSnapshot{{
+			ServerID:       sid,
+			Command:        exe,
+			Args:           args,
+			Cwd:            t.TempDir(),
+			Mode:           "global",
+			Classification: classify.ModeShared,
+			CachedInit:     "e30=",
+			CachedTools:    "e30=",
+			Env:            upstreamEnv,
+		}},
+	}
+	data, err := json.Marshal(snap)
+	if err != nil {
+		t.Fatalf("marshal snapshot: %v", err)
+	}
+	if err := os.WriteFile(SnapshotPath(), data, 0o600); err != nil {
+		t.Fatalf("write snapshot: %v", err)
+	}
+	tokenPath := filepath.Join(t.TempDir(), "handoff.token")
+	const token = "final-ack-rollback-unix-token"
+	if err := os.WriteFile(tokenPath, []byte(token), 0o600); err != nil {
+		t.Fatalf("write token: %v", err)
+	}
+	socketPath := filepath.Join(t.TempDir(), "handoff.sock")
+	serverErr := make(chan error, 1)
+	go func() {
+		conn, err := listenHandoffUnix(socketPath, 5*time.Second)
+		if err != nil {
+			serverErr <- err
+			return
+		}
+		defer conn.Close()
+		_, err = performHandoff(context.Background(), conn, token, []HandoffUpstream{{
+			ServerID: sid, Command: exe, PID: oldPID,
+			StdinFD: stdinFD, StdoutFD: stdoutFD, StderrFD: stderrFD,
+			commit: proc.CommitDetach, abort: proc.AbortDetach,
+		}})
+		serverErr <- err
+	}()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, err := os.Stat(socketPath); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("handoff socket did not become ready")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	cmd := exec.Command(exe, args...)
+	cmd.Env = append(os.Environ(),
+		roleEnv+"=successor",
+		oldPIDEnv+"="+strconv.Itoa(oldPID),
+		pidsEnv+"="+pidPath,
+		snapshotEnv+"="+base64.StdEncoding.EncodeToString(data),
+		"MCPMUX_HANDOFF_TOKEN_PATH="+tokenPath,
+		"MCPMUX_HANDOFF_SOCKET="+socketPath,
+	)
+	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start successor: %v", err)
+	}
+	t.Cleanup(func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+	})
+	select {
+	case err := <-serverErr:
+		if err == nil {
+			t.Fatal("predecessor handoff error=nil, want final ACK failure")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("predecessor did not observe final ACK failure")
+	}
+	select {
+	case <-proc.Done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("predecessor did not abort the uncommitted upstream")
+	}
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("successor rollback failed: %v", err)
+	}
+}
+
+func TestHandoffIntegration_FinalAckWriteFailureAbortsPreparedTreeUnix(t *testing.T) {
+	proc, err := upstream.Start("sleep", []string{"30"}, nil, "", nil)
+	if err != nil {
+		t.Fatalf("start upstream: %v", err)
+	}
+	t.Cleanup(func() { _ = proc.AbortDetach() })
+	pid, stdinFD, stdoutFD, stderrFD, _, err := proc.DetachWithAuthority()
+	if err != nil {
+		t.Fatalf("detach upstream: %v", err)
+	}
+	const sid = "unix-final-ack-platform"
+	const token = "unix-final-ack-platform-token"
+	socketPath := filepath.Join(t.TempDir(), "handoff.sock")
+	serverDone := make(chan error, 1)
+	go func() {
+		conn, listenErr := listenHandoffUnix(socketPath, 5*time.Second)
+		if listenErr != nil {
+			serverDone <- listenErr
+			return
+		}
+		defer conn.Close()
+		_, handoffErr := performHandoff(context.Background(), conn, token, []HandoffUpstream{{
+			ServerID: sid, Command: "sleep", PID: pid,
+			StdinFD: stdinFD, StdoutFD: stdoutFD, StderrFD: stderrFD,
+			commit: proc.CommitDetach, abort: proc.AbortDetach,
+		}})
+		serverDone <- handoffErr
+	}()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, err := os.Stat(socketPath); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("handoff listener did not start")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	raw, err := dialHandoffUnix(socketPath, 2*time.Second)
+	if err != nil {
+		t.Fatalf("dial handoff: %v", err)
+	}
+	conn := &failFinalAckUnixConn{fdConn: raw}
+	receipt, err := prepareHandoffReceive(context.Background(), conn, token)
+	if err != nil {
+		t.Fatalf("prepare receive: %v", err)
+	}
+	received, ok := receipt.take(sid)
+	if !ok {
+		t.Fatal("transferred process missing from receipt")
+	}
+	adopted, err := upstream.AttachFromFDsWithAuthority(received.PID, received.StdinFD, received.StdoutFD, received.StderrFD, received.AuthorityFD, received.Command, nil)
+	if err != nil {
+		_ = receipt.finalize(nil)
+		t.Fatalf("attach transferred process: %v", err)
+	}
+	if err := receipt.finalize([]string{sid}); err == nil {
+		_ = adopted.Close()
+		t.Fatal("final ACK error=nil, want injected disconnect")
+	}
+	if err := adopted.Close(); err != nil {
+		t.Fatalf("rollback adopted process: %v", err)
+	}
+	select {
+	case err := <-serverDone:
+		if err == nil {
+			t.Fatal("predecessor committed despite final ACK disconnect")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("predecessor did not abort after final ACK disconnect")
+	}
+	select {
+	case <-proc.Done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("prepared predecessor tree remained alive")
+	}
+}
+
+func TestMixedRestartActivatesCacheOnlyOnlyAfterPredecessorBarrier(t *testing.T) {
+	const roleEnv = "MCPMUX_TEST_MIXED_BARRIER_ROLE"
+	const pidsEnv = "MCPMUX_TEST_MIXED_BARRIER_PIDS"
+	const labelEnv = "MCPMUX_TEST_MIXED_BARRIER_LABEL"
+	if os.Getenv(roleEnv) == "upstream" {
+		pidFile, err := os.OpenFile(os.Getenv(pidsEnv), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+		if err != nil {
+			t.Fatalf("open pid file: %v", err)
+		}
+		_, _ = fmt.Fprintf(pidFile, "%s %d\n", os.Getenv(labelEnv), os.Getpid())
+		_ = pidFile.Close()
+		go func() {
+			for range time.NewTicker(10 * time.Millisecond).C {
+				_, _ = fmt.Fprintln(os.Stdout, `{"jsonrpc":"2.0","method":"notifications/message","params":{"level":"info","data":"barrier"}}`)
+			}
+		}()
+		scanner := bufio.NewScanner(os.Stdin)
+		for scanner.Scan() {
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+				t.Fatalf("decode request: %v", err)
+			}
+			switch req.Method {
+			case "initialize":
+				_, err = fmt.Fprintf(os.Stdout, `{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":"2025-11-25","capabilities":{"x-mux":{"sharing":"shared"}},"serverInfo":{"name":"mixed-barrier","version":"1"}}}`+"\n", req.ID)
+			case "tools/list":
+				_, err = fmt.Fprintf(os.Stdout, `{"jsonrpc":"2.0","id":%s,"result":{"tools":[]}}`+"\n", req.ID)
+			}
+			if err != nil {
+				t.Fatalf("write response: %v", err)
+			}
+		}
+		return
+	}
+
+	for _, failFinalAck := range []bool{false, true} {
+		name := "success"
+		if failFinalAck {
+			name = "final-ack-failure"
+		}
+		t.Run(name, func(t *testing.T) {
+			_ = os.Remove(SnapshotPath())
+			t.Cleanup(func() { _ = os.Remove(SnapshotPath()) })
+			tmp := t.TempDir()
+			pidPath := filepath.Join(tmp, "pids")
+			controlPath := filepath.Join(tmp, "control.sock")
+			predecessor, err := New(Config{
+				Name:         "mixed-barrier-predecessor",
+				ControlPath:  controlPath,
+				GracePeriod:  time.Second,
+				IdleTimeout:  time.Minute,
+				SkipSnapshot: true,
+			})
+			if err != nil {
+				t.Fatalf("New predecessor: %v", err)
+			}
+			predecessorStopped := false
+			t.Cleanup(func() {
+				if !predecessorStopped {
+					predecessor.Shutdown()
+				}
+			})
+
+			exe, err := os.Executable()
+			if err != nil {
+				t.Fatalf("os.Executable: %v", err)
+			}
+			args := []string{"-test.run=^TestMixedRestartActivatesCacheOnlyOnlyAfterPredecessorBarrier$"}
+			envA := map[string]string{roleEnv: "upstream", pidsEnv: pidPath, labelEnv: "A"}
+			envB := map[string]string{roleEnv: "upstream", pidsEnv: pidPath, labelEnv: "B"}
+			proc, err := upstream.Start(exe, args, envA, tmp, nil)
+			if err != nil {
+				t.Fatalf("start adopted predecessor: %v", err)
+			}
+			t.Cleanup(func() { _ = proc.AbortDetach() })
+			oldPID, stdinFD, stdoutFD, stderrFD, _, err := proc.DetachWithAuthority()
+			if err != nil {
+				t.Fatalf("detach adopted predecessor: %v", err)
+			}
+			const adoptedID = "aabbccdd-mixed-adopted"
+			const cacheID = "eeff0011-mixed-cache"
+			snapshot := DaemonSnapshot{
+				Version:   mcpsnapshot.SnapshotVersion,
+				Timestamp: time.Now().UTC().Format(time.RFC3339),
+				Owners: []mcpsnapshot.OwnerSnapshot{
+					{ServerID: adoptedID, Command: exe, Args: args, Cwd: tmp, Env: envA, Mode: "global", Classification: classify.ModeShared, CachedInit: "e30=", CachedTools: "e30="},
+					{ServerID: cacheID, Command: exe, Args: args, Cwd: tmp, Env: envB, Mode: "global", Classification: classify.ModeShared, CachedInit: "e30=", CachedTools: "e30="},
+				},
+			}
+			data, err := json.Marshal(snapshot)
+			if err != nil {
+				t.Fatalf("marshal snapshot: %v", err)
+			}
+			if err := os.WriteFile(SnapshotPath(), data, 0o600); err != nil {
+				t.Fatalf("write snapshot: %v", err)
+			}
+			tokenPath := filepath.Join(tmp, "handoff.token")
+			const token = "mixed-barrier-token"
+			if err := os.WriteFile(tokenPath, []byte(token), 0o600); err != nil {
+				t.Fatalf("write token: %v", err)
+			}
+			handoffPath := filepath.Join(tmp, "handoff.sock")
+			handoffDone := make(chan error, 1)
+			go func() {
+				conn, listenErr := listenHandoffUnix(handoffPath, 5*time.Second)
+				if listenErr != nil {
+					handoffDone <- listenErr
+					return
+				}
+				defer conn.Close()
+				_, handoffErr := performHandoff(context.Background(), conn, token, []HandoffUpstream{{
+					ServerID: adoptedID, Command: exe, PID: oldPID,
+					StdinFD: stdinFD, StdoutFD: stdoutFD, StderrFD: stderrFD,
+					commit: proc.CommitDetach, abort: proc.AbortDetach,
+				}})
+				handoffDone <- handoffErr
+			}()
+			deadline := time.Now().Add(2 * time.Second)
+			for {
+				if _, err := os.Stat(handoffPath); err == nil {
+					break
+				}
+				if time.Now().After(deadline) {
+					t.Fatal("handoff listener did not start")
+				}
+				time.Sleep(10 * time.Millisecond)
+			}
+
+			origDelay := snapshotRestartControlBindDelay
+			origInterval := controlBindRetryInterval
+			origAttempts := controlBindMaxAttempts
+			snapshotRestartControlBindDelay = 0
+			controlBindRetryInterval = 10 * time.Millisecond
+			controlBindMaxAttempts = 500
+			t.Cleanup(func() {
+				snapshotRestartControlBindDelay = origDelay
+				controlBindRetryInterval = origInterval
+				controlBindMaxAttempts = origAttempts
+			})
+			origHook := dialHandoffHook
+			if failFinalAck {
+				dialHandoffHook = func(name string, timeout time.Duration) (fdConn, error) {
+					conn, dialErr := dialHandoffUnix(name, timeout)
+					if dialErr != nil {
+						return nil, dialErr
+					}
+					return &failFinalAckUnixConn{fdConn: conn}, nil
+				}
+			}
+			t.Cleanup(func() { dialHandoffHook = origHook })
+			t.Setenv(snapshotRestartEnv, "1")
+			t.Setenv("MCPMUX_HANDOFF_TOKEN_PATH", tokenPath)
+			t.Setenv("MCPMUX_HANDOFF_SOCKET", handoffPath)
+			type newResult struct {
+				d   *Daemon
+				err error
+			}
+			successorDone := make(chan newResult, 1)
+			go func() {
+				d, newErr := New(Config{Name: "mixed-barrier-successor", ControlPath: controlPath, GracePeriod: time.Second, IdleTimeout: time.Minute})
+				successorDone <- newResult{d: d, err: newErr}
+			}()
+			select {
+			case handoffErr := <-handoffDone:
+				if failFinalAck && handoffErr == nil {
+					t.Fatal("handoff succeeded despite injected final ACK failure")
+				}
+				if !failFinalAck && handoffErr != nil {
+					t.Fatalf("handoff failed: %v", handoffErr)
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("handoff did not reach terminal result")
+			}
+			time.Sleep(100 * time.Millisecond)
+			if counts := mixedBarrierPIDCounts(pidPath); counts["A"] != 1 || counts["B"] != 0 {
+				t.Fatalf("pre-barrier starts=%v, want only predecessor A", counts)
+			}
+			select {
+			case early := <-successorDone:
+				if early.d != nil {
+					early.d.Shutdown()
+				}
+				t.Fatalf("successor escaped predecessor barrier early: %v", early.err)
+			default:
+			}
+
+			predecessor.Shutdown()
+			predecessorStopped = true
+			var result newResult
+			select {
+			case result = <-successorDone:
+				if result.err != nil {
+					t.Fatalf("New successor: %v", result.err)
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("successor did not cross predecessor barrier")
+			}
+			successor := result.d
+			t.Cleanup(successor.Shutdown)
+			wantA, wantB := 1, 1
+			if failFinalAck {
+				wantA, wantB = 2, 0
+			}
+			waitForDaemonCondition(t, 3*time.Second, func() bool {
+				counts := mixedBarrierPIDCounts(pidPath)
+				return counts["A"] == wantA && counts["B"] == wantB
+			}, "post-barrier owners did not reach the committed restore outcome")
+			time.Sleep(100 * time.Millisecond)
+			if counts := mixedBarrierPIDCounts(pidPath); counts["A"] != wantA || counts["B"] != wantB {
+				t.Fatalf("post-barrier duplicate starts=%v, want A=%d B=%d", counts, wantA, wantB)
+			}
+			adoptedEntry := successor.Entry(adoptedID)
+			cacheEntry := successor.Entry(cacheID)
+			if adoptedEntry == nil {
+				t.Fatal("adopted/fallback entry missing")
+			}
+			if failFinalAck {
+				if adoptedEntry.RestoreSource != "snapshot_fallback" || cacheEntry != nil {
+					t.Fatalf("failed commit outcome adopted=%q cache=%v, want sole adopted fallback", adoptedEntry.RestoreSource, cacheEntry)
+				}
+			} else if adoptedEntry.RestoreSource != "snapshot_handoff" || cacheEntry == nil || cacheEntry.RestoreSource != "snapshot_fallback" {
+				t.Fatalf("committed outcome adopted=%q cache=%v", adoptedEntry.RestoreSource, cacheEntry)
+			}
+		})
+	}
+}
+
+func mixedBarrierPIDCounts(path string) map[string]int {
+	data, _ := os.ReadFile(path)
+	counts := make(map[string]int)
+	fields := strings.Fields(string(data))
+	for i := 0; i+1 < len(fields); i += 2 {
+		counts[fields[i]]++
+	}
+	return counts
+}

--- a/muxcore/daemon/handoff_final_ack_linux_test.go
+++ b/muxcore/daemon/handoff_final_ack_linux_test.go
@@ -122,8 +122,8 @@ func TestHandoffUnix_FinalAckDisconnectClosesTransferredFDsAndStartsOneFallback(
 		if entry.RestoreSource != "snapshot_fallback" {
 			t.Fatalf("restore_source=%q, want snapshot_fallback after final ACK failure; logs:\n%s", entry.RestoreSource, logs.String())
 		}
-		if !entry.Owner.CacheReady() {
-			t.Fatalf("fallback owner lost cached discovery state; logs:\n%s", logs.String())
+		if entry.Owner.CacheReady() {
+			t.Fatalf("fallback owner exposed stale cached discovery after final ACK failure; logs:\n%s", logs.String())
 		}
 		if state := entry.Owner.MaterializationState(); state == owner.MaterializationCacheOnly {
 			t.Fatalf("fallback materialization state=%s after predecessor barrier, want eager restore", state)

--- a/muxcore/daemon/handoff_final_ack_linux_test.go
+++ b/muxcore/daemon/handoff_final_ack_linux_test.go
@@ -108,7 +108,11 @@ func TestHandoffUnix_FinalAckDisconnectClosesTransferredFDsAndStartsOneFallback(
 		if restored := d.loadSnapshot(); restored != 1 {
 			t.Fatalf("loadSnapshot() restored %d owners, want 1", restored)
 		}
-		if activated := d.activateRestartStaging(); activated != 1 {
+		activated, err := d.activateRestartStaging()
+		if err != nil {
+			t.Fatalf("activateRestartStaging() error: %v; logs:\n%s", err, logs.String())
+		}
+		if activated != 1 {
 			t.Fatalf("activateRestartStaging()=%d, want 1; logs:\n%s", activated, logs.String())
 		}
 		entry := d.Entry("aabbccdd-final-ack-rollback-unix")

--- a/muxcore/daemon/handoff_integration_windows_test.go
+++ b/muxcore/daemon/handoff_integration_windows_test.go
@@ -3,6 +3,7 @@
 package daemon
 
 import (
+	"bufio"
 	"context"
 	"crypto/rand"
 	"encoding/base64"
@@ -22,6 +23,8 @@ import (
 	"unsafe"
 
 	"github.com/thebtf/mcp-mux/muxcore/classify"
+	"github.com/thebtf/mcp-mux/muxcore/ipc"
+	"github.com/thebtf/mcp-mux/muxcore/owner"
 	mcpsnapshot "github.com/thebtf/mcp-mux/muxcore/snapshot"
 	"github.com/thebtf/mcp-mux/muxcore/upstream"
 	"golang.org/x/sys/windows"
@@ -491,6 +494,9 @@ func TestLoadSnapshot_FinalAckWriteFailureRollsBackAdoptedOwner(t *testing.T) {
 		if restored := d.loadSnapshot(); restored != 1 {
 			t.Fatalf("loadSnapshot() restored %d owners, want 1", restored)
 		}
+		if activated := d.activateRestartStaging(); activated != 1 {
+			t.Fatalf("activateRestartStaging()=%d, want 1; logs:\n%s", activated, logs.String())
+		}
 		entry := d.Entry("aabbccdd-final-ack-rollback")
 		if entry == nil || entry.Owner == nil {
 			t.Fatalf("fallback owner missing after final ACK failure; logs:\n%s", logs.String())
@@ -499,33 +505,30 @@ func TestLoadSnapshot_FinalAckWriteFailureRollsBackAdoptedOwner(t *testing.T) {
 			t.Fatalf("restore_source=%q, want snapshot_fallback after final ACK failure; logs:\n%s", entry.RestoreSource, logs.String())
 		}
 
-		deadline := time.Now().Add(5 * time.Second)
-		newPID := 0
-		for time.Now().Before(deadline) {
+		if !entry.Owner.CacheReady() {
+			t.Fatalf("fallback owner lost cached discovery state; logs:\n%s", logs.String())
+		}
+		if state := entry.Owner.MaterializationState(); state == owner.MaterializationCacheOnly {
+			t.Fatalf("fallback materialization state=%s after predecessor barrier, want eager restore", state)
+		}
+		var newPIDs []int
+		waitForDaemonCondition(t, 2*time.Second, func() bool {
 			pidData, _ := os.ReadFile(os.Getenv("MCPMUX_TEST_FINAL_ACK_ROLLBACK_PIDS"))
+			seen := make(map[int]struct{})
 			for _, field := range strings.Fields(string(pidData)) {
 				pid, _ := strconv.Atoi(field)
 				if pid > 0 && pid != oldPID {
-					newPID = pid
-					break
+					seen[pid] = struct{}{}
 				}
 			}
-			if newPID > 0 {
-				break
+			newPIDs = newPIDs[:0]
+			for pid := range seen {
+				newPIDs = append(newPIDs, pid)
 			}
-			time.Sleep(10 * time.Millisecond)
-		}
-		if newPID <= 0 || newPID == oldPID {
-			t.Fatalf("fallback upstream pid=%d, want fresh process distinct from %d; logs:\n%s", newPID, oldPID, logs.String())
-		}
-
-		processHandle, err := windows.OpenProcess(windows.SYNCHRONIZE, false, uint32(newPID))
-		if err != nil {
-			t.Fatalf("OpenProcess fallback pid %d: %v", newPID, err)
-		}
-		defer windows.CloseHandle(processHandle)
-		if status, err := windows.WaitForSingleObject(processHandle, 0); err != nil || status != uint32(windows.WAIT_TIMEOUT) {
-			t.Fatalf("fallback process is not alive: WaitForSingleObject=(%d, %v)", status, err)
+			return len(newPIDs) == 1
+		}, "rollback fallback did not start exactly one fresh upstream generation")
+		if pid, _ := entry.Owner.Status()["upstream_pid"].(int); pid != newPIDs[0] {
+			t.Fatalf("fallback upstream pid=%d, want sole fresh pid %d", pid, newPIDs[0])
 		}
 
 		if failedConn == nil || len(failedConn.received) != 4 {
@@ -667,5 +670,246 @@ func TestLoadSnapshot_FinalAckWriteFailureRollsBackAdoptedOwner(t *testing.T) {
 	}
 	if err := cmd.Wait(); err != nil {
 		t.Fatalf("successor rollback failed: %v", err)
+	}
+}
+
+func TestHandoffIntegration_MaterializingOwnerTransfersSingleReadyGeneration(t *testing.T) {
+	const roleEnv = "MCPMUX_TEST_MATERIALIZING_HANDOFF_ROLE"
+	const pipeEnv = "MCPMUX_TEST_MATERIALIZING_HANDOFF_PIPE"
+	const snapshotEnv = "MCPMUX_TEST_MATERIALIZING_HANDOFF_SNAPSHOT"
+	const ipcEnv = "MCPMUX_TEST_MATERIALIZING_HANDOFF_IPC"
+	const committedEnv = "MCPMUX_TEST_MATERIALIZING_HANDOFF_COMMITTED"
+	const pidPathEnv = "MCPMUX_TEST_MATERIALIZING_HANDOFF_PIDS"
+	switch os.Getenv(roleEnv) {
+	case "upstream":
+		pidFile, err := os.OpenFile(os.Getenv(pidPathEnv), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+		if err != nil {
+			t.Fatalf("open pid file: %v", err)
+		}
+		_, _ = fmt.Fprintln(pidFile, os.Getpid())
+		_ = pidFile.Close()
+		scanner := bufio.NewScanner(os.Stdin)
+		for scanner.Scan() {
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+				t.Fatalf("decode upstream request: %v", err)
+			}
+			switch req.Method {
+			case "initialize":
+				_, err = fmt.Fprintf(os.Stdout, `{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":"2025-11-25","capabilities":{"x-mux":{"sharing":"shared"}},"serverInfo":{"name":"materializing-handoff","version":"1"}}}`+"\n", req.ID)
+			case "tools/list":
+				_, err = fmt.Fprintf(os.Stdout, `{"jsonrpc":"2.0","id":%s,"result":{"tools":[{"name":"handoff-tool"}]}}`+"\n", req.ID)
+			case "ping":
+				_, err = fmt.Fprintf(os.Stdout, `{"jsonrpc":"2.0","id":%s,"result":{"pid":%d}}`+"\n", req.ID, os.Getpid())
+			}
+			if err != nil {
+				t.Fatalf("write upstream response: %v", err)
+			}
+		}
+		return
+	case "successor":
+		rawSnapshot, err := base64.StdEncoding.DecodeString(os.Getenv(snapshotEnv))
+		if err != nil {
+			t.Fatalf("decode snapshot: %v", err)
+		}
+		var snapshot mcpsnapshot.OwnerSnapshot
+		if err := json.Unmarshal(rawSnapshot, &snapshot); err != nil {
+			t.Fatalf("unmarshal snapshot: %v", err)
+		}
+		conn, err := dialHandoffWindows(os.Getenv(pipeEnv), 5*time.Second)
+		if err != nil {
+			t.Fatalf("successor dial: %v", err)
+		}
+		receipt, err := prepareHandoffReceive(context.Background(), conn, "materializing-token")
+		if err != nil {
+			t.Fatalf("successor receive: %v", err)
+		}
+		received, ok := receipt.take(snapshot.ServerID)
+		if !ok {
+			t.Fatal("successor did not receive materializing owner")
+		}
+		successor, err := owner.NewOwnerFromHandoff(owner.OwnerConfig{
+			Command:              snapshot.Command,
+			Args:                 snapshot.Args,
+			Cwd:                  snapshot.Cwd,
+			Env:                  snapshot.Env,
+			IPCPath:              os.Getenv(ipcEnv),
+			ServerID:             snapshot.ServerID,
+			CachedClassification: snapshot.Classification,
+			AdoptedSnapshot:      &snapshot,
+		}, owner.HandoffPayload{
+			ServerID:    snapshot.ServerID,
+			PID:         received.PID,
+			StdinFD:     received.StdinFD,
+			StdoutFD:    received.StdoutFD,
+			StderrFD:    received.StderrFD,
+			AuthorityFD: received.AuthorityFD,
+			Command:     snapshot.Command,
+			Args:        snapshot.Args,
+			Cwd:         snapshot.Cwd,
+		})
+		if err != nil {
+			_ = receipt.finalize(nil)
+			t.Fatalf("successor adoption: %v", err)
+		}
+		defer successor.Shutdown()
+		if err := receipt.finalize([]string{snapshot.ServerID}); err != nil {
+			t.Fatalf("successor finalize: %v", err)
+		}
+		deadline := time.Now().Add(5 * time.Second)
+		for {
+			if _, err := os.Stat(os.Getenv(committedEnv)); err == nil {
+				break
+			}
+			if time.Now().After(deadline) {
+				t.Fatal("predecessor did not publish commit marker")
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		if successor.MaterializationState() != owner.MaterializationReady || successor.Status()["upstream_pid"] != received.PID {
+			t.Fatalf("successor status=%+v", successor.Status())
+		}
+		ownerConn, err := ipc.Dial(os.Getenv(ipcEnv))
+		if err != nil {
+			t.Fatalf("dial adopted owner: %v", err)
+		}
+		defer ownerConn.Close()
+		if _, err := fmt.Fprintln(ownerConn, `{"jsonrpc":"2.0","id":91,"method":"ping","params":{}}`); err != nil {
+			t.Fatalf("write adopted ping: %v", err)
+		}
+		responses := bufio.NewScanner(ownerConn)
+		for responses.Scan() {
+			if strings.Contains(responses.Text(), `"id":91`) {
+				if !strings.Contains(responses.Text(), `"pid":`) {
+					t.Fatalf("adopted ping response=%s", responses.Text())
+				}
+				return
+			}
+		}
+		t.Fatalf("adopted response stream ended: %v", responses.Err())
+	}
+
+	tmp := t.TempDir()
+	pidPath := filepath.Join(tmp, "pids")
+	committedPath := filepath.Join(tmp, "committed")
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	publishEntered := make(chan struct{})
+	releasePublish := make(chan struct{})
+	predecessor, err := owner.NewOwner(owner.OwnerConfig{
+		Command:  exe,
+		Args:     []string{"-test.run=^TestHandoffIntegration_MaterializingOwnerTransfersSingleReadyGeneration$"},
+		Env:      map[string]string{roleEnv: "upstream", pidPathEnv: pidPath},
+		Cwd:      t.TempDir(),
+		IPCPath:  shortSocketPath(t, "materializing-predecessor.sock"),
+		ServerID: "materializing-handoff-owner",
+		OnCacheReady: func(*owner.Owner, owner.OwnerSnapshot) bool {
+			close(publishEntered)
+			<-releasePublish
+			return true
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewOwner predecessor: %v", err)
+	}
+	predecessorClosed := false
+	t.Cleanup(func() {
+		if !predecessorClosed {
+			predecessor.Shutdown()
+		}
+	})
+	select {
+	case <-publishEntered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("predecessor did not reach materializing publish barrier")
+	}
+	type handoffResult struct {
+		payload owner.HandoffPayload
+		err     error
+	}
+	handoffDone := make(chan handoffResult, 1)
+	go func() {
+		payload, handoffErr := predecessor.ShutdownForHandoff()
+		handoffDone <- handoffResult{payload: payload, err: handoffErr}
+	}()
+	select {
+	case result := <-handoffDone:
+		t.Fatalf("handoff detached before cache/template commit: %+v", result)
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(releasePublish)
+	var result handoffResult
+	select {
+	case result = <-handoffDone:
+		if result.err != nil {
+			t.Fatalf("ShutdownForHandoff: %v", result.err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("handoff did not complete after coherent materialization")
+	}
+	predecessorClosed = true
+	snapshot := predecessor.ExportSnapshot()
+	snapshot.ServerID = result.payload.ServerID
+	snapshotData, err := json.Marshal(snapshot)
+	if err != nil {
+		t.Fatalf("marshal snapshot: %v", err)
+	}
+	name := randomPipeName(t)
+	connCh := make(chan fdConn, 1)
+	go func() {
+		conn, _ := listenHandoffWindows(name, 5*time.Second)
+		connCh <- conn
+	}()
+	successorIPC := shortSocketPath(t, "materializing-successor.sock")
+	cmd := exec.Command(exe, "-test.run=^TestHandoffIntegration_MaterializingOwnerTransfersSingleReadyGeneration$")
+	cmd.Env = append(os.Environ(),
+		roleEnv+"=successor",
+		pipeEnv+"="+name,
+		snapshotEnv+"="+base64.StdEncoding.EncodeToString(snapshotData),
+		ipcEnv+"="+successorIPC,
+		committedEnv+"="+committedPath,
+	)
+	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start successor: %v", err)
+	}
+	t.Cleanup(func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+	})
+	conn := <-connCh
+	if conn == nil {
+		t.Fatal("successor did not connect to handoff pipe")
+	}
+	defer conn.Close()
+	_, handoffErr := performHandoff(context.Background(), conn, "materializing-token", []HandoffUpstream{{
+		ServerID:    result.payload.ServerID,
+		Command:     result.payload.Command,
+		PID:         result.payload.PID,
+		StdinFD:     result.payload.StdinFD,
+		StdoutFD:    result.payload.StdoutFD,
+		StderrFD:    result.payload.StderrFD,
+		AuthorityFD: result.payload.AuthorityFD,
+		commit:      result.payload.Commit,
+		abort:       result.payload.Abort,
+	}})
+	if handoffErr != nil {
+		t.Fatalf("performHandoff: %v", handoffErr)
+	}
+	if err := os.WriteFile(committedPath, nil, 0o600); err != nil {
+		t.Fatalf("write commit marker: %v", err)
+	}
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("successor failed: %v", err)
+	}
+	pidData, _ := os.ReadFile(pidPath)
+	if got := len(strings.Fields(string(pidData))); got != 1 {
+		t.Fatalf("upstream starts=%d, want one transferred generation; data=%q", got, pidData)
 	}
 }

--- a/muxcore/daemon/handoff_integration_windows_test.go
+++ b/muxcore/daemon/handoff_integration_windows_test.go
@@ -494,7 +494,11 @@ func TestLoadSnapshot_FinalAckWriteFailureRollsBackAdoptedOwner(t *testing.T) {
 		if restored := d.loadSnapshot(); restored != 1 {
 			t.Fatalf("loadSnapshot() restored %d owners, want 1", restored)
 		}
-		if activated := d.activateRestartStaging(); activated != 1 {
+		activated, err := d.activateRestartStaging()
+		if err != nil {
+			t.Fatalf("activateRestartStaging() error: %v; logs:\n%s", err, logs.String())
+		}
+		if activated != 1 {
 			t.Fatalf("activateRestartStaging()=%d, want 1; logs:\n%s", activated, logs.String())
 		}
 		entry := d.Entry("aabbccdd-final-ack-rollback")
@@ -505,8 +509,8 @@ func TestLoadSnapshot_FinalAckWriteFailureRollsBackAdoptedOwner(t *testing.T) {
 			t.Fatalf("restore_source=%q, want snapshot_fallback after final ACK failure; logs:\n%s", entry.RestoreSource, logs.String())
 		}
 
-		if !entry.Owner.CacheReady() {
-			t.Fatalf("fallback owner lost cached discovery state; logs:\n%s", logs.String())
+		if entry.Owner.CacheReady() {
+			t.Fatalf("fallback owner exposed stale cached discovery after final ACK failure; logs:\n%s", logs.String())
 		}
 		if state := entry.Owner.MaterializationState(); state == owner.MaterializationCacheOnly {
 			t.Fatalf("fallback materialization state=%s after predecessor barrier, want eager restore", state)

--- a/muxcore/daemon/handoff_integration_windows_test.go
+++ b/muxcore/daemon/handoff_integration_windows_test.go
@@ -727,7 +727,9 @@ func TestHandoffIntegration_MaterializingOwnerTransfersSingleReadyGeneration(t *
 		if err != nil {
 			t.Fatalf("successor dial: %v", err)
 		}
-		receipt, err := prepareHandoffReceive(context.Background(), conn, "materializing-token")
+		receiveCtx, cancelReceive := context.WithTimeout(context.Background(), 10*time.Second)
+		receipt, err := prepareHandoffReceive(receiveCtx, conn, "materializing-token")
+		cancelReceive()
 		if err != nil {
 			t.Fatalf("successor receive: %v", err)
 		}
@@ -856,6 +858,12 @@ func TestHandoffIntegration_MaterializingOwnerTransfersSingleReadyGeneration(t *
 	case <-time.After(5 * time.Second):
 		t.Fatal("handoff did not complete after coherent materialization")
 	}
+	handoffSettled := false
+	t.Cleanup(func() {
+		if !handoffSettled {
+			_ = result.payload.Abort()
+		}
+	})
 	predecessorClosed = true
 	snapshot := predecessor.ExportSnapshot()
 	snapshot.ServerID = result.payload.ServerID
@@ -892,7 +900,8 @@ func TestHandoffIntegration_MaterializingOwnerTransfersSingleReadyGeneration(t *
 		t.Fatal("successor did not connect to handoff pipe")
 	}
 	defer conn.Close()
-	_, handoffErr := performHandoff(context.Background(), conn, "materializing-token", []HandoffUpstream{{
+	handoffCtx, cancelHandoff := context.WithTimeout(context.Background(), 10*time.Second)
+	_, handoffErr := performHandoff(handoffCtx, conn, "materializing-token", []HandoffUpstream{{
 		ServerID:    result.payload.ServerID,
 		Command:     result.payload.Command,
 		PID:         result.payload.PID,
@@ -903,9 +912,11 @@ func TestHandoffIntegration_MaterializingOwnerTransfersSingleReadyGeneration(t *
 		commit:      result.payload.Commit,
 		abort:       result.payload.Abort,
 	}})
+	cancelHandoff()
 	if handoffErr != nil {
 		t.Fatalf("performHandoff: %v", handoffErr)
 	}
+	handoffSettled = true
 	if err := os.WriteFile(committedPath, nil, 0o600); err != nil {
 		t.Fatalf("write commit marker: %v", err)
 	}

--- a/muxcore/daemon/handoff_proto.go
+++ b/muxcore/daemon/handoff_proto.go
@@ -6,14 +6,13 @@ import (
 )
 
 // HandoffProtocolVersion is the current version of the handoff control protocol.
-// The protocol_version field is mandatory in every message; a successor daemon
-// that receives an unknown version must reject the handoff and fall back to
-// the legacy shutdown-and-respawn path (FR-6, FR-8).
+// The protocol_version field is mandatory in every message. Unknown versions
+// are rejected during Hello before any owner detach or session quiesce, so the
+// predecessor releases its restart pins and remains serving.
 // Version 2 adds an explicit optional tree-authority handle to FdTransferMsg
 // and moves the commit boundary to HandoffAckMsg.Accepted/Aborted. Version 1
-// peers are intentionally rejected during Hello: an old predecessor cannot
-// transfer the Windows Job handle, so the safe migration is one bounded
-// shutdown-and-respawn rather than an authority-less live handoff.
+// peers cannot transfer the Windows Job handle and therefore cannot authorize
+// an authority-less live handoff.
 const HandoffProtocolVersion = 2
 
 // MsgType identifies the kind of handoff control message.

--- a/muxcore/daemon/handoff_socket_unix.go
+++ b/muxcore/daemon/handoff_socket_unix.go
@@ -3,6 +3,9 @@
 package daemon
 
 import (
+	"crypto/rand"
+	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"syscall"
@@ -13,7 +16,11 @@ import (
 // The socket is created in baseDir (typically os.TempDir()) so it is accessible
 // to both old and new daemon processes running as the same user.
 func handoffSocketPath(baseDir string) string {
-	return filepath.Join(baseDir, "mcp-mux-handoff.sock")
+	var suffix [8]byte
+	if _, err := rand.Read(suffix[:]); err == nil {
+		return filepath.Join(baseDir, fmt.Sprintf("mcp-mux-handoff-%x.sock", suffix))
+	}
+	return filepath.Join(baseDir, fmt.Sprintf("mcp-mux-handoff-%d-%d.sock", os.Getpid(), time.Now().UnixNano()))
 }
 
 // listenHandoff accepts one connection on the handoff Unix domain socket.

--- a/muxcore/daemon/handoff_test.go
+++ b/muxcore/daemon/handoff_test.go
@@ -204,10 +204,10 @@ func TestRetireOldOwnerSocketsRemovesPathsAndCounts(t *testing.T) {
 func TestSuccessorExecutableUsesActiveEnginePointer(t *testing.T) {
 	dir := t.TempDir()
 	enginePath := filepath.Join(dir, "versions", "abc123", "mcp-mux-engine.exe")
-	if err := os.MkdirAll(filepath.Dir(enginePath), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(enginePath), 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
-	if err := os.WriteFile(enginePath, []byte("engine"), 0755); err != nil {
+	if err := os.WriteFile(enginePath, []byte("engine"), 0o755); err != nil {
 		t.Fatalf("WriteFile engine: %v", err)
 	}
 	pointerPath := filepath.Join(dir, "active.txt")
@@ -215,7 +215,7 @@ func TestSuccessorExecutableUsesActiveEnginePointer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Rel: %v", err)
 	}
-	if err := os.WriteFile(pointerPath, []byte(rel+"\n"), 0644); err != nil {
+	if err := os.WriteFile(pointerPath, []byte(rel+"\n"), 0o644); err != nil {
 		t.Fatalf("WriteFile pointer: %v", err)
 	}
 
@@ -462,25 +462,35 @@ func TestPerformHandoffFinalAckFailureAbortsEveryPreparedTree(t *testing.T) {
 	}
 }
 
-func TestPerformHandoffVersionSkewRejectsBeforeLeaseSettlement(t *testing.T) {
-	var settled int
-	conn := &scriptedHandoffConn{
-		schema: handoffHandleSchema{count: 3},
-		reads: []scriptedHandoffRead{{
-			msg: HelloMsg{Type: MsgHello, ProtocolVersion: HandoffProtocolVersion - 1, Token: "secret"},
-		}},
+func TestPerformHandoffHelloRejectsBeforeLeaseSettlement(t *testing.T) {
+	tests := []struct {
+		name  string
+		hello HelloMsg
+		want  error
+	}{
+		{name: "version skew", hello: HelloMsg{Type: MsgHello, ProtocolVersion: HandoffProtocolVersion - 1, Token: "secret"}, want: ErrProtocolVersionMismatch},
+		{name: "token mismatch", hello: HelloMsg{Type: MsgHello, ProtocolVersion: HandoffProtocolVersion, Token: "wrong"}, want: ErrTokenMismatch},
 	}
-	upstreams := []HandoffUpstream{{
-		ServerID: "s1", PID: 1, StdinFD: 11, StdoutFD: 12, StderrFD: 13,
-		commit: func() error { settled++; return nil },
-		abort:  func() error { settled++; return nil },
-	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var settled int
+			conn := &scriptedHandoffConn{
+				schema: handoffHandleSchema{count: 3},
+				reads:  []scriptedHandoffRead{{msg: tt.hello}},
+			}
+			upstreams := []HandoffUpstream{{
+				ServerID: "s1", PID: 1, StdinFD: 11, StdoutFD: 12, StderrFD: 13,
+				commit: func() error { settled++; return nil },
+				abort:  func() error { settled++; return nil },
+			}}
 
-	if _, err := performHandoff(context.Background(), conn, "secret", upstreams); !errors.Is(err, ErrProtocolVersionMismatch) {
-		t.Fatalf("performHandoff error=%v, want ErrProtocolVersionMismatch", err)
-	}
-	if settled != 0 {
-		t.Fatalf("lease settled %d times before Hello version acceptance", settled)
+			if _, err := performHandoff(context.Background(), conn, "secret", upstreams); !errors.Is(err, tt.want) {
+				t.Fatalf("performHandoff error=%v, want %v", err, tt.want)
+			}
+			if settled != 0 {
+				t.Fatalf("lease settled %d times before Hello acceptance", settled)
+			}
+		})
 	}
 }
 

--- a/muxcore/daemon/handoff_unix.go
+++ b/muxcore/daemon/handoff_unix.go
@@ -339,15 +339,41 @@ func listenHandoffUnix(socketPath string, acceptTimeout time.Duration) (fdConn, 
 // dialHandoffUnix connects to a Unix domain socket previously bound by
 // listenHandoffUnix. Caller owns the returned conn's lifetime.
 func dialHandoffUnix(socketPath string, timeout time.Duration) (fdConn, error) {
-	d := net.Dialer{Timeout: timeout}
-	conn, err := d.Dial("unix", socketPath)
-	if err != nil {
-		return nil, fmt.Errorf("handoff dial: %w", err)
+	deadline := time.Now().Add(timeout)
+	for {
+		attemptTimeout := timeout
+		if timeout > 0 {
+			attemptTimeout = time.Until(deadline)
+			if attemptTimeout <= 0 {
+				return nil, fmt.Errorf("handoff dial: timeout waiting for %s", socketPath)
+			}
+		}
+
+		d := net.Dialer{Timeout: attemptTimeout}
+		conn, err := d.Dial("unix", socketPath)
+		if err == nil {
+			uc, ok := conn.(*net.UnixConn)
+			if !ok {
+				_ = conn.Close()
+				return nil, fmt.Errorf("handoff dial: not *net.UnixConn")
+			}
+			return newUnixFDConn(uc), nil
+		}
+		// attemptHandoff starts the blocking listener in a goroutine. Unix dial
+		// can observe the path before bind (ENOENT) or during rebinding
+		// (ECONNREFUSED), so wait within the caller's existing handoff budget.
+		if timeout <= 0 || (!errors.Is(err, syscall.ENOENT) && !errors.Is(err, syscall.ECONNREFUSED)) {
+			return nil, fmt.Errorf("handoff dial: %w", err)
+		}
+
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return nil, fmt.Errorf("handoff dial: %w", err)
+		}
+		delay := 5 * time.Millisecond
+		if remaining < delay {
+			delay = remaining
+		}
+		time.Sleep(delay)
 	}
-	uc, ok := conn.(*net.UnixConn)
-	if !ok {
-		_ = conn.Close()
-		return nil, fmt.Errorf("handoff dial: not *net.UnixConn")
-	}
-	return newUnixFDConn(uc), nil
 }

--- a/muxcore/daemon/handoff_unix_test.go
+++ b/muxcore/daemon/handoff_unix_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"syscall"
 	"testing"
+	"time"
 )
 
 // socketpairUnixConn creates a connected pair of *unixFDConn using the kernel
@@ -196,5 +197,47 @@ func TestRecvFDs_TripleRoundtrip(t *testing.T) {
 	// Clean up the duplicated FDs on the receiver side.
 	for _, f := range recv {
 		_ = syscall.Close(int(f))
+	}
+}
+
+func TestDialHandoffUnixWaitsForLateListener(t *testing.T) {
+	socketPath := shortSocketPath(t, "late-handoff.sock")
+	listenerResult := make(chan error, 1)
+	go func() {
+		time.Sleep(25 * time.Millisecond)
+		ln, err := net.Listen("unix", socketPath)
+		if err != nil {
+			listenerResult <- err
+			return
+		}
+		defer ln.Close()
+		if unixListener, ok := ln.(*net.UnixListener); ok {
+			_ = unixListener.SetDeadline(time.Now().Add(100 * time.Millisecond))
+		}
+		conn, err := ln.Accept()
+		if err == nil {
+			err = conn.Close()
+		}
+		listenerResult <- err
+	}()
+
+	conn, dialErr := dialHandoffUnix(socketPath, 500*time.Millisecond)
+	if dialErr == nil {
+		dialErr = conn.Close()
+	}
+	listenerErr := <-listenerResult
+	if dialErr != nil {
+		t.Fatalf("dialHandoffUnix before late listener: %v", dialErr)
+	}
+	if listenerErr != nil {
+		t.Fatalf("late listener: %v", listenerErr)
+	}
+}
+
+func TestHandoffSocketPathIsUnique(t *testing.T) {
+	first := handoffSocketPath(os.TempDir())
+	second := handoffSocketPath(os.TempDir())
+	if first == second {
+		t.Fatalf("handoff socket path reused across attempts: %s", first)
 	}
 }

--- a/muxcore/daemon/handoff_windows.go
+++ b/muxcore/daemon/handoff_windows.go
@@ -75,17 +75,35 @@ func listenHandoffPipe(name string) (net.Listener, error) {
 	return ln, nil
 }
 
+const handoffPipeDialRetryDelay = 10 * time.Millisecond
+
 // dialHandoffPipe connects to a named pipe created by listenHandoffPipe.
 // `name` must match the listener. `timeout` is applied to the dial attempt.
 func dialHandoffPipe(name string, timeout time.Duration) (net.Conn, error) {
+	return dialHandoffPipeWith(name, timeout, winio.DialPipeContext)
+}
+
+func dialHandoffPipeWith(name string, timeout time.Duration, dial func(context.Context, string) (net.Conn, error)) (net.Conn, error) {
 	path := handoffPipePrefix + name
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
-	conn, err := winio.DialPipeContext(ctx, path)
-	if err != nil {
-		return nil, fmt.Errorf("handoff: dial named pipe %s: %w", path, err)
+	for {
+		conn, err := dial(ctx, path)
+		if err == nil {
+			return conn, nil
+		}
+		if !errors.Is(err, windows.ERROR_FILE_NOT_FOUND) && !errors.Is(err, windows.ERROR_PIPE_BUSY) {
+			return nil, fmt.Errorf("handoff: dial named pipe %s: %w", path, err)
+		}
+
+		timer := time.NewTimer(handoffPipeDialRetryDelay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, fmt.Errorf("handoff: dial named pipe %s: %w", path, ctx.Err())
+		case <-timer.C:
+		}
 	}
-	return conn, nil
 }
 
 // msgHandleBatch is the MsgType for windowsHandleBatch wire messages.

--- a/muxcore/daemon/handoff_windows_test.go
+++ b/muxcore/daemon/handoff_windows_test.go
@@ -3,14 +3,19 @@
 package daemon
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"net"
 	"os"
 	"strings"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/Microsoft/go-winio"
+	"golang.org/x/sys/windows"
 )
 
 func randomPipeName(t *testing.T) string {
@@ -77,6 +82,119 @@ func TestHandoffPipe_ListenDialRoundtrip(t *testing.T) {
 		t.Errorf("unexpected resp: %v", resp)
 	}
 	wg.Wait()
+}
+
+// TestHandoffPipe_DialBeforeDelayedBind proves the client can start before the
+// successor has bound its pipe. The first real dial must observe FILE_NOT_FOUND;
+// only then does the test bind the listener and permit the retry.
+func TestHandoffPipe_DialBeforeDelayedBind(t *testing.T) {
+	name := randomPipeName(t)
+	firstAttempt := make(chan error, 1)
+	allowRetry := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseRetry := func() {
+		releaseOnce.Do(func() { close(allowRetry) })
+	}
+	defer releaseRetry()
+
+	attempts := 0
+	dial := func(ctx context.Context, path string) (net.Conn, error) {
+		conn, err := winio.DialPipeContext(ctx, path)
+		attempts++
+		if attempts == 1 {
+			firstAttempt <- err
+			<-allowRetry
+		}
+		return conn, err
+	}
+	type dialResult struct {
+		conn net.Conn
+		err  error
+	}
+	dialDone := make(chan dialResult, 1)
+	go func() {
+		conn, err := dialHandoffPipeWith(name, 2*time.Second, dial)
+		dialDone <- dialResult{conn: conn, err: err}
+	}()
+
+	select {
+	case err := <-firstAttempt:
+		if !errors.Is(err, windows.ERROR_FILE_NOT_FOUND) {
+			t.Fatalf("first dial error = %v, want ERROR_FILE_NOT_FOUND", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("first dial attempt did not complete")
+	}
+
+	ln, err := listenHandoffPipe(name)
+	if err != nil {
+		t.Fatalf("listenHandoffPipe: %v", err)
+	}
+	defer ln.Close()
+	acceptDone := make(chan dialResult, 1)
+	go func() {
+		conn, err := ln.Accept()
+		acceptDone <- dialResult{conn: conn, err: err}
+	}()
+	releaseRetry()
+
+	var client dialResult
+	select {
+	case client = <-dialDone:
+		if client.err != nil {
+			t.Fatalf("dial after delayed bind: %v", client.err)
+		}
+		defer client.conn.Close()
+	case <-time.After(3 * time.Second):
+		t.Fatal("dial did not complete after delayed bind")
+	}
+	select {
+	case server := <-acceptDone:
+		if server.err != nil {
+			t.Fatalf("accept after delayed bind: %v", server.err)
+		}
+		server.conn.Close()
+	case <-time.After(3 * time.Second):
+		t.Fatal("accept did not complete after delayed bind")
+	}
+	if attempts < 2 {
+		t.Fatalf("dial attempts = %d, want at least 2", attempts)
+	}
+}
+
+func TestHandoffPipe_DialRetriesPipeBusy(t *testing.T) {
+	client, server := net.Pipe()
+	defer server.Close()
+
+	attempts := 0
+	conn, err := dialHandoffPipeWith(randomPipeName(t), time.Second, func(context.Context, string) (net.Conn, error) {
+		attempts++
+		if attempts == 1 {
+			return nil, windows.ERROR_PIPE_BUSY
+		}
+		return client, nil
+	})
+	if err != nil {
+		t.Fatalf("dial after ERROR_PIPE_BUSY: %v", err)
+	}
+	defer conn.Close()
+	if attempts != 2 {
+		t.Fatalf("dial attempts = %d, want 2", attempts)
+	}
+}
+
+func TestHandoffPipe_DialPermanentErrorFailsFast(t *testing.T) {
+	attempts := 0
+	_, err := dialHandoffPipeWith(randomPipeName(t), 100*time.Millisecond, func(context.Context, string) (net.Conn, error) {
+		attempts++
+		return nil, windows.ERROR_ACCESS_DENIED
+	})
+	if !errors.Is(err, windows.ERROR_ACCESS_DENIED) {
+		t.Fatalf("dial error = %v, want ERROR_ACCESS_DENIED", err)
+	}
+	if attempts != 1 {
+		t.Fatalf("dial attempts = %d, want 1", attempts)
+	}
 }
 
 // TestHandoffPipe_DialMissingListener verifies that dial fails cleanly when

--- a/muxcore/daemon/materialization_test.go
+++ b/muxcore/daemon/materialization_test.go
@@ -848,6 +848,99 @@ func TestMaterializationFreshSharedTemplateKeepsLiveOwnerIsolated(t *testing.T) 
 	}
 }
 
+func TestMaterializingOwnerAdmissionFreezeDoesNotTriggerReplacement(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		mode string
+	}{
+		{name: "exact-global", mode: "global"},
+		{name: "legacy-cwd-shared-scan", mode: "cwd"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d := testDaemon(t)
+			var starts atomic.Int32
+			d.handlerFunc = func(_ context.Context, stdin io.Reader, stdout io.Writer) error {
+				starts.Add(1)
+				scanner := bufio.NewScanner(stdin)
+				for scanner.Scan() {
+					var req struct {
+						ID     json.RawMessage `json:"id"`
+						Method string          `json:"method"`
+					}
+					if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+						return err
+					}
+					switch req.Method {
+					case "initialize":
+						if err := writeDaemonResponse(stdout, req.ID, `{"protocolVersion":"2025-11-25","capabilities":{"x-mux":{"sharing":"shared"}},"serverInfo":{"name":"admission-freeze","version":"1"}}`); err != nil {
+							return err
+						}
+					case "tools/list":
+						if err := writeDaemonResponse(stdout, req.ID, `{"tools":[{"name":"probe"}]}`); err != nil {
+							return err
+						}
+					}
+				}
+				return scanner.Err()
+			}
+			publishEntered := make(chan struct{})
+			releasePublish := make(chan struct{})
+			var enteredOnce sync.Once
+			var releaseOnce sync.Once
+			t.Cleanup(func() { releaseOnce.Do(func() { close(releasePublish) }) })
+			d.beforeOwnerCachePublish = func(*owner.Owner) {
+				enteredOnce.Do(func() { close(publishEntered) })
+				<-releasePublish
+			}
+
+			command := "admission-freeze-" + tc.name
+			path, sid, _, err := d.Spawn(control.Request{Command: command, Mode: tc.mode, Cwd: t.TempDir()})
+			if err != nil {
+				t.Fatalf("Spawn first: %v", err)
+			}
+			select {
+			case <-publishEntered:
+			case <-time.After(2 * time.Second):
+				t.Fatal("owner did not enter cache-commit admission freeze")
+			}
+			entry := d.Entry(sid)
+			type spawnResult struct {
+				path  string
+				sid   string
+				token string
+				err   error
+			}
+			resultCh := make(chan spawnResult, 1)
+			go func() {
+				path, sid, token, err := d.Spawn(control.Request{Command: command, Mode: tc.mode, Cwd: t.TempDir()})
+				resultCh <- spawnResult{path: path, sid: sid, token: token, err: err}
+			}()
+			time.Sleep(50 * time.Millisecond)
+			select {
+			case result := <-resultCh:
+				t.Fatalf("second Spawn bypassed cache-commit barrier: %+v", result)
+			default:
+			}
+			releaseOnce.Do(func() { close(releasePublish) })
+
+			select {
+			case result := <-resultCh:
+				if result.err != nil {
+					t.Fatalf("Spawn second: %v", result.err)
+				}
+				if result.path != path || result.sid != sid || result.token == "" {
+					t.Fatalf("second Spawn = (%q, %q, token=%v), want existing (%q, %q)", result.path, result.sid, result.token != "", path, sid)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatal("second Spawn did not resume after cache commit")
+			}
+			if d.Entry(sid) != entry || d.OwnerCount() != 1 || starts.Load() != 1 {
+				t.Fatalf("admission freeze replaced owner: same=%v owners=%d starts=%d", d.Entry(sid) == entry, d.OwnerCount(), starts.Load())
+			}
+		})
+	}
+}
+
 func TestLiveSessionsJoinSingleReplacementControllerDuringUnexpectedExit(t *testing.T) {
 	d := testDaemon(t)
 	var starts atomic.Int32
@@ -903,7 +996,13 @@ func TestLiveSessionsJoinSingleReplacementControllerDuringUnexpectedExit(t *test
 		t.Fatalf("second sid=%s, want shared sid %s", sid2, sid)
 	}
 	entry := d.Entry(sid)
-	waitForDaemonCondition(t, 2*time.Second, func() bool { return entry.Owner.MaterializationState() == owner.MaterializationReady }, "initial generation did not become ready")
+	readyDeadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(readyDeadline) && entry.Owner.MaterializationState() != owner.MaterializationReady {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if entry.Owner.MaterializationState() != owner.MaterializationReady {
+		t.Fatalf("initial generation did not become ready: starts=%d status=%#v", starts.Load(), entry.Owner.Status())
+	}
 	conn1, scan1 := connectSpawnedOwner(t, path, token1)
 	defer conn1.Close()
 	conn2, scan2 := connectSpawnedOwner(t, path, token2)
@@ -947,9 +1046,22 @@ func TestLiveSessionsJoinSingleReplacementControllerDuringUnexpectedExit(t *test
 func TestPersistentZeroSessionCrashRacingReaperUsesOneReplacementController(t *testing.T) {
 	d := testDaemon(t)
 	var starts atomic.Int32
+	gen1Init := make(chan struct{})
+	releaseGen1Init := make(chan struct{})
 	crashFirst := make(chan struct{})
 	gen2Init := make(chan struct{})
 	releaseGen2 := make(chan struct{})
+	closeSignal := func(ch chan struct{}) {
+		select {
+		case <-ch:
+		default:
+			close(ch)
+		}
+	}
+	defer closeSignal(releaseGen1Init)
+	defer closeSignal(crashFirst)
+	defer closeSignal(releaseGen2)
+	var gen1Once sync.Once
 	var gen2Once sync.Once
 	d.handlerFunc = func(_ context.Context, stdin io.Reader, stdout io.Writer) error {
 		generation := starts.Add(1)
@@ -964,7 +1076,10 @@ func TestPersistentZeroSessionCrashRacingReaperUsesOneReplacementController(t *t
 			}
 			switch req.Method {
 			case "initialize":
-				if generation == 2 {
+				if generation == 1 {
+					gen1Once.Do(func() { close(gen1Init) })
+					<-releaseGen1Init
+				} else if generation == 2 {
 					gen2Once.Do(func() { close(gen2Init) })
 					<-releaseGen2
 				}
@@ -990,13 +1105,20 @@ func TestPersistentZeroSessionCrashRacingReaperUsesOneReplacementController(t *t
 		t.Fatalf("Spawn: %v", err)
 	}
 	entry := d.Entry(sid)
+	select {
+	case <-gen1Init:
+	case <-time.After(2 * time.Second):
+		t.Fatal("initial persistent generation did not reach initialize")
+	}
 	conn, _ := connectSpawnedOwner(t, path, token)
+	waitForDaemonCondition(t, time.Second, func() bool { return entry.Owner.SessionCount() == 1 }, "persistent owner did not admit session before readiness")
+	closeSignal(releaseGen1Init)
 	waitForDaemonCondition(t, 2*time.Second, func() bool {
 		return entry.Owner.MaterializationState() == owner.MaterializationReady && entry.Owner.SessionCount() == 1
 	}, "persistent owner did not become ready")
 	_ = conn.Close()
 	waitForDaemonCondition(t, time.Second, func() bool { return entry.Owner.SessionCount() == 0 }, "persistent owner retained a session")
-	close(crashFirst)
+	closeSignal(crashFirst)
 	select {
 	case <-gen2Init:
 	case <-time.After(3 * time.Second):
@@ -1012,7 +1134,7 @@ func TestPersistentZeroSessionCrashRacingReaperUsesOneReplacementController(t *t
 	if starts.Load() != 2 {
 		t.Fatalf("competing persistent replacement generations=%d, want 2 total", starts.Load())
 	}
-	close(releaseGen2)
+	closeSignal(releaseGen2)
 	waitForDaemonCondition(t, 2*time.Second, func() bool { return entry.Owner.MaterializationState() == owner.MaterializationReady }, "persistent replacement did not become ready")
 	if d.Entry(sid) != entry || starts.Load() != 2 {
 		t.Fatalf("persistent recovery final same=%v starts=%d", d.Entry(sid) == entry, starts.Load())
@@ -1038,7 +1160,11 @@ func TestPendingPersistenceConcurrentReaperRetriesWithoutDemandAndDeniesSuspend(
 			}
 			switch req.Method {
 			case "initialize":
-				if err := writeDaemonResponse(stdout, req.ID, `{"protocolVersion":"2025-11-25","capabilities":{"x-mux":{"sharing":"shared","persistent":true}},"serverInfo":{"name":"pending-persistent","version":"1"}}`); err != nil {
+				result := `{"protocolVersion":"2025-11-25","capabilities":{"x-mux":{"sharing":"shared"}},"serverInfo":{"name":"pending-persistent","version":"1"}}`
+				if generation == 1 {
+					result = `{"protocolVersion":"2025-11-25","capabilities":{"x-mux":{"sharing":"shared","persistent":true}},"serverInfo":{"name":"pending-persistent","version":"1"}}`
+				}
+				if err := writeDaemonResponse(stdout, req.ID, result); err != nil {
 					return err
 				}
 			case "tools/list":
@@ -1097,9 +1223,12 @@ func TestPendingPersistenceConcurrentReaperRetriesWithoutDemandAndDeniesSuspend(
 	if d.Entry(sid) != entry || starts.Load() != 2 {
 		t.Fatalf("pending persistence recovery same=%v starts=%d", d.Entry(sid) == entry, starts.Load())
 	}
+	if !entry.Persistent {
+		t.Fatal("successful retry downgraded the latched daemon persistence obligation")
+	}
 }
 
-func TestConcurrentCacheTemplateCommitAndSnapshotIsCoherentAndBounded(t *testing.T) {
+func TestRestartRacingSharedToIsolatedCommitCapturesMatchingGeneration(t *testing.T) {
 	_ = os.Remove(SnapshotPath())
 	t.Cleanup(func() { _ = os.Remove(SnapshotPath()) })
 	d := testDaemon(t)
@@ -1122,7 +1251,7 @@ func TestConcurrentCacheTemplateCommitAndSnapshotIsCoherentAndBounded(t *testing
 			}
 			switch req.Method {
 			case "initialize":
-				if err := writeDaemonResponse(stdout, req.ID, `{"protocolVersion":"2025-11-25","capabilities":{"x-mux":{"sharing":"shared"}},"serverInfo":{"name":"new-coherent","version":"2"}}`); err != nil {
+				if err := writeDaemonResponse(stdout, req.ID, `{"protocolVersion":"2025-11-25","capabilities":{"x-mux":{"sharing":"isolated"}},"serverInfo":{"name":"new-coherent","version":"2"}}`); err != nil {
 					return err
 				}
 			case "tools/list":
@@ -1183,8 +1312,8 @@ func TestConcurrentCacheTemplateCommitAndSnapshotIsCoherentAndBounded(t *testing
 	if err != nil || !strings.Contains(string(tools), "new-coherent-tool") {
 		t.Fatalf("captured tools=%s err=%v, want wholly new cache", tools, err)
 	}
-	if captured.Classification != "shared" || captured.OwnerGeneration != entry.OwnerGeneration {
-		t.Fatalf("captured metadata classification=%q owner_generation=%q, want shared/%q", captured.Classification, captured.OwnerGeneration, entry.OwnerGeneration)
+	if captured.Classification != "isolated" || captured.OwnerGeneration != entry.OwnerGeneration {
+		t.Fatalf("captured metadata classification=%q owner_generation=%q, want isolated/%q", captured.Classification, captured.OwnerGeneration, entry.OwnerGeneration)
 	}
 	template, ok := d.getTemplate(command, nil)
 	if !ok || template.CachedInit != captured.CachedInit || template.CachedTools != captured.CachedTools || template.Classification != captured.Classification {

--- a/muxcore/daemon/materialization_test.go
+++ b/muxcore/daemon/materialization_test.go
@@ -324,8 +324,8 @@ func TestListChangedInvalidatesDaemonTemplate(t *testing.T) {
 	}
 
 	d, err := New(Config{
-		Name:             "materialization-invalidation-test",
-		ControlPath:      shortSocketPath(t, "materialization-invalidation.ctl"),
+		Name:             "mi",
+		ControlPath:      shortSocketPath(t, "mi.ctl"),
 		SkipSnapshot:     true,
 		HandlerFunc:      handler,
 		OwnerIdleTimeout: time.Minute,
@@ -1364,7 +1364,7 @@ func TestRestartRacingSharedToIsolatedCommitCapturesMatchingGeneration(t *testin
 	}
 }
 
-func TestTwoTemplateRevisionMismatchesThenOneColdBypassWithoutStaleFrames(t *testing.T) {
+func TestGeneralRetryBeforeTwoTemplateRevisionMismatchesStillColdBypasses(t *testing.T) {
 	d := testDaemon(t)
 	var starts atomic.Int32
 	initSeen := make(chan struct{})
@@ -1408,12 +1408,24 @@ func TestTwoTemplateRevisionMismatchesThenOneColdBypassWithoutStaleFrames(t *tes
 		return snapshot
 	}
 	d.updateTemplate(command, nil, makeSnapshot("stale-one"))
+	sid := serverid.GenerateContextKey(serverid.ModeGlobal, command, nil, nil, cwd)
 	var hookCalls atomic.Int32
 	d.beforeTemplatePromotion = func() {
 		switch hookCalls.Add(1) {
 		case 1:
-			d.updateTemplate(command, nil, makeSnapshot("stale-two"))
+			d.mu.Lock()
+			entry := d.owners[sid]
+			removed := entry != nil && entry.Owner == nil && entry.creating != nil
+			if removed {
+				d.deleteOwnerEntryLocked(sid)
+			}
+			d.mu.Unlock()
+			if !removed {
+				t.Errorf("general retry hook found owner entry=%#v, want creating placeholder", entry)
+			}
 		case 2:
+			d.updateTemplate(command, nil, makeSnapshot("stale-two"))
+		case 3:
 			d.updateTemplate(command, nil, makeSnapshot("stale-three"))
 		default:
 			t.Error("template promotion hook called after bounded bypass")
@@ -1437,7 +1449,7 @@ func TestTwoTemplateRevisionMismatchesThenOneColdBypassWithoutStaleFrames(t *tes
 			t.Fatalf("Spawn: %v", result.err)
 		}
 	case <-time.After(2 * time.Second):
-		t.Fatal("second template mismatch livelocked instead of taking cold bypass")
+		t.Fatal("general retry plus two template mismatches exhausted the shared budget before cold bypass")
 	}
 	select {
 	case <-initSeen:
@@ -1449,7 +1461,7 @@ func TestTwoTemplateRevisionMismatchesThenOneColdBypassWithoutStaleFrames(t *tes
 	if preCommit.CachedInit != "" || preCommit.CachedTools != "" {
 		t.Fatalf("cold bypass admitted stale cached frames: %+v", preCommit)
 	}
-	if hookCalls.Load() != 2 || starts.Load() != 1 || d.OwnerCount() != 1 {
+	if hookCalls.Load() != 3 || starts.Load() != 1 || d.OwnerCount() != 1 {
 		t.Fatalf("bounded bypass hook_calls=%d starts=%d owners=%d", hookCalls.Load(), starts.Load(), d.OwnerCount())
 	}
 	conn, scanner := connectSpawnedOwner(t, result.path, result.token)

--- a/muxcore/daemon/materialization_test.go
+++ b/muxcore/daemon/materialization_test.go
@@ -1,0 +1,1897 @@
+package daemon
+
+import (
+	"bufio"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/thebtf/mcp-mux/muxcore/control"
+	"github.com/thebtf/mcp-mux/muxcore/ipc"
+	"github.com/thebtf/mcp-mux/muxcore/owner"
+	"github.com/thebtf/mcp-mux/muxcore/serverid"
+	mcpsnapshot "github.com/thebtf/mcp-mux/muxcore/snapshot"
+)
+
+func daemonMaterializationSnapshot(persistent bool) mcpsnapshot.OwnerSnapshot {
+	initResp := `{"jsonrpc":"2.0","id":"cached-init","result":{"protocolVersion":"2025-11-25","capabilities":{},"serverInfo":{"name":"cached","version":"1"}}}`
+	toolsResp := `{"jsonrpc":"2.0","id":"cached-tools","result":{"tools":[{"name":"cached-tool"}]}}`
+	return mcpsnapshot.OwnerSnapshot{
+		Classification: "shared",
+		CachedInit:     base64.StdEncoding.EncodeToString([]byte(initResp)),
+		CachedTools:    base64.StdEncoding.EncodeToString([]byte(toolsResp)),
+		Persistent:     persistent,
+	}
+}
+
+func connectSpawnedOwner(t *testing.T, path, token string) (net.Conn, *bufio.Scanner) {
+	t.Helper()
+	conn, err := ipc.Dial(path)
+	if err != nil {
+		t.Fatalf("ipc.Dial: %v", err)
+	}
+	if _, err := fmt.Fprintln(conn, token); err != nil {
+		_ = conn.Close()
+		t.Fatalf("write handshake token: %v", err)
+	}
+	return conn, bufio.NewScanner(conn)
+}
+
+func waitForDaemonCondition(t *testing.T, timeout time.Duration, condition func() bool, message string) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal(message)
+}
+
+func readDaemonResponseID(t *testing.T, scanner *bufio.Scanner, id string) []byte {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if !scanner.Scan() {
+			t.Fatalf("response stream ended: %v", scanner.Err())
+		}
+		line := append([]byte(nil), scanner.Bytes()...)
+		var msg map[string]json.RawMessage
+		if err := json.Unmarshal(line, &msg); err != nil {
+			t.Fatalf("invalid JSON-RPC response %q: %v", line, err)
+		}
+		if string(msg["id"]) == id {
+			return line
+		}
+	}
+	t.Fatalf("timed out waiting for response id %s", id)
+	return nil
+}
+
+func writeDaemonResponse(w io.Writer, id json.RawMessage, result string) error {
+	_, err := fmt.Fprintf(w, `{"jsonrpc":"2.0","id":%s,"result":%s}`+"\n", id, result)
+	return err
+}
+
+func TestSpawnTemplateCacheHitStaysCacheOnlyAndServesTools(t *testing.T) {
+	d := testDaemon(t)
+	command := "definitely-not-a-real-template-command"
+	d.updateTemplate(command, nil, daemonMaterializationSnapshot(false))
+
+	path, sid, token, err := d.Spawn(control.Request{Command: command, Mode: "global", Cwd: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	entry := d.Entry(sid)
+	if entry == nil || entry.Owner == nil {
+		t.Fatal("template-backed owner missing")
+	}
+	if state := entry.Owner.MaterializationState(); state != owner.MaterializationCacheOnly {
+		t.Fatalf("materialization state=%s, want cache-only", state)
+	}
+	status := entry.Owner.Status()
+	if got := status["materialization_generation"]; got != uint64(0) {
+		t.Fatalf("materialization generation=%v, want 0", got)
+	}
+	if got := status["upstream_pid"]; got != 0 {
+		t.Fatalf("upstream pid=%v, want 0", got)
+	}
+
+	conn, scanner := connectSpawnedOwner(t, path, token)
+	defer conn.Close()
+	if _, err := fmt.Fprintln(conn, `{"jsonrpc":"2.0","id":41,"method":"tools/list","params":{}}`); err != nil {
+		t.Fatalf("write tools/list: %v", err)
+	}
+	resp := readDaemonResponseID(t, scanner, "41")
+	if !strings.Contains(string(resp), "cached-tool") {
+		t.Fatalf("cached tools/list response=%s", resp)
+	}
+	if state := entry.Owner.MaterializationState(); state != owner.MaterializationCacheOnly {
+		t.Fatalf("cached hit changed state to %s", state)
+	}
+}
+
+func TestTemplateCacheRequiresCompatibleContext(t *testing.T) {
+	t.Run("shared env bucket may cross cwd", func(t *testing.T) {
+		d := testDaemon(t)
+		command := "template-shared-compatible"
+		cwdA := t.TempDir()
+		snap := daemonMaterializationSnapshot(false)
+		snap.Cwd = cwdA
+		snap.Env = map[string]string{"MCPMUX_TEMPLATE_TEST_TOKEN": "same"}
+		d.updateTemplate(command, nil, snap)
+
+		_, sid, _, err := d.Spawn(control.Request{
+			Command: command,
+			Mode:    "global",
+			Cwd:     t.TempDir(),
+			Env:     map[string]string{"MCPMUX_TEMPLATE_TEST_TOKEN": "same"},
+		})
+		if err != nil {
+			t.Fatalf("Spawn compatible shared template: %v", err)
+		}
+		if entry := d.Entry(sid); entry == nil || entry.Owner.MaterializationState() != owner.MaterializationCacheOnly {
+			t.Fatalf("compatible shared template did not stay cache-only: %#v", entry)
+		}
+	})
+
+	t.Run("different env gets no cached replay", func(t *testing.T) {
+		d := testDaemon(t)
+		command := "definitely-not-a-real-env-mismatch-command"
+		snap := daemonMaterializationSnapshot(false)
+		snap.Cwd = t.TempDir()
+		snap.Env = map[string]string{"MCPMUX_TEMPLATE_TEST_TOKEN": "A"}
+		d.updateTemplate(command, nil, snap)
+
+		if _, _, _, err := d.Spawn(control.Request{
+			Command: command,
+			Mode:    "global",
+			Cwd:     t.TempDir(),
+			Env:     map[string]string{"MCPMUX_TEMPLATE_TEST_TOKEN": "B"},
+		}); err == nil {
+			t.Fatal("Spawn with incompatible env unexpectedly replayed cached template")
+		}
+	})
+
+	t.Run("isolated template requires exact canonical cwd", func(t *testing.T) {
+		d := testDaemon(t)
+		command := "definitely-not-a-real-isolated-cwd-command"
+		cwdA := t.TempDir()
+		snap := daemonMaterializationSnapshot(false)
+		snap.Classification = "isolated"
+		snap.Cwd = cwdA
+		snap.Env = map[string]string{"MCPMUX_TEMPLATE_TEST_TOKEN": "same"}
+		d.updateTemplate(command, nil, snap)
+
+		if _, _, _, err := d.Spawn(control.Request{
+			Command: command,
+			Mode:    "global",
+			Cwd:     t.TempDir(),
+			Env:     map[string]string{"MCPMUX_TEMPLATE_TEST_TOKEN": "same"},
+		}); err == nil {
+			t.Fatal("isolated template from another cwd was replayed")
+		}
+	})
+}
+
+func TestTemplateRevisionRevalidatedBeforePromotion(t *testing.T) {
+	d := testDaemon(t)
+	command := "template-revision-refresh"
+	cwd := t.TempDir()
+	env := map[string]string{"MCPMUX_TEMPLATE_TEST_TOKEN": "same"}
+	oldSnap := daemonMaterializationSnapshot(false)
+	oldSnap.Cwd = cwd
+	oldSnap.Env = env
+	d.updateTemplate(command, nil, oldSnap)
+
+	newSnap := daemonMaterializationSnapshot(false)
+	newSnap.Cwd = cwd
+	newSnap.Env = env
+	newTools := `{"jsonrpc":"2.0","id":"cached-tools","result":{"tools":[{"name":"new-template-tool"}]}}`
+	newSnap.CachedTools = base64.StdEncoding.EncodeToString([]byte(newTools))
+	var hookCalls atomic.Int32
+	d.beforeTemplatePromotion = func() {
+		if hookCalls.Add(1) == 1 {
+			d.updateTemplate(command, nil, newSnap)
+		}
+	}
+
+	path, sid, token, err := d.Spawn(control.Request{Command: command, Mode: "global", Cwd: cwd, Env: env})
+	if err != nil {
+		t.Fatalf("Spawn after revision refresh: %v", err)
+	}
+	if got := hookCalls.Load(); got != 2 {
+		t.Fatalf("promotion hook calls=%d, want 2 template constructions", got)
+	}
+	if got := d.OwnerCount(); got != 1 {
+		t.Fatalf("owner count=%d, want exactly one promoted owner", got)
+	}
+	conn, scanner := connectSpawnedOwner(t, path, token)
+	defer conn.Close()
+	if _, err := fmt.Fprintln(conn, `{"jsonrpc":"2.0","id":91,"method":"tools/list","params":{}}`); err != nil {
+		t.Fatalf("write tools/list: %v", err)
+	}
+	resp := readDaemonResponseID(t, scanner, "91")
+	if !strings.Contains(string(resp), "new-template-tool") {
+		t.Fatalf("promoted stale template for owner %s: %s", sid, resp)
+	}
+}
+
+func TestTemplateInvalidationPreventsStalePromotion(t *testing.T) {
+	d := testDaemon(t)
+	command := "definitely-not-a-real-invalidated-template-command"
+	cwd := t.TempDir()
+	env := map[string]string{"MCPMUX_TEMPLATE_TEST_TOKEN": "same"}
+	snap := daemonMaterializationSnapshot(false)
+	snap.Cwd = cwd
+	snap.Env = env
+	d.updateTemplate(command, nil, snap)
+
+	var hookCalls atomic.Int32
+	d.beforeTemplatePromotion = func() {
+		if hookCalls.Add(1) == 1 {
+			d.invalidateTemplate(command, nil)
+		}
+	}
+	if _, _, _, err := d.Spawn(control.Request{Command: command, Mode: "global", Cwd: cwd, Env: env}); err == nil {
+		t.Fatal("invalidated template was promoted instead of taking the cold path")
+	}
+	if got := d.OwnerCount(); got != 0 {
+		t.Fatalf("owner count=%d after invalidation race, want 0", got)
+	}
+}
+
+func TestListChangedInvalidatesDaemonTemplate(t *testing.T) {
+	var starts atomic.Int32
+	handler := func(_ context.Context, stdin io.Reader, stdout io.Writer) error {
+		starts.Add(1)
+		scanner := bufio.NewScanner(stdin)
+		for scanner.Scan() {
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+				return err
+			}
+			switch req.Method {
+			case "initialize":
+				if err := writeDaemonResponse(stdout, req.ID, `{"protocolVersion":"2025-11-25","capabilities":{},"serverInfo":{"name":"live","version":"2"}}`); err != nil {
+					return err
+				}
+			case "tools/list":
+				if err := writeDaemonResponse(stdout, req.ID, `{"tools":[{"name":"live-tool"}]}`); err != nil {
+					return err
+				}
+				if _, err := fmt.Fprintln(stdout, `{"jsonrpc":"2.0","method":"notifications/tools/list_changed"}`); err != nil {
+					return err
+				}
+			case "custom/wake":
+				if err := writeDaemonResponse(stdout, req.ID, `{"ok":true}`); err != nil {
+					return err
+				}
+			}
+		}
+		return scanner.Err()
+	}
+
+	d, err := New(Config{
+		Name:             "materialization-invalidation-test",
+		ControlPath:      shortSocketPath(t, "materialization-invalidation.ctl"),
+		SkipSnapshot:     true,
+		HandlerFunc:      handler,
+		OwnerIdleTimeout: time.Minute,
+		Logger:           testLogger(t),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { d.Shutdown() })
+	command := "in-process-invalidation"
+	d.updateTemplate(command, nil, daemonMaterializationSnapshot(false))
+	path, _, token, err := d.Spawn(control.Request{Command: command, Mode: "global", Cwd: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	conn, scanner := connectSpawnedOwner(t, path, token)
+	defer conn.Close()
+	if _, err := fmt.Fprintln(conn, `{"jsonrpc":"2.0","id":51,"method":"custom/wake","params":{}}`); err != nil {
+		t.Fatalf("write wake request: %v", err)
+	}
+	_ = readDaemonResponseID(t, scanner, "51")
+	waitForDaemonCondition(t, 2*time.Second, func() bool {
+		_, ok := d.getTemplate(command, nil)
+		return !ok
+	}, "list_changed did not invalidate daemon template")
+	if got := starts.Load(); got != 1 {
+		t.Fatalf("upstream starts=%d, want 1", got)
+	}
+}
+
+func TestDynamicPersistentDeclarationRestartsWithoutDemand(t *testing.T) {
+	var starts atomic.Int32
+	allowFirstExit := make(chan struct{})
+	handler := func(_ context.Context, stdin io.Reader, stdout io.Writer) error {
+		generation := starts.Add(1)
+		scanner := bufio.NewScanner(stdin)
+		for scanner.Scan() {
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+				return err
+			}
+			switch req.Method {
+			case "initialize":
+				result := `{"protocolVersion":"2025-11-25","capabilities":{"x-mux":{"sharing":"shared","persistent":true}},"serverInfo":{"name":"persistent","version":"1"}}`
+				if err := writeDaemonResponse(stdout, req.ID, result); err != nil {
+					return err
+				}
+			case "tools/list":
+				if err := writeDaemonResponse(stdout, req.ID, `{"tools":[]}`); err != nil {
+					return err
+				}
+			case "custom/wake":
+				if err := writeDaemonResponse(stdout, req.ID, `{"ok":true}`); err != nil {
+					return err
+				}
+				if generation == 1 {
+					<-allowFirstExit
+					return nil
+				}
+			}
+		}
+		return scanner.Err()
+	}
+
+	d, err := New(Config{
+		Name:             "dynamic-persistent-test",
+		ControlPath:      shortSocketPath(t, "dynamic-persistent.ctl"),
+		SkipSnapshot:     true,
+		HandlerFunc:      handler,
+		OwnerIdleTimeout: time.Minute,
+		Logger:           testLogger(t),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { d.Shutdown() })
+	command := "in-process-persistent"
+	d.updateTemplate(command, nil, daemonMaterializationSnapshot(false))
+	path, sid, token, err := d.Spawn(control.Request{Command: command, Mode: "global", Cwd: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	if got := starts.Load(); got != 0 {
+		t.Fatalf("template hit eagerly started %d generations before demand", got)
+	}
+	conn, scanner := connectSpawnedOwner(t, path, token)
+	if _, err := fmt.Fprintln(conn, `{"jsonrpc":"2.0","id":61,"method":"custom/wake","params":{}}`); err != nil {
+		t.Fatalf("write wake request: %v", err)
+	}
+	_ = readDaemonResponseID(t, scanner, "61")
+	entry := d.Entry(sid)
+	waitForDaemonCondition(t, 2*time.Second, func() bool { return entry != nil && entry.Persistent }, "persistent declaration was not applied")
+	_ = conn.Close()
+	waitForDaemonCondition(t, 2*time.Second, func() bool { return entry.Owner.SessionCount() == 0 }, "session did not disconnect")
+	close(allowFirstExit)
+	waitForDaemonCondition(t, 2*time.Second, func() bool { return starts.Load() >= 2 }, "persistent owner did not restart without demand")
+}
+
+func TestPersistentTemplateMaterializesEagerly(t *testing.T) {
+	var starts atomic.Int32
+	handler := func(_ context.Context, stdin io.Reader, stdout io.Writer) error {
+		starts.Add(1)
+		scanner := bufio.NewScanner(stdin)
+		for scanner.Scan() {
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+				return err
+			}
+			switch req.Method {
+			case "initialize":
+				if err := writeDaemonResponse(stdout, req.ID, `{"protocolVersion":"2025-11-25","capabilities":{"x-mux":{"persistent":true}},"serverInfo":{"name":"persistent-template","version":"1"}}`); err != nil {
+					return err
+				}
+			case "tools/list":
+				if err := writeDaemonResponse(stdout, req.ID, `{"tools":[]}`); err != nil {
+					return err
+				}
+			}
+		}
+		return scanner.Err()
+	}
+	d, err := New(Config{
+		Name:             "persistent-template-test",
+		ControlPath:      shortSocketPath(t, "persistent-template.ctl"),
+		SkipSnapshot:     true,
+		HandlerFunc:      handler,
+		OwnerIdleTimeout: time.Minute,
+		Logger:           testLogger(t),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { d.Shutdown() })
+	command := "persistent-template"
+	d.updateTemplate(command, nil, daemonMaterializationSnapshot(true))
+	_, sid, _, err := d.Spawn(control.Request{Command: command, Mode: "global", Cwd: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	entry := d.Entry(sid)
+	waitForDaemonCondition(t, 2*time.Second, func() bool {
+		return starts.Load() == 1 && entry != nil && entry.Owner.MaterializationState() == owner.MaterializationReady
+	}, "persistent template did not materialize eagerly")
+	if !entry.Persistent {
+		t.Fatal("persistent template entry was not marked persistent")
+	}
+}
+
+func TestSerializeSnapshotDuringMaterializationPreservesLiveSession(t *testing.T) {
+	_ = os.Remove(SnapshotPath())
+	t.Cleanup(func() { _ = os.Remove(SnapshotPath()) })
+
+	firstInit := make(chan struct{})
+	var starts atomic.Int32
+	handler := func(_ context.Context, stdin io.Reader, stdout io.Writer) error {
+		generation := starts.Add(1)
+		scanner := bufio.NewScanner(stdin)
+		for scanner.Scan() {
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+				return err
+			}
+			switch req.Method {
+			case "initialize":
+				if generation == 1 {
+					select {
+					case <-firstInit:
+					default:
+						close(firstInit)
+					}
+					continue
+				}
+				if err := writeDaemonResponse(stdout, req.ID, `{"protocolVersion":"2025-11-25","capabilities":{},"serverInfo":{"name":"restart","version":"2"}}`); err != nil {
+					return err
+				}
+			case "tools/list":
+				if err := writeDaemonResponse(stdout, req.ID, `{"tools":[]}`); err != nil {
+					return err
+				}
+			case "custom/wake":
+				if err := writeDaemonResponse(stdout, req.ID, `{"generation":2}`); err != nil {
+					return err
+				}
+			}
+		}
+		return scanner.Err()
+	}
+
+	d, err := New(Config{
+		Name:             "snapshot-materialization-race",
+		ControlPath:      shortSocketPath(t, "snapshot-materialization-race.ctl"),
+		SkipSnapshot:     true,
+		HandlerFunc:      handler,
+		OwnerIdleTimeout: time.Minute,
+		Logger:           testLogger(t),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { d.Shutdown() })
+	command := "snapshot-materialization-upstream"
+	template := daemonMaterializationSnapshot(false)
+	template.Env = map[string]string{"GITHUB_TOKEN": "snapshot-secret"}
+	d.updateTemplate(command, nil, template)
+	path, sid, token, err := d.Spawn(control.Request{Command: command, Mode: "global", Cwd: t.TempDir(), Env: map[string]string{"GITHUB_TOKEN": "snapshot-secret"}})
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	conn, scanner := connectSpawnedOwner(t, path, token)
+	defer conn.Close()
+	if _, err := fmt.Fprintln(conn, `{"jsonrpc":"2.0","id":71,"method":"custom/wake","params":{}}`); err != nil {
+		t.Fatalf("write first demand: %v", err)
+	}
+	select {
+	case <-firstInit:
+	case <-time.After(time.Second):
+		t.Fatal("first generation did not reach initialize")
+	}
+	snapshotPath, err := d.SerializeSnapshot()
+	if err != nil {
+		t.Fatalf("SerializeSnapshot: %v", err)
+	}
+	if snapshotPath == "" {
+		t.Fatal("SerializeSnapshot returned empty path")
+	}
+	first := readDaemonResponseID(t, scanner, "71")
+	if !strings.Contains(string(first), "cancelled for restart") {
+		t.Fatalf("first demand was not terminated by restart barrier: %s", first)
+	}
+	entry := d.Entry(sid)
+	if entry == nil || entry.Owner.SessionCount() != 1 || !entry.Owner.CacheReady() {
+		t.Fatalf("restart snapshot lost live owner/session/cache: entry=%+v", entry)
+	}
+	if entry.Owner.Status()["restart_pin_count"] != int64(0) {
+		t.Fatalf("restart pin remained after serialization: %#v", entry.Owner.Status())
+	}
+	if _, err := fmt.Fprintln(conn, `{"jsonrpc":"2.0","id":72,"method":"custom/wake","params":{}}`); err != nil {
+		t.Fatalf("write post-snapshot demand: %v", err)
+	}
+	second := readDaemonResponseID(t, scanner, "72")
+	if !strings.Contains(string(second), `"generation":2`) {
+		t.Fatalf("live session did not recover after snapshot: %s", second)
+	}
+	if got := starts.Load(); got != 2 {
+		t.Fatalf("upstream starts=%d, want exactly 2 generations", got)
+	}
+}
+
+func TestColdFastHandlerPublishesOnlyAfterExactOwnerRegistration(t *testing.T) {
+	d := testDaemon(t)
+	var starts atomic.Int32
+	d.handlerFunc = func(_ context.Context, stdin io.Reader, stdout io.Writer) error {
+		starts.Add(1)
+		scanner := bufio.NewScanner(stdin)
+		for scanner.Scan() {
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+				return err
+			}
+			switch req.Method {
+			case "initialize":
+				if err := writeDaemonResponse(stdout, req.ID, `{"protocolVersion":"2025-11-25","capabilities":{},"serverInfo":{"name":"fast","version":"1"}}`); err != nil {
+					return err
+				}
+			case "tools/list":
+				if err := writeDaemonResponse(stdout, req.ID, `{"tools":[{"name":"fast-tool"}]}`); err != nil {
+					return err
+				}
+			}
+		}
+		return scanner.Err()
+	}
+
+	promotionCheck := make(chan error, 1)
+	d.beforeColdOwnerPromotion = func(got *owner.Owner) {
+		if state := got.MaterializationState(); state != owner.MaterializationCacheOnly {
+			promotionCheck <- fmt.Errorf("cold owner state before promotion=%s, want cache_only", state)
+			return
+		}
+		promotionCheck <- nil
+	}
+	publishCheck := make(chan error, 1)
+	d.beforeOwnerCachePublish = func(got *owner.Owner) {
+		entry := d.Entry(got.ServerID())
+		if entry == nil || entry.Owner != got {
+			publishCheck <- fmt.Errorf("cache publish observed entry=%+v for owner=%p", entry, got)
+			return
+		}
+		publishCheck <- nil
+	}
+
+	const secret = "raw-config-secret-value"
+	command := "cold-fast-publish"
+	_, sid, _, err := d.Spawn(control.Request{
+		Command: command,
+		Mode:    "global",
+		Cwd:     t.TempDir(),
+		Env:     map[string]string{"CONFIG_PATH": secret},
+	})
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	if err := <-promotionCheck; err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-publishCheck:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("fast handler did not publish cache")
+	}
+	entry := d.Entry(sid)
+	if entry == nil {
+		t.Fatal("cold owner missing after spawn")
+	}
+	waitForDaemonCondition(t, 3*time.Second, entry.Owner.CacheReady, "cold owner cache did not become ready")
+	if _, ok := d.getTemplate(command, nil); !ok {
+		t.Fatal("cold owner did not publish template")
+	}
+	if got := starts.Load(); got != 1 {
+		t.Fatalf("upstream starts=%d, want one exact owner generation", got)
+	}
+	statusJSON, marshalErr := json.Marshal(d.HandleStatus())
+	if marshalErr != nil {
+		t.Fatalf("marshal status: %v", marshalErr)
+	}
+	if strings.Contains(string(statusJSON), secret) {
+		t.Fatal("raw identity value leaked into public status")
+	}
+}
+
+func TestCompatibleTemplateCachedBurstThenUncachedWakeSameIPCSession(t *testing.T) {
+	d := testDaemon(t)
+	var starts atomic.Int32
+	d.handlerFunc = func(_ context.Context, stdin io.Reader, stdout io.Writer) error {
+		starts.Add(1)
+		scanner := bufio.NewScanner(stdin)
+		for scanner.Scan() {
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+				return err
+			}
+			switch req.Method {
+			case "initialize":
+				if err := writeDaemonResponse(stdout, req.ID, `{"protocolVersion":"2025-11-25","capabilities":{},"serverInfo":{"name":"live","version":"1"}}`); err != nil {
+					return err
+				}
+			case "tools/list":
+				if err := writeDaemonResponse(stdout, req.ID, `{"tools":[{"name":"live-tool"}]}`); err != nil {
+					return err
+				}
+			case "custom/wake":
+				if err := writeDaemonResponse(stdout, req.ID, `{"ok":true}`); err != nil {
+					return err
+				}
+			}
+		}
+		return scanner.Err()
+	}
+	command := "same-session-template-wake"
+	template := daemonMaterializationSnapshot(false)
+	template.CachedPrompts = base64.StdEncoding.EncodeToString([]byte(`{"jsonrpc":"2.0","id":1,"result":{"prompts":[]}}`))
+	template.CachedResources = base64.StdEncoding.EncodeToString([]byte(`{"jsonrpc":"2.0","id":1,"result":{"resources":[]}}`))
+	template.CachedResourceTemplates = base64.StdEncoding.EncodeToString([]byte(`{"jsonrpc":"2.0","id":1,"result":{"resourceTemplates":[]}}`))
+	template.Cwd = t.TempDir()
+	d.updateTemplate(command, nil, template)
+	path, _, token, err := d.Spawn(control.Request{Command: command, Mode: "global", Cwd: template.Cwd})
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	conn, scanner := connectSpawnedOwner(t, path, token)
+	defer conn.Close()
+	requests := []struct {
+		id     int
+		method string
+	}{
+		{1, "initialize"},
+		{2, "tools/list"},
+		{3, "prompts/list"},
+		{4, "resources/list"},
+		{5, "resources/templates/list"},
+	}
+	for _, request := range requests {
+		if _, err := fmt.Fprintf(conn, `{"jsonrpc":"2.0","id":%d,"method":%q,"params":{}}`+"\n", request.id, request.method); err != nil {
+			t.Fatalf("write %s: %v", request.method, err)
+		}
+		_ = readDaemonResponseID(t, scanner, fmt.Sprint(request.id))
+		if request.method == "initialize" {
+			if _, err := fmt.Fprintln(conn, `{"jsonrpc":"2.0","method":"notifications/initialized"}`); err != nil {
+				t.Fatalf("write initialized: %v", err)
+			}
+		}
+	}
+	if got := starts.Load(); got != 0 {
+		t.Fatalf("cached host burst started upstream %d times, want 0", got)
+	}
+	if _, err := fmt.Fprintln(conn, `{"jsonrpc":"2.0","id":6,"method":"custom/wake","params":{}}`); err != nil {
+		t.Fatalf("write uncached wake: %v", err)
+	}
+	wake := readDaemonResponseID(t, scanner, "6")
+	if !strings.Contains(string(wake), `"ok":true`) {
+		t.Fatalf("uncached wake response=%s", wake)
+	}
+	if got := starts.Load(); got != 1 {
+		t.Fatalf("uncached wake starts=%d, want exactly 1 on same IPC session", got)
+	}
+}
+
+func TestStaleOwnerCallbacksCannotMutateReplacementGeneration(t *testing.T) {
+	d := testDaemon(t)
+	d.supervisor = nil
+	sid := "stale-callback-generation"
+	stale := testReconnectOwner(t, sid)
+	replacement := testReconnectOwner(t, sid)
+	command := "stale-callback-command"
+	lastSession := time.Now().Add(-time.Hour)
+	entry := &OwnerEntry{
+		Owner:           replacement,
+		ServerID:        sid,
+		Command:         command,
+		LastSession:     lastSession,
+		OwnerGeneration: "owner_gen_replacement",
+	}
+	d.mu.Lock()
+	d.owners[sid] = entry
+	d.mu.Unlock()
+
+	snap := daemonMaterializationSnapshot(false)
+	snap.Cwd = t.TempDir()
+	if !d.publishOwnerCache(replacement, snap) {
+		t.Fatal("replacement cache publish was rejected")
+	}
+	wantTemplate, ok := d.getTemplate(command, nil)
+	if !ok {
+		t.Fatal("replacement template missing")
+	}
+
+	if d.setOwnerPersistent(stale, true) {
+		t.Fatal("stale persistent callback was accepted")
+	}
+	d.resolveOwnerPersistent(stale, true)
+	d.invalidateOwnerTemplate(stale)
+	staleSnap := snap
+	staleSnap.CachedTools = base64.StdEncoding.EncodeToString([]byte(`{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"stale"}]}}`))
+	if d.publishOwnerCache(stale, staleSnap) {
+		t.Fatal("stale cache publish was accepted")
+	}
+	d.onZeroSessions(stale)
+	d.onUpstreamExit(stale)
+
+	current := d.Entry(sid)
+	if current != entry || current.Owner != replacement {
+		t.Fatal("stale callback replaced or removed the current owner")
+	}
+	if current.Persistent {
+		t.Fatal("stale callback changed replacement persistence")
+	}
+	if !current.LastSession.Equal(lastSession) {
+		t.Fatal("stale zero-session callback changed replacement lifecycle time")
+	}
+	gotTemplate, ok := d.getTemplate(command, nil)
+	if !ok || gotTemplate.CachedTools != wantTemplate.CachedTools {
+		t.Fatal("stale callback invalidated or overwrote replacement template")
+	}
+}
+
+func TestMaterializationFreshSharedTemplateKeepsLiveOwnerIsolated(t *testing.T) {
+	d := testDaemon(t)
+	const sid = "t044-live-isolated"
+	const command = "t044-command"
+	args := []string{"--serve"}
+	env := map[string]string{"SERVICE_CONFIG_PATH": "/cfg/t044"}
+	handler := func(_ context.Context, stdin io.Reader, stdout io.Writer) error {
+		scanner := bufio.NewScanner(stdin)
+		for scanner.Scan() {
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+				return err
+			}
+			switch req.Method {
+			case "initialize":
+				if err := writeDaemonResponse(stdout, req.ID, `{"protocolVersion":"2025-11-25","capabilities":{"x-mux":{"sharing":"shared"}},"serverInfo":{"name":"fresh","version":"1"}}`); err != nil {
+					return err
+				}
+			case "tools/list":
+				if err := writeDaemonResponse(stdout, req.ID, `{"tools":[{"name":"fresh-shared"}]}`); err != nil {
+					return err
+				}
+			}
+		}
+		return scanner.Err()
+	}
+
+	snap := daemonMaterializationSnapshot(false)
+	snap.Classification = "isolated"
+	snap.ClassificationSource = "capability"
+	snap.Cwd = "/project/live"
+	snap.Env = env
+	o, err := owner.NewOwnerFromSnapshot(owner.OwnerConfig{
+		Command:               command,
+		Args:                  args,
+		Cwd:                   snap.Cwd,
+		Env:                   env,
+		HandlerFunc:           handler,
+		IPCPath:               shortSocketPath(t, "t044-owner.sock"),
+		ServerID:              sid,
+		MaterializationPolicy: owner.MaterializationOnDemand,
+		OnCacheReady:          d.publishOwnerCache,
+		Logger:                d.logger,
+	}, snap)
+	if err != nil {
+		t.Fatalf("NewOwnerFromSnapshot: %v", err)
+	}
+	defer o.Shutdown()
+	d.mu.Lock()
+	d.owners[sid] = &OwnerEntry{Owner: o, ServerID: sid, Command: command, Args: args, Cwd: snap.Cwd, Env: env}
+	d.mu.Unlock()
+
+	if err := o.StartInitialMaterialization(); err != nil {
+		t.Fatalf("StartInitialMaterialization: %v", err)
+	}
+	waitForDaemonCondition(t, time.Second, func() bool {
+		return o.MaterializationState() == owner.MaterializationReady
+	}, "fresh shared generation did not commit")
+	if !o.IsClassifiedIsolated() {
+		t.Fatal("fresh less-restrictive classification reopened live isolated owner")
+	}
+	if o.PreRegister("feedface", "/project/other", env) {
+		t.Fatal("live isolated owner accepted fresh fan-in after shared refresh")
+	}
+	match, ok := d.getCompatibleTemplate(command, args, "/project/future", mergeEnv(env))
+	if !ok {
+		t.Fatal("fresh shared template was not published for future owner")
+	}
+	if match.snapshot.Classification != "shared" {
+		t.Fatalf("future template classification = %q, want fresh shared", match.snapshot.Classification)
+	}
+}
+
+func TestLiveSessionsJoinSingleReplacementControllerDuringUnexpectedExit(t *testing.T) {
+	d := testDaemon(t)
+	var starts atomic.Int32
+	gen2Init := make(chan struct{})
+	releaseGen2 := make(chan struct{})
+	var gen2Once sync.Once
+	d.handlerFunc = func(_ context.Context, stdin io.Reader, stdout io.Writer) error {
+		generation := starts.Add(1)
+		scanner := bufio.NewScanner(stdin)
+		for scanner.Scan() {
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+				return err
+			}
+			switch req.Method {
+			case "initialize":
+				if generation == 2 {
+					gen2Once.Do(func() { close(gen2Init) })
+					<-releaseGen2
+				}
+				if err := writeDaemonResponse(stdout, req.ID, `{"protocolVersion":"2025-11-25","capabilities":{"x-mux":{"sharing":"shared"}},"serverInfo":{"name":"recovery","version":"1"}}`); err != nil {
+					return err
+				}
+			case "tools/list":
+				if err := writeDaemonResponse(stdout, req.ID, `{"tools":[{"name":"crash"}]}`); err != nil {
+					return err
+				}
+			case "tools/call":
+				if generation == 1 {
+					return fmt.Errorf("synthetic unexpected exit")
+				}
+			case "ping":
+				if err := writeDaemonResponse(stdout, req.ID, fmt.Sprintf(`{"generation":%d}`, generation)); err != nil {
+					return err
+				}
+			}
+		}
+		return scanner.Err()
+	}
+
+	path, sid, token1, err := d.Spawn(control.Request{Command: "live-recovery", Mode: "global", Cwd: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Spawn first: %v", err)
+	}
+	_, sid2, token2, err := d.Spawn(control.Request{Command: "live-recovery", Mode: "global", Cwd: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Spawn second: %v", err)
+	}
+	if sid2 != sid {
+		t.Fatalf("second sid=%s, want shared sid %s", sid2, sid)
+	}
+	entry := d.Entry(sid)
+	waitForDaemonCondition(t, 2*time.Second, func() bool { return entry.Owner.MaterializationState() == owner.MaterializationReady }, "initial generation did not become ready")
+	conn1, scan1 := connectSpawnedOwner(t, path, token1)
+	defer conn1.Close()
+	conn2, scan2 := connectSpawnedOwner(t, path, token2)
+	defer conn2.Close()
+	for id, conn := range map[int]net.Conn{1: conn1, 2: conn2} {
+		if _, err := fmt.Fprintf(conn, `{"jsonrpc":"2.0","id":%d,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"live","version":"1"}}}`+"\n", id); err != nil {
+			t.Fatalf("initialize session %d: %v", id, err)
+		}
+	}
+	readDaemonResponseID(t, scan1, "1")
+	readDaemonResponseID(t, scan2, "2")
+	if _, err := fmt.Fprintln(conn1, `{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"crash","arguments":{}}}`); err != nil {
+		t.Fatalf("write crash: %v", err)
+	}
+	crash := readDaemonResponseID(t, scan1, "3")
+	if !strings.Contains(string(crash), "upstream process exited") {
+		t.Fatalf("crash response=%s", crash)
+	}
+	select {
+	case <-gen2Init:
+	case <-time.After(2 * time.Second):
+		t.Fatal("replacement controller did not start")
+	}
+	if _, err := fmt.Fprintln(conn1, `{"jsonrpc":"2.0","id":4,"method":"ping","params":{}}`); err != nil {
+		t.Fatalf("write recovery ping 1: %v", err)
+	}
+	if _, err := fmt.Fprintln(conn2, `{"jsonrpc":"2.0","id":5,"method":"ping","params":{}}`); err != nil {
+		t.Fatalf("write recovery ping 2: %v", err)
+	}
+	close(releaseGen2)
+	resp1 := readDaemonResponseID(t, scan1, "4")
+	resp2 := readDaemonResponseID(t, scan2, "5")
+	if !strings.Contains(string(resp1), `"generation":2`) || !strings.Contains(string(resp2), `"generation":2`) {
+		t.Fatalf("recovery responses=(%s, %s), want generation 2", resp1, resp2)
+	}
+	if starts.Load() != 2 || d.OwnerCount() != 1 || d.Entry(sid) != entry || entry.Owner.SessionCount() != 2 {
+		t.Fatalf("recovery state starts=%d owners=%d same_entry=%v sessions=%d", starts.Load(), d.OwnerCount(), d.Entry(sid) == entry, entry.Owner.SessionCount())
+	}
+}
+
+func TestPersistentZeroSessionCrashRacingReaperUsesOneReplacementController(t *testing.T) {
+	d := testDaemon(t)
+	var starts atomic.Int32
+	crashFirst := make(chan struct{})
+	gen2Init := make(chan struct{})
+	releaseGen2 := make(chan struct{})
+	var gen2Once sync.Once
+	d.handlerFunc = func(_ context.Context, stdin io.Reader, stdout io.Writer) error {
+		generation := starts.Add(1)
+		scanner := bufio.NewScanner(stdin)
+		for scanner.Scan() {
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+				return err
+			}
+			switch req.Method {
+			case "initialize":
+				if generation == 2 {
+					gen2Once.Do(func() { close(gen2Init) })
+					<-releaseGen2
+				}
+				if err := writeDaemonResponse(stdout, req.ID, `{"protocolVersion":"2025-11-25","capabilities":{"x-mux":{"sharing":"shared","persistent":true}},"serverInfo":{"name":"persistent-recovery","version":"1"}}`); err != nil {
+					return err
+				}
+			case "tools/list":
+				if err := writeDaemonResponse(stdout, req.ID, `{"tools":[]}`); err != nil {
+					return err
+				}
+				if generation == 1 {
+					<-crashFirst
+					return fmt.Errorf("persistent generation crashed")
+				}
+			}
+		}
+		return scanner.Err()
+	}
+	command := "persistent-zero-session-recovery"
+	d.updateTemplate(command, nil, daemonMaterializationSnapshot(true))
+	path, sid, token, err := d.Spawn(control.Request{Command: command, Mode: "global", Cwd: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	entry := d.Entry(sid)
+	conn, _ := connectSpawnedOwner(t, path, token)
+	waitForDaemonCondition(t, 2*time.Second, func() bool {
+		return entry.Owner.MaterializationState() == owner.MaterializationReady && entry.Owner.SessionCount() == 1
+	}, "persistent owner did not become ready")
+	_ = conn.Close()
+	waitForDaemonCondition(t, time.Second, func() bool { return entry.Owner.SessionCount() == 0 }, "persistent owner retained a session")
+	close(crashFirst)
+	select {
+	case <-gen2Init:
+	case <-time.After(3 * time.Second):
+		t.Fatal("persistent owner did not replace crashed generation without demand")
+	}
+	if affected := (&Reaper{daemon: d, logger: d.logger}).sweep(); affected != 0 {
+		t.Fatalf("reaper affected=%d during persistent recovery", affected)
+	}
+	if d.Entry(sid) != entry || d.OwnerCount() != 1 || starts.Load() != 2 {
+		t.Fatalf("persistent recovery before release: same=%v owners=%d starts=%d", d.Entry(sid) == entry, d.OwnerCount(), starts.Load())
+	}
+	time.Sleep(50 * time.Millisecond)
+	if starts.Load() != 2 {
+		t.Fatalf("competing persistent replacement generations=%d, want 2 total", starts.Load())
+	}
+	close(releaseGen2)
+	waitForDaemonCondition(t, 2*time.Second, func() bool { return entry.Owner.MaterializationState() == owner.MaterializationReady }, "persistent replacement did not become ready")
+	if d.Entry(sid) != entry || starts.Load() != 2 {
+		t.Fatalf("persistent recovery final same=%v starts=%d", d.Entry(sid) == entry, starts.Load())
+	}
+}
+
+func TestPendingPersistenceConcurrentReaperRetriesWithoutDemandAndDeniesSuspend(t *testing.T) {
+	d := testDaemon(t)
+	var starts atomic.Int32
+	firstTools := make(chan struct{})
+	releaseFailure := make(chan struct{})
+	var firstToolsOnce sync.Once
+	d.handlerFunc = func(_ context.Context, stdin io.Reader, stdout io.Writer) error {
+		generation := starts.Add(1)
+		scanner := bufio.NewScanner(stdin)
+		for scanner.Scan() {
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+				return err
+			}
+			switch req.Method {
+			case "initialize":
+				if err := writeDaemonResponse(stdout, req.ID, `{"protocolVersion":"2025-11-25","capabilities":{"x-mux":{"sharing":"shared","persistent":true}},"serverInfo":{"name":"pending-persistent","version":"1"}}`); err != nil {
+					return err
+				}
+			case "tools/list":
+				if generation == 1 {
+					firstToolsOnce.Do(func() { close(firstTools) })
+					<-releaseFailure
+					return fmt.Errorf("first discovery failed")
+				}
+				if err := writeDaemonResponse(stdout, req.ID, `{"tools":[{"name":"recovered"}]}`); err != nil {
+					return err
+				}
+			case "custom/wake":
+				if err := writeDaemonResponse(stdout, req.ID, `{"ok":true}`); err != nil {
+					return err
+				}
+			}
+		}
+		return scanner.Err()
+	}
+	command := "pending-persistent-reaper"
+	d.updateTemplate(command, nil, daemonMaterializationSnapshot(false))
+	path, sid, token, err := d.Spawn(control.Request{Command: command, Mode: "global", Cwd: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	entry := d.Entry(sid)
+	conn, _ := connectSpawnedOwner(t, path, token)
+	if _, err := fmt.Fprintln(conn, `{"jsonrpc":"2.0","id":61,"method":"custom/wake","params":{}}`); err != nil {
+		t.Fatalf("write wake: %v", err)
+	}
+	select {
+	case <-firstTools:
+	case <-time.After(2 * time.Second):
+		t.Fatal("persistent declaration did not reach blocked discovery")
+	}
+	waitForDaemonCondition(t, time.Second, func() bool { return entry.Owner.PersistentPending() }, "pending persistence was not latched")
+	_ = conn.Close()
+	waitForDaemonCondition(t, time.Second, func() bool { return entry.Owner.SessionCount() == 0 }, "pending-persistent session did not close")
+	if affected := (&Reaper{daemon: d, logger: d.logger}).sweep(); affected != 0 {
+		t.Fatalf("reaper affected=%d with pending persistence", affected)
+	}
+	if d.Entry(sid) != entry {
+		t.Fatal("pending-persistent owner was replaced or removed")
+	}
+	suspend, err := d.HandleCanSuspendForOwner(token, sid)
+	if err != nil {
+		t.Fatalf("HandleCanSuspendForOwner: %v", err)
+	}
+	if suspend.Allowed || suspend.Reason != "pending_persistent" {
+		t.Fatalf("suspend=%+v, want pending_persistent denial", suspend)
+	}
+	close(releaseFailure)
+	waitForDaemonCondition(t, 3*time.Second, func() bool {
+		return starts.Load() == 2 && entry.Owner.MaterializationState() == owner.MaterializationReady
+	}, "pending persistence did not retry eagerly without demand")
+	if d.Entry(sid) != entry || starts.Load() != 2 {
+		t.Fatalf("pending persistence recovery same=%v starts=%d", d.Entry(sid) == entry, starts.Load())
+	}
+}
+
+func TestConcurrentCacheTemplateCommitAndSnapshotIsCoherentAndBounded(t *testing.T) {
+	_ = os.Remove(SnapshotPath())
+	t.Cleanup(func() { _ = os.Remove(SnapshotPath()) })
+	d := testDaemon(t)
+	publishEntered := make(chan struct{})
+	releasePublish := make(chan struct{})
+	var publishOnce sync.Once
+	d.beforeOwnerCachePublish = func(*owner.Owner) {
+		publishOnce.Do(func() { close(publishEntered) })
+		<-releasePublish
+	}
+	d.handlerFunc = func(_ context.Context, stdin io.Reader, stdout io.Writer) error {
+		scanner := bufio.NewScanner(stdin)
+		for scanner.Scan() {
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+				return err
+			}
+			switch req.Method {
+			case "initialize":
+				if err := writeDaemonResponse(stdout, req.ID, `{"protocolVersion":"2025-11-25","capabilities":{"x-mux":{"sharing":"shared"}},"serverInfo":{"name":"new-coherent","version":"2"}}`); err != nil {
+					return err
+				}
+			case "tools/list":
+				if err := writeDaemonResponse(stdout, req.ID, `{"tools":[{"name":"new-coherent-tool"}]}`); err != nil {
+					return err
+				}
+			case "custom/wake":
+				if err := writeDaemonResponse(stdout, req.ID, `{"ok":true}`); err != nil {
+					return err
+				}
+			}
+		}
+		return scanner.Err()
+	}
+	command := "snapshot-cache-commit-race"
+	oldSnapshot := daemonMaterializationSnapshot(false)
+	d.updateTemplate(command, nil, oldSnapshot)
+	path, sid, token, err := d.Spawn(control.Request{Command: command, Mode: "global", Cwd: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	entry := d.Entry(sid)
+	conn, scanner := connectSpawnedOwner(t, path, token)
+	defer conn.Close()
+	if _, err := fmt.Fprintln(conn, `{"jsonrpc":"2.0","id":71,"method":"custom/wake","params":{}}`); err != nil {
+		t.Fatalf("write wake: %v", err)
+	}
+	select {
+	case <-publishEntered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("cache/template commit did not reach publish barrier")
+	}
+	type serializeResult struct {
+		err error
+	}
+	serialized := make(chan serializeResult, 1)
+	go func() {
+		_, serializeErr := d.SerializeSnapshot()
+		serialized <- serializeResult{err: serializeErr}
+	}()
+	time.Sleep(30 * time.Millisecond)
+	close(releasePublish)
+	select {
+	case result := <-serialized:
+		if result.err != nil {
+			t.Fatalf("SerializeSnapshot: %v", result.err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("cache commit and SerializeSnapshot deadlocked")
+	}
+	readDaemonResponseID(t, scanner, "71")
+	snapshot, err := DeserializeSnapshot(d.logger)
+	if err != nil || snapshot == nil || len(snapshot.Owners) != 1 {
+		t.Fatalf("DeserializeSnapshot=(%+v,%v)", snapshot, err)
+	}
+	captured := snapshot.Owners[0]
+	tools, err := base64.StdEncoding.DecodeString(captured.CachedTools)
+	if err != nil || !strings.Contains(string(tools), "new-coherent-tool") {
+		t.Fatalf("captured tools=%s err=%v, want wholly new cache", tools, err)
+	}
+	if captured.Classification != "shared" || captured.OwnerGeneration != entry.OwnerGeneration {
+		t.Fatalf("captured metadata classification=%q owner_generation=%q, want shared/%q", captured.Classification, captured.OwnerGeneration, entry.OwnerGeneration)
+	}
+	template, ok := d.getTemplate(command, nil)
+	if !ok || template.CachedInit != captured.CachedInit || template.CachedTools != captured.CachedTools || template.Classification != captured.Classification {
+		t.Fatalf("snapshot/template mixed: snapshot=%+v template=%+v ok=%v", captured, template, ok)
+	}
+}
+
+func TestTwoTemplateRevisionMismatchesThenOneColdBypassWithoutStaleFrames(t *testing.T) {
+	d := testDaemon(t)
+	var starts atomic.Int32
+	initSeen := make(chan struct{})
+	releaseInit := make(chan struct{})
+	var initOnce sync.Once
+	d.handlerFunc = func(_ context.Context, stdin io.Reader, stdout io.Writer) error {
+		starts.Add(1)
+		scanner := bufio.NewScanner(stdin)
+		for scanner.Scan() {
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+				return err
+			}
+			switch req.Method {
+			case "initialize":
+				initOnce.Do(func() { close(initSeen) })
+				<-releaseInit
+				if err := writeDaemonResponse(stdout, req.ID, `{"protocolVersion":"2025-11-25","capabilities":{"x-mux":{"sharing":"shared"}},"serverInfo":{"name":"fresh-cold","version":"4"}}`); err != nil {
+					return err
+				}
+			case "tools/list":
+				if err := writeDaemonResponse(stdout, req.ID, `{"tools":[{"name":"fresh-cold-tool"}]}`); err != nil {
+					return err
+				}
+			}
+		}
+		return scanner.Err()
+	}
+	command := "double-template-revision-mismatch"
+	cwd := t.TempDir()
+	env := map[string]string{"SERVICE_CONFIG_PATH": "/cfg/revision"}
+	makeSnapshot := func(label string) mcpsnapshot.OwnerSnapshot {
+		snapshot := daemonMaterializationSnapshot(false)
+		snapshot.Cwd = cwd
+		snapshot.Env = mergeEnv(env)
+		snapshot.CachedInit = base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"jsonrpc":"2.0","id":"%s-init","result":{"protocolVersion":"2025-11-25","capabilities":{},"serverInfo":{"name":"%s","version":"1"}}}`, label, label)))
+		snapshot.CachedTools = base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"jsonrpc":"2.0","id":"%s-tools","result":{"tools":[{"name":"%s-tool"}]}}`, label, label)))
+		return snapshot
+	}
+	d.updateTemplate(command, nil, makeSnapshot("stale-one"))
+	var hookCalls atomic.Int32
+	d.beforeTemplatePromotion = func() {
+		switch hookCalls.Add(1) {
+		case 1:
+			d.updateTemplate(command, nil, makeSnapshot("stale-two"))
+		case 2:
+			d.updateTemplate(command, nil, makeSnapshot("stale-three"))
+		default:
+			t.Error("template promotion hook called after bounded bypass")
+		}
+	}
+	type spawnResult struct {
+		path  string
+		sid   string
+		token string
+		err   error
+	}
+	spawned := make(chan spawnResult, 1)
+	go func() {
+		path, sid, token, spawnErr := d.Spawn(control.Request{Command: command, Mode: "global", Cwd: cwd, Env: env})
+		spawned <- spawnResult{path: path, sid: sid, token: token, err: spawnErr}
+	}()
+	var result spawnResult
+	select {
+	case result = <-spawned:
+		if result.err != nil {
+			t.Fatalf("Spawn: %v", result.err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("second template mismatch livelocked instead of taking cold bypass")
+	}
+	select {
+	case <-initSeen:
+	case <-time.After(2 * time.Second):
+		t.Fatal("cold bypass did not start one fresh generation")
+	}
+	entry := d.Entry(result.sid)
+	preCommit := entry.Owner.ExportSnapshot()
+	if preCommit.CachedInit != "" || preCommit.CachedTools != "" {
+		t.Fatalf("cold bypass admitted stale cached frames: %+v", preCommit)
+	}
+	if hookCalls.Load() != 2 || starts.Load() != 1 || d.OwnerCount() != 1 {
+		t.Fatalf("bounded bypass hook_calls=%d starts=%d owners=%d", hookCalls.Load(), starts.Load(), d.OwnerCount())
+	}
+	conn, scanner := connectSpawnedOwner(t, result.path, result.token)
+	defer conn.Close()
+	if _, err := fmt.Fprintln(conn, `{"jsonrpc":"2.0","id":81,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"fresh","version":"1"}}}`); err != nil {
+		t.Fatalf("write initialize: %v", err)
+	}
+	close(releaseInit)
+	response := readDaemonResponseID(t, scanner, "81")
+	if !strings.Contains(string(response), "fresh-cold") || strings.Contains(string(response), "stale-") {
+		t.Fatalf("cold bypass response=%s", response)
+	}
+}
+
+func TestIncompatibleTemplateContextGetsNoCachedFramesAndOneColdProcess(t *testing.T) {
+	d := testDaemon(t)
+	var starts atomic.Int32
+	d.handlerFunc = func(_ context.Context, stdin io.Reader, stdout io.Writer) error {
+		starts.Add(1)
+		scanner := bufio.NewScanner(stdin)
+		for scanner.Scan() {
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+				return err
+			}
+			switch req.Method {
+			case "initialize":
+				if err := writeDaemonResponse(stdout, req.ID, `{"protocolVersion":"2025-11-25","capabilities":{"x-mux":{"sharing":"isolated"}},"serverInfo":{"name":"fresh-B","version":"1"}}`); err != nil {
+					return err
+				}
+			case "tools/list":
+				if err := writeDaemonResponse(stdout, req.ID, `{"tools":[{"name":"fresh-B-tool"}]}`); err != nil {
+					return err
+				}
+			}
+		}
+		return scanner.Err()
+	}
+	command := "scoped-template-context"
+	cwdA, cwdB := t.TempDir(), t.TempDir()
+	envA := map[string]string{"SERVICE_CONFIG_PATH": "/cfg/A"}
+	envB := map[string]string{"SERVICE_CONFIG_PATH": "/cfg/B"}
+	snapshotA := daemonMaterializationSnapshot(false)
+	snapshotA.Classification = "isolated"
+	snapshotA.Cwd = cwdA
+	snapshotA.Env = mergeEnv(envA)
+	snapshotA.CachedInit = base64.StdEncoding.EncodeToString([]byte(`{"jsonrpc":"2.0","id":"A-init","result":{"protocolVersion":"2025-11-25","capabilities":{},"serverInfo":{"name":"cached-A","version":"1"}}}`))
+	snapshotA.CachedTools = base64.StdEncoding.EncodeToString([]byte(`{"jsonrpc":"2.0","id":"A-tools","result":{"tools":[{"name":"cached-A-tool"}]}}`))
+	d.updateTemplate(command, nil, snapshotA)
+
+	pathA, sidA, tokenA, err := d.Spawn(control.Request{Command: command, Mode: "isolated", Cwd: cwdA, Env: envA})
+	if err != nil {
+		t.Fatalf("Spawn compatible A: %v", err)
+	}
+	connA, scanA := connectSpawnedOwner(t, pathA, tokenA)
+	defer connA.Close()
+	if _, err := fmt.Fprintln(connA, `{"jsonrpc":"2.0","id":91,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"A","version":"1"}}}`); err != nil {
+		t.Fatalf("write A initialize: %v", err)
+	}
+	if got := readDaemonResponseID(t, scanA, "91"); !strings.Contains(string(got), "cached-A") {
+		t.Fatalf("compatible A response=%s", got)
+	}
+	if starts.Load() != 0 || d.Entry(sidA).Owner.MaterializationState() != owner.MaterializationCacheOnly {
+		t.Fatalf("compatible A starts=%d state=%s, want handshake-only cache", starts.Load(), d.Entry(sidA).Owner.MaterializationState())
+	}
+
+	pathB, sidB, tokenB, err := d.Spawn(control.Request{Command: command, Mode: "isolated", Cwd: cwdB, Env: envB})
+	if err != nil {
+		t.Fatalf("Spawn incompatible B: %v", err)
+	}
+	if sidB == sidA {
+		t.Fatalf("incompatible B reused A sid %s", sidA)
+	}
+	connB, scanB := connectSpawnedOwner(t, pathB, tokenB)
+	defer connB.Close()
+	if _, err := fmt.Fprintln(connB, `{"jsonrpc":"2.0","id":92,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"B","version":"1"}}}`); err != nil {
+		t.Fatalf("write B initialize: %v", err)
+	}
+	responseB := readDaemonResponseID(t, scanB, "92")
+	if !strings.Contains(string(responseB), "fresh-B") || strings.Contains(string(responseB), "cached-A") || strings.Contains(string(responseB), "/cfg/A") {
+		t.Fatalf("incompatible B response leaked A state: %s", responseB)
+	}
+	waitForDaemonCondition(t, 2*time.Second, func() bool { return d.Entry(sidB).Owner.MaterializationState() == owner.MaterializationReady }, "B cold generation did not become ready")
+	if starts.Load() != 1 {
+		t.Fatalf("incompatible B process starts=%d, want exactly 1", starts.Load())
+	}
+}
+
+func TestProcessBackedIsolatedWinnerUsesInitiatorContextAndEvictsOthers(t *testing.T) {
+	const roleEnv = "MCPMUX_TEST_ISOLATED_WINNER_ROLE"
+	const observationEnv = "MCPMUX_TEST_ISOLATED_WINNER_OBSERVATION"
+	const releaseEnv = "MCPMUX_TEST_ISOLATED_WINNER_RELEASE"
+	const requestCountEnv = "MCPMUX_TEST_ISOLATED_WINNER_REQUESTS"
+	const winnerEnv = "WINNER_ONLY_MARKER"
+	const evicteeEnv = "EVICTEE_ONLY_MARKER"
+	const credentialValue = "daemon-credential-sentinel"
+	if os.Getenv(roleEnv) == "upstream" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatalf("Getwd: %v", err)
+		}
+		observation := map[string]string{
+			"cwd":        cwd,
+			"winner":     os.Getenv(winnerEnv),
+			"evictee":    os.Getenv(evicteeEnv),
+			"credential": os.Getenv("GITHUB_TOKEN"),
+		}
+		data, err := json.Marshal(observation)
+		if err != nil {
+			t.Fatalf("marshal observation: %v", err)
+		}
+		if err := os.WriteFile(os.Getenv(observationEnv), data, 0o600); err != nil {
+			t.Fatalf("write observation: %v", err)
+		}
+		deadline := time.Now().Add(10 * time.Second)
+		for {
+			if _, err := os.Stat(os.Getenv(releaseEnv)); err == nil {
+				break
+			}
+			if time.Now().After(deadline) {
+				t.Fatal("timed out waiting for isolated winner release")
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		scanner := bufio.NewScanner(os.Stdin)
+		for scanner.Scan() {
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+				t.Fatalf("decode isolated winner request: %v", err)
+			}
+			switch req.Method {
+			case "initialize":
+				if err := writeDaemonResponse(os.Stdout, req.ID, `{"protocolVersion":"2025-11-25","capabilities":{"x-mux":{"sharing":"isolated"}},"serverInfo":{"name":"isolated-winner","version":"1"}}`); err != nil {
+					t.Fatalf("write initialize: %v", err)
+				}
+			case "tools/list":
+				if err := writeDaemonResponse(os.Stdout, req.ID, `{"tools":[{"name":"winner-tool"}]}`); err != nil {
+					t.Fatalf("write tools: %v", err)
+				}
+			case "custom/wake":
+				countFile, err := os.OpenFile(os.Getenv(requestCountEnv), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+				if err != nil {
+					t.Fatalf("open request count: %v", err)
+				}
+				_, _ = fmt.Fprintln(countFile, string(req.ID))
+				_ = countFile.Close()
+				result, _ := json.Marshal(observation)
+				if err := writeDaemonResponse(os.Stdout, req.ID, string(result)); err != nil {
+					t.Fatalf("write wake: %v", err)
+				}
+			}
+		}
+		return
+	}
+
+	t.Setenv("GITHUB_TOKEN", credentialValue)
+	tmp := t.TempDir()
+	observationPath := filepath.Join(tmp, "observation.json")
+	releasePath := filepath.Join(tmp, "release")
+	requestCountPath := filepath.Join(tmp, "requests")
+	command := os.Args[0]
+	args := []string{"-test.run=^TestProcessBackedIsolatedWinnerUsesInitiatorContextAndEvictsOthers$"}
+	cwdA, cwdB := t.TempDir(), t.TempDir()
+	d := testDaemon(t)
+	common := map[string]string{
+		roleEnv:         "upstream",
+		observationEnv:  observationPath,
+		releaseEnv:      releasePath,
+		requestCountEnv: requestCountPath,
+	}
+	envA := cloneSnapshotStringMap(common)
+	envA[evicteeEnv] = "evictee-only"
+	envB := cloneSnapshotStringMap(common)
+	envB[winnerEnv] = "winner-only"
+	snapshot := daemonMaterializationSnapshot(false)
+	snapshot.Classification = "shared"
+	snapshot.Cwd = cwdA
+	snapshot.Env = mergeEnv(envA)
+	d.updateTemplate(command, args, snapshot)
+	path, sid, tokenA, err := d.Spawn(control.Request{Command: command, Args: args, Mode: "global", Cwd: cwdA, Env: envA})
+	if err != nil {
+		t.Fatalf("Spawn A: %v", err)
+	}
+	_, sidB, tokenB, err := d.Spawn(control.Request{Command: command, Args: args, Mode: "global", Cwd: cwdB, Env: envB})
+	if err != nil {
+		t.Fatalf("Spawn B: %v", err)
+	}
+	if sidB != sid {
+		t.Fatalf("compatible B sid=%s, want shared owner %s", sidB, sid)
+	}
+	entry := d.Entry(sid)
+	connA, scanA := connectSpawnedOwner(t, path, tokenA)
+	defer connA.Close()
+	connB, scanB := connectSpawnedOwner(t, path, tokenB)
+	defer connB.Close()
+	waitForDaemonCondition(t, time.Second, func() bool { return entry.Owner.SessionCount() == 2 }, "both sessions did not attach")
+	if _, err := fmt.Fprintln(connB, `{"jsonrpc":"2.0","id":201,"method":"custom/wake","params":{}}`); err != nil {
+		t.Fatalf("write winner demand: %v", err)
+	}
+	waitForDaemonCondition(t, 3*time.Second, func() bool {
+		_, statErr := os.Stat(observationPath)
+		return statErr == nil
+	}, "process-backed winner did not start")
+	if _, err := fmt.Fprintln(connA, `{"jsonrpc":"2.0","id":202,"method":"custom/wake","params":{}}`); err != nil {
+		t.Fatalf("write evictee demand: %v", err)
+	}
+	data, err := os.ReadFile(observationPath)
+	if err != nil {
+		t.Fatalf("read observation: %v", err)
+	}
+	var observation map[string]string
+	if err := json.Unmarshal(data, &observation); err != nil {
+		t.Fatalf("decode observation: %v", err)
+	}
+	if serverid.CanonicalizePath(observation["cwd"]) != serverid.CanonicalizePath(cwdB) {
+		t.Fatalf("child cwd=%q, want winner cwd %q", observation["cwd"], cwdB)
+	}
+	if observation["winner"] != "winner-only" || observation["evictee"] != "" || observation["credential"] != credentialValue {
+		t.Fatalf("child env observation=%v", observation)
+	}
+	if err := os.WriteFile(releasePath, nil, 0o600); err != nil {
+		t.Fatalf("release child: %v", err)
+	}
+	winnerResponse := readDaemonResponseID(t, scanB, "201")
+	if !strings.Contains(string(winnerResponse), `"winner":"winner-only"`) || strings.Contains(string(winnerResponse), "evictee-only") {
+		t.Fatalf("winner response=%s", winnerResponse)
+	}
+	waitForDaemonCondition(t, 2*time.Second, func() bool { return entry.Owner.IsClassifiedIsolated() && entry.Owner.SessionCount() == 1 }, "isolated commit did not retain exactly one session")
+	if err := connA.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
+		t.Fatalf("set evictee deadline: %v", err)
+	}
+	for scanA.Scan() {
+		if strings.Contains(scanA.Text(), `"id":202`) {
+			t.Fatalf("evicted waiter received a response: %s", scanA.Text())
+		}
+	}
+	requestData, _ := os.ReadFile(requestCountPath)
+	if got := len(strings.Fields(string(requestData))); got != 1 {
+		t.Fatalf("forwarded winner requests=%d, want exactly 1; data=%q", got, requestData)
+	}
+}
+
+func TestRestartCaptureZeroSessionMaterializationBarrier(t *testing.T) {
+	for _, readyBeforeCapture := range []bool{true, false} {
+		name := "ready-commit"
+		if !readyBeforeCapture {
+			name = "bounded-fallback"
+		}
+		t.Run(name, func(t *testing.T) {
+			_ = os.Remove(SnapshotPath())
+			t.Cleanup(func() { _ = os.Remove(SnapshotPath()) })
+			var starts, active, maxActive, exits atomic.Int32
+			toolsSeen := make(chan struct{})
+			releaseTools := make(chan struct{})
+			var releaseToolsOnce sync.Once
+			t.Cleanup(func() { releaseToolsOnce.Do(func() { close(releaseTools) }) })
+			var toolsOnce sync.Once
+			handler := func(ctx context.Context, stdin io.Reader, stdout io.Writer) error {
+				starts.Add(1)
+				current := active.Add(1)
+				for {
+					max := maxActive.Load()
+					if current <= max || maxActive.CompareAndSwap(max, current) {
+						break
+					}
+				}
+				defer func() {
+					active.Add(-1)
+					exits.Add(1)
+				}()
+				generation := starts.Load()
+				scanner := bufio.NewScanner(stdin)
+				for scanner.Scan() {
+					var req struct {
+						ID     json.RawMessage `json:"id"`
+						Method string          `json:"method"`
+					}
+					if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+						return err
+					}
+					if len(req.ID) == 0 {
+						continue
+					}
+					switch req.Method {
+					case "initialize":
+						if err := writeDaemonResponse(stdout, req.ID, `{"protocolVersion":"2025-11-25","capabilities":{"x-mux":{"sharing":"shared"}},"serverInfo":{"name":"restart-capture","version":"1"}}`); err != nil {
+							return err
+						}
+					case "tools/list":
+						if generation == 1 {
+							toolsOnce.Do(func() { close(toolsSeen) })
+							select {
+							case <-releaseTools:
+							case <-ctx.Done():
+								return ctx.Err()
+							}
+						}
+						if err := writeDaemonResponse(stdout, req.ID, `{"tools":[{"name":"restart-fresh"}]}`); err != nil {
+							return err
+						}
+					default:
+						if err := writeDaemonResponse(stdout, req.ID, `{"ok":true}`); err != nil {
+							return err
+						}
+					}
+				}
+				return scanner.Err()
+			}
+
+			d, err := New(Config{
+				Name:                    "restart-capture-zero-session",
+				ControlPath:             shortSocketPath(t, "restart-capture.ctl"),
+				SkipSnapshot:            true,
+				HandlerFunc:             handler,
+				OwnerIdleTimeout:        time.Minute,
+				ZeroSessionCleanupDelay: 20 * time.Millisecond,
+			})
+			if err != nil {
+				t.Fatalf("New daemon: %v", err)
+			}
+			t.Cleanup(d.Shutdown)
+			command := "restart-capture-upstream"
+			template := daemonMaterializationSnapshot(false)
+			template.Cwd = "/cached/restart"
+			template.Env = map[string]string{"CACHED_SENTINEL": "old"}
+			d.updateTemplate(command, nil, template)
+			path, sid, token, err := d.Spawn(control.Request{Command: command, Mode: "global", Cwd: "/winner/restart", Env: map[string]string{"WINNER_SENTINEL": "winner"}})
+			if err != nil {
+				t.Fatalf("Spawn: %v", err)
+			}
+			entry := d.Entry(sid)
+			conn, _ := connectSpawnedOwner(t, path, token)
+			if _, err := fmt.Fprintln(conn, `{"jsonrpc":"2.0","id":301,"method":"custom/wake","params":{}}`); err != nil {
+				t.Fatalf("write demand: %v", err)
+			}
+			select {
+			case <-toolsSeen:
+			case <-time.After(2 * time.Second):
+				t.Fatal("materialization did not reach tools barrier")
+			}
+
+			type snapshotResult struct {
+				path  string
+				lease *snapshotRestartLease
+				err   error
+			}
+			resultCh := make(chan snapshotResult, 1)
+			go func() {
+				path, lease, serializeErr := d.serializeSnapshotPinned()
+				resultCh <- snapshotResult{path: path, lease: lease, err: serializeErr}
+			}()
+			waitForDaemonCondition(t, time.Second, func() bool {
+				return entry.Owner.Status()["restart_pin_count"] == int64(1)
+			}, "restart pin was not acquired")
+			_ = conn.Close()
+			waitForDaemonCondition(t, time.Second, func() bool { return entry.Owner.SessionCount() == 0 }, "session did not close")
+			if affected := (&Reaper{daemon: d, logger: d.logger}).sweep(); affected != 0 || d.Entry(sid) != entry {
+				t.Fatalf("reaper crossed live restart pin: affected=%d same=%v", affected, d.Entry(sid) == entry)
+			}
+			if readyBeforeCapture {
+				releaseToolsOnce.Do(func() { close(releaseTools) })
+			}
+			var result snapshotResult
+			select {
+			case result = <-resultCh:
+			case <-time.After(8 * time.Second):
+				t.Fatal("snapshot capture did not settle")
+			}
+			if affected := (&Reaper{daemon: d, logger: d.logger}).sweep(); affected != 0 || d.Entry(sid) != entry {
+				t.Fatalf("reaper removed leased owner: affected=%d same=%v", affected, d.Entry(sid) == entry)
+			}
+			if maxActive.Load() != 1 || starts.Load() != 1 {
+				t.Fatalf("pre-capture generations starts=%d max=%d", starts.Load(), maxActive.Load())
+			}
+			if !readyBeforeCapture && entry.Owner.MaterializationState() != owner.MaterializationCacheOnly {
+				t.Fatalf("bounded capture state=%s, want CACHE_ONLY", entry.Owner.MaterializationState())
+			}
+			if !readyBeforeCapture {
+				releaseToolsOnce.Do(func() { close(releaseTools) })
+				waitForDaemonCondition(t, time.Second, func() bool { return exits.Load() == 1 }, "retired handler did not drain")
+			}
+			if result.err != nil || result.path == "" || result.lease == nil {
+				t.Fatalf("SerializeSnapshotPinned = (%q, %v, %v)", result.path, result.lease, result.err)
+			}
+			snapshot, err := DeserializeSnapshot(d.logger)
+			if err != nil || snapshot == nil || len(snapshot.Owners) != 1 {
+				t.Fatalf("captured snapshot=%#v err=%v", snapshot, err)
+			}
+			captured := snapshot.Owners[0]
+			if captured.Cwd != "/winner/restart" || captured.Env["WINNER_SENTINEL"] != "winner" {
+				t.Fatalf("captured launch context=%+v", captured)
+			}
+			tools, err := base64.StdEncoding.DecodeString(captured.CachedTools)
+			if err != nil {
+				t.Fatalf("decode tools: %v", err)
+			}
+			if readyBeforeCapture {
+				if !strings.Contains(string(tools), "restart-fresh") || entry.Owner.MaterializationState() != owner.MaterializationReady {
+					t.Fatalf("ready capture state=%s tools=%s", entry.Owner.MaterializationState(), tools)
+				}
+				result.lease.Release()
+				time.Sleep(50 * time.Millisecond)
+				if starts.Load() != 1 || maxActive.Load() != 1 {
+					t.Fatalf("ready capture spawned replacement: starts=%d max=%d", starts.Load(), maxActive.Load())
+				}
+				return
+			}
+			if captured.CachedTools != template.CachedTools {
+				t.Fatalf("bounded fallback published partial tools: got=%q want=%q", captured.CachedTools, template.CachedTools)
+			}
+			entry.Owner.Shutdown()
+			result.lease.Release()
+			successor, err := owner.NewOwnerFromSnapshot(owner.OwnerConfig{
+				HandlerFunc:           handler,
+				IPCPath:               shortSocketPath(t, "restart-capture-successor.sock"),
+				MaterializationPolicy: owner.MaterializationEager,
+			}, captured)
+			if err != nil {
+				t.Fatalf("hydrate successor: %v", err)
+			}
+			t.Cleanup(successor.Shutdown)
+			successor.SpawnUpstreamBackground()
+			waitForDaemonCondition(t, 2*time.Second, func() bool {
+				return starts.Load() == 2 && successor.MaterializationState() == owner.MaterializationReady
+			}, "successor eager restore did not start after predecessor finalization")
+			if maxActive.Load() != 1 || exits.Load() < 1 {
+				t.Fatalf("successor overlapped predecessor: starts=%d exits=%d max=%d", starts.Load(), exits.Load(), maxActive.Load())
+			}
+		})
+	}
+}
+
+func TestPersistentWinningContextSurvivesRestartHydration(t *testing.T) {
+	_ = os.Remove(SnapshotPath())
+	t.Cleanup(func() { _ = os.Remove(SnapshotPath()) })
+	t.Setenv("GITHUB_TOKEN", "daemon-credential")
+	releaseFirstTools := make(chan struct{})
+	var releaseFirstToolsOnce sync.Once
+	t.Cleanup(func() { releaseFirstToolsOnce.Do(func() { close(releaseFirstTools) }) })
+	var starts, active, maxActive, exits atomic.Int32
+	initSeen := make(chan struct{})
+	toolsSeen := make(chan struct{})
+	var initOnce, toolsOnce sync.Once
+	handler := func(_ context.Context, stdin io.Reader, stdout io.Writer) error {
+		generation := starts.Add(1)
+		current := active.Add(1)
+		for {
+			max := maxActive.Load()
+			if current <= max || maxActive.CompareAndSwap(max, current) {
+				break
+			}
+		}
+		defer func() {
+			active.Add(-1)
+			exits.Add(1)
+		}()
+		scanner := bufio.NewScanner(stdin)
+		for scanner.Scan() {
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+				return err
+			}
+			if len(req.ID) == 0 {
+				continue
+			}
+			switch req.Method {
+			case "initialize":
+				if err := writeDaemonResponse(stdout, req.ID, `{"protocolVersion":"2025-11-25","capabilities":{"x-mux":{"sharing":"shared","persistent":true}},"serverInfo":{"name":"persistent-restart","version":"1"}}`); err != nil {
+					return err
+				}
+				if generation == 1 {
+					initOnce.Do(func() { close(initSeen) })
+				}
+			case "tools/list":
+				if generation == 1 {
+					toolsOnce.Do(func() { close(toolsSeen) })
+					<-releaseFirstTools
+					return fmt.Errorf("retired first persistent generation")
+				}
+				if err := writeDaemonResponse(stdout, req.ID, `{"tools":[{"name":"persistent-ready"}]}`); err != nil {
+					return err
+				}
+			default:
+				if err := writeDaemonResponse(stdout, req.ID, `{"ok":true}`); err != nil {
+					return err
+				}
+			}
+		}
+		return scanner.Err()
+	}
+
+	d, err := New(Config{
+		Name:                    "persistent-winning-context",
+		ControlPath:             shortSocketPath(t, "persistent-winning.ctl"),
+		SkipSnapshot:            true,
+		HandlerFunc:             handler,
+		OwnerIdleTimeout:        time.Minute,
+		ZeroSessionCleanupDelay: 20 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("New predecessor: %v", err)
+	}
+	t.Cleanup(d.Shutdown)
+	command := "persistent-winning-upstream"
+	template := daemonMaterializationSnapshot(false)
+	d.updateTemplate(command, nil, template)
+	path, sid, tokenA, err := d.Spawn(control.Request{Command: command, Mode: "global", Cwd: "/project/A", Env: map[string]string{"SESSION_SENTINEL": "A"}})
+	if err != nil {
+		t.Fatalf("Spawn A: %v", err)
+	}
+	_, sidB, tokenB, err := d.Spawn(control.Request{Command: command, Mode: "global", Cwd: "/project/B", Env: map[string]string{"SESSION_SENTINEL": "B"}})
+	if err != nil || sidB != sid {
+		t.Fatalf("Spawn B = (%s, %v), want shared owner %s", sidB, err, sid)
+	}
+	entry := d.Entry(sid)
+	connA, _ := connectSpawnedOwner(t, path, tokenA)
+	connB, _ := connectSpawnedOwner(t, path, tokenB)
+	if _, err := fmt.Fprintln(connB, `{"jsonrpc":"2.0","id":401,"method":"custom/wake","params":{}}`); err != nil {
+		t.Fatalf("write B demand: %v", err)
+	}
+	select {
+	case <-initSeen:
+	case <-time.After(2 * time.Second):
+		t.Fatal("persistent initialize did not complete")
+	}
+	select {
+	case <-toolsSeen:
+	case <-time.After(2 * time.Second):
+		t.Fatal("persistent generation did not block at tools")
+	}
+	waitForDaemonCondition(t, time.Second, entry.Owner.PersistentPending, "pending persistence was not latched")
+
+	type snapshotResult struct {
+		lease *snapshotRestartLease
+		err   error
+	}
+	resultCh := make(chan snapshotResult, 1)
+	go func() {
+		_, lease, serializeErr := d.serializeSnapshotPinned()
+		resultCh <- snapshotResult{lease: lease, err: serializeErr}
+	}()
+	waitForDaemonCondition(t, time.Second, func() bool {
+		return entry.Owner.Status()["restart_pin_count"] == int64(1)
+	}, "persistent restart pin was not acquired")
+	_ = connA.Close()
+	_ = connB.Close()
+	waitForDaemonCondition(t, time.Second, func() bool { return entry.Owner.SessionCount() == 0 }, "persistent sessions did not close")
+	if affected := (&Reaper{daemon: d, logger: d.logger}).sweep(); affected != 0 || d.Entry(sid) != entry {
+		t.Fatalf("reaper crossed pending-persistent pin: affected=%d same=%v", affected, d.Entry(sid) == entry)
+	}
+	var result snapshotResult
+	select {
+	case result = <-resultCh:
+	case <-time.After(8 * time.Second):
+		t.Fatal("persistent restart capture did not settle")
+	}
+	if starts.Load() != 1 || maxActive.Load() != 1 {
+		t.Fatalf("predecessor authority starts=%d max=%d", starts.Load(), maxActive.Load())
+	}
+	releaseFirstToolsOnce.Do(func() { close(releaseFirstTools) })
+	waitForDaemonCondition(t, time.Second, func() bool { return exits.Load() == 1 }, "retired persistent handler did not drain")
+	if result.err != nil || result.lease == nil {
+		t.Fatalf("SerializeSnapshotPinned = (%v, %v)", result.lease, result.err)
+	}
+	snapshot, err := DeserializeSnapshot(d.logger)
+	if err != nil || snapshot == nil || len(snapshot.Owners) != 1 {
+		t.Fatalf("captured snapshot=%#v err=%v", snapshot, err)
+	}
+	captured := snapshot.Owners[0]
+	if captured.Cwd != "/project/B" || captured.Env["SESSION_SENTINEL"] != "B" || captured.Env["GITHUB_TOKEN"] != "daemon-credential" || !captured.Persistent {
+		t.Fatalf("persistent winning context not captured: %+v", captured)
+	}
+	entry.Owner.Shutdown()
+	result.lease.Release()
+
+	successorDaemon, err := New(Config{
+		Name:         "persistent-winning-successor",
+		ControlPath:  shortSocketPath(t, "persistent-winning-successor.ctl"),
+		SkipSnapshot: true,
+		HandlerFunc:  handler,
+		IdleTimeout:  time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("New successor: %v", err)
+	}
+	t.Cleanup(successorDaemon.Shutdown)
+	plan := successorDaemon.makeSnapshotRestorePlan(captured)
+	successorEntry, reattached, err := successorDaemon.restoreSnapshotPlan(plan, nil, "snapshot_fallback", true, true)
+	if err != nil || reattached {
+		t.Fatalf("restore successor = (%v, %v)", reattached, err)
+	}
+	waitForDaemonCondition(t, 2*time.Second, func() bool {
+		return starts.Load() == 2 && successorEntry.Owner.MaterializationState() == owner.MaterializationReady
+	}, "persistent successor did not reach one ready generation")
+	if maxActive.Load() != 1 || successorEntry.Owner.ExportSnapshot().Cwd != "/project/B" || successorEntry.Owner.ExportSnapshot().Env["SESSION_SENTINEL"] != "B" {
+		t.Fatalf("successor context/authority mismatch: starts=%d max=%d snapshot=%+v", starts.Load(), maxActive.Load(), successorEntry.Owner.ExportSnapshot())
+	}
+	if !successorEntry.Persistent {
+		t.Fatal("successor lost committed persistence")
+	}
+	if affected := (&Reaper{daemon: successorDaemon, logger: successorDaemon.logger}).sweep(); affected != 0 || successorDaemon.Entry(sid) != successorEntry {
+		t.Fatalf("persistent successor was evicted: affected=%d same=%v", affected, successorDaemon.Entry(sid) == successorEntry)
+	}
+	time.Sleep(50 * time.Millisecond)
+	if starts.Load() != 2 || successorEntry.Owner.Status()["upstream_live"] != true {
+		t.Fatalf("persistent successor duplicated or suspended: starts=%d status=%+v", starts.Load(), successorEntry.Owner.Status())
+	}
+}

--- a/muxcore/daemon/materialization_test.go
+++ b/muxcore/daemon/materialization_test.go
@@ -34,12 +34,24 @@ func daemonMaterializationSnapshot(persistent bool) mcpsnapshot.OwnerSnapshot {
 	}
 }
 
+type testReadDeadlineConn struct {
+	net.Conn
+}
+
+func (c *testReadDeadlineConn) Read(p []byte) (int, error) {
+	if err := c.Conn.SetReadDeadline(time.Now().Add(3 * time.Second)); err != nil {
+		return 0, err
+	}
+	return c.Conn.Read(p)
+}
+
 func connectSpawnedOwner(t *testing.T, path, token string) (net.Conn, *bufio.Scanner) {
 	t.Helper()
-	conn, err := ipc.Dial(path)
+	rawConn, err := ipc.Dial(path)
 	if err != nil {
 		t.Fatalf("ipc.Dial: %v", err)
 	}
+	conn := &testReadDeadlineConn{Conn: rawConn}
 	if _, err := fmt.Fprintln(conn, token); err != nil {
 		_ = conn.Close()
 		t.Fatalf("write handshake token: %v", err)
@@ -82,6 +94,30 @@ func readDaemonResponseID(t *testing.T, scanner *bufio.Scanner, id string) []byt
 func writeDaemonResponse(w io.Writer, id json.RawMessage, result string) error {
 	_, err := fmt.Fprintf(w, `{"jsonrpc":"2.0","id":%s,"result":%s}`+"\n", id, result)
 	return err
+}
+
+func TestRejectedOwnerCachePublishDoesNotCommitPersistence(t *testing.T) {
+	d := testDaemon(t)
+	command := "rejected-owner-cache-publish"
+	d.updateTemplate(command, nil, daemonMaterializationSnapshot(false))
+	_, sid, _, err := d.Spawn(control.Request{Command: command, Mode: "global", Cwd: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	defer d.Remove(sid) //nolint:errcheck
+
+	entry := d.Entry(sid)
+	if entry == nil || entry.Owner == nil {
+		t.Fatalf("spawned owner %q missing", sid)
+	}
+	rejected := daemonMaterializationSnapshot(true)
+	rejected.CachedTools = ""
+	if d.publishOwnerCache(entry.Owner, rejected) {
+		t.Fatal("invalid cache snapshot was published")
+	}
+	if entry.Persistent {
+		t.Fatal("rejected cache publication committed owner persistence")
+	}
 }
 
 func TestSpawnTemplateCacheHitStaysCacheOnlyAndServesTools(t *testing.T) {
@@ -603,8 +639,13 @@ func TestColdFastHandlerPublishesOnlyAfterExactOwnerRegistration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Spawn: %v", err)
 	}
-	if err := <-promotionCheck; err != nil {
-		t.Fatal(err)
+	select {
+	case err := <-promotionCheck:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("cold owner promotion check did not complete")
 	}
 	select {
 	case err := <-publishCheck:

--- a/muxcore/daemon/materialization_test.go
+++ b/muxcore/daemon/materialization_test.go
@@ -30,6 +30,7 @@ func daemonMaterializationSnapshot(persistent bool) mcpsnapshot.OwnerSnapshot {
 		Classification: "shared",
 		CachedInit:     base64.StdEncoding.EncodeToString([]byte(initResp)),
 		CachedTools:    base64.StdEncoding.EncodeToString([]byte(toolsResp)),
+		Env:            mergeEnv(nil),
 		Persistent:     persistent,
 	}
 }
@@ -165,7 +166,7 @@ func TestTemplateCacheRequiresCompatibleContext(t *testing.T) {
 		cwdA := t.TempDir()
 		snap := daemonMaterializationSnapshot(false)
 		snap.Cwd = cwdA
-		snap.Env = map[string]string{"MCPMUX_TEMPLATE_TEST_TOKEN": "same"}
+		snap.Env = mergeEnv(map[string]string{"MCPMUX_TEMPLATE_TEST_TOKEN": "same"})
 		d.updateTemplate(command, nil, snap)
 
 		_, sid, _, err := d.Spawn(control.Request{
@@ -187,7 +188,7 @@ func TestTemplateCacheRequiresCompatibleContext(t *testing.T) {
 		command := "definitely-not-a-real-env-mismatch-command"
 		snap := daemonMaterializationSnapshot(false)
 		snap.Cwd = t.TempDir()
-		snap.Env = map[string]string{"MCPMUX_TEMPLATE_TEST_TOKEN": "A"}
+		snap.Env = mergeEnv(map[string]string{"MCPMUX_TEMPLATE_TEST_TOKEN": "A"})
 		d.updateTemplate(command, nil, snap)
 
 		if _, _, _, err := d.Spawn(control.Request{
@@ -207,7 +208,7 @@ func TestTemplateCacheRequiresCompatibleContext(t *testing.T) {
 		snap := daemonMaterializationSnapshot(false)
 		snap.Classification = "isolated"
 		snap.Cwd = cwdA
-		snap.Env = map[string]string{"MCPMUX_TEMPLATE_TEST_TOKEN": "same"}
+		snap.Env = mergeEnv(map[string]string{"MCPMUX_TEMPLATE_TEST_TOKEN": "same"})
 		d.updateTemplate(command, nil, snap)
 
 		if _, _, _, err := d.Spawn(control.Request{
@@ -228,12 +229,12 @@ func TestTemplateRevisionRevalidatedBeforePromotion(t *testing.T) {
 	env := map[string]string{"MCPMUX_TEMPLATE_TEST_TOKEN": "same"}
 	oldSnap := daemonMaterializationSnapshot(false)
 	oldSnap.Cwd = cwd
-	oldSnap.Env = env
+	oldSnap.Env = mergeEnv(env)
 	d.updateTemplate(command, nil, oldSnap)
 
 	newSnap := daemonMaterializationSnapshot(false)
 	newSnap.Cwd = cwd
-	newSnap.Env = env
+	newSnap.Env = mergeEnv(env)
 	newTools := `{"jsonrpc":"2.0","id":"cached-tools","result":{"tools":[{"name":"new-template-tool"}]}}`
 	newSnap.CachedTools = base64.StdEncoding.EncodeToString([]byte(newTools))
 	var hookCalls atomic.Int32
@@ -271,7 +272,7 @@ func TestTemplateInvalidationPreventsStalePromotion(t *testing.T) {
 	env := map[string]string{"MCPMUX_TEMPLATE_TEST_TOKEN": "same"}
 	snap := daemonMaterializationSnapshot(false)
 	snap.Cwd = cwd
-	snap.Env = env
+	snap.Env = mergeEnv(env)
 	d.updateTemplate(command, nil, snap)
 
 	var hookCalls atomic.Int32
@@ -536,7 +537,7 @@ func TestSerializeSnapshotDuringMaterializationPreservesLiveSession(t *testing.T
 	t.Cleanup(func() { d.Shutdown() })
 	command := "snapshot-materialization-upstream"
 	template := daemonMaterializationSnapshot(false)
-	template.Env = map[string]string{"GITHUB_TOKEN": "snapshot-secret"}
+	template.Env = mergeEnv(map[string]string{"GITHUB_TOKEN": "snapshot-secret"})
 	d.updateTemplate(command, nil, template)
 	path, sid, token, err := d.Spawn(control.Request{Command: command, Mode: "global", Cwd: t.TempDir(), Env: map[string]string{"GITHUB_TOKEN": "snapshot-secret"}})
 	if err != nil {
@@ -819,6 +820,7 @@ func TestMaterializationFreshSharedTemplateKeepsLiveOwnerIsolated(t *testing.T) 
 	const command = "t044-command"
 	args := []string{"--serve"}
 	env := map[string]string{"SERVICE_CONFIG_PATH": "/cfg/t044"}
+	effectiveEnv := mergeEnv(env)
 	handler := func(_ context.Context, stdin io.Reader, stdout io.Writer) error {
 		scanner := bufio.NewScanner(stdin)
 		for scanner.Scan() {
@@ -847,12 +849,12 @@ func TestMaterializationFreshSharedTemplateKeepsLiveOwnerIsolated(t *testing.T) 
 	snap.Classification = "isolated"
 	snap.ClassificationSource = "capability"
 	snap.Cwd = "/project/live"
-	snap.Env = env
+	snap.Env = effectiveEnv
 	o, err := owner.NewOwnerFromSnapshot(owner.OwnerConfig{
 		Command:               command,
 		Args:                  args,
 		Cwd:                   snap.Cwd,
-		Env:                   env,
+		Env:                   effectiveEnv,
 		HandlerFunc:           handler,
 		IPCPath:               shortSocketPath(t, "t044-owner.sock"),
 		ServerID:              sid,
@@ -865,7 +867,7 @@ func TestMaterializationFreshSharedTemplateKeepsLiveOwnerIsolated(t *testing.T) 
 	}
 	defer o.Shutdown()
 	d.mu.Lock()
-	d.owners[sid] = &OwnerEntry{Owner: o, ServerID: sid, Command: command, Args: args, Cwd: snap.Cwd, Env: env}
+	d.owners[sid] = &OwnerEntry{Owner: o, ServerID: sid, Command: command, Args: args, Cwd: snap.Cwd, Env: effectiveEnv}
 	d.mu.Unlock()
 
 	if err := o.StartInitialMaterialization(); err != nil {
@@ -1778,7 +1780,7 @@ func TestRestartCaptureZeroSessionMaterializationBarrier(t *testing.T) {
 			command := "restart-capture-upstream"
 			template := daemonMaterializationSnapshot(false)
 			template.Cwd = "/cached/restart"
-			template.Env = map[string]string{"CACHED_SENTINEL": "old"}
+			template.Env = mergeEnv(map[string]string{"CACHED_SENTINEL": "old"})
 			d.updateTemplate(command, nil, template)
 			path, sid, token, err := d.Spawn(control.Request{Command: command, Mode: "global", Cwd: "/winner/restart", Env: map[string]string{"WINNER_SENTINEL": "winner"}})
 			if err != nil {

--- a/muxcore/daemon/owner_lifecycle.go
+++ b/muxcore/daemon/owner_lifecycle.go
@@ -151,6 +151,14 @@ func (d *Daemon) finalizeAndRemoveOwner(serverID string, expected *OwnerEntry, r
 			d.mu.Unlock()
 			return result, nil
 		}
+		if current.removalInProgress {
+			settled := current.removalDone
+			d.mu.Unlock()
+			if err := waitForOwnerRemovalAttempt(serverID, settled); err != nil {
+				return result, err
+			}
+			continue
+		}
 		if current.snapshotPins > 0 {
 			unpinned := current.snapshotUnpinned
 			d.mu.Unlock()
@@ -160,6 +168,7 @@ func (d *Daemon) finalizeAndRemoveOwner(serverID string, expected *OwnerEntry, r
 			continue
 		}
 		current.removalInProgress = true
+		current.removalDone = make(chan struct{})
 		current.terminationHint = terminationHintForRemoval(reason)
 		entry = current
 		d.mu.Unlock()
@@ -169,9 +178,7 @@ func (d *Daemon) finalizeAndRemoveOwner(serverID string, expected *OwnerEntry, r
 	exitCode, finalized, finalizationErr := d.finalizeOwnerWithRetry(entry.Owner, soft)
 	if !finalized {
 		d.mu.Lock()
-		if current := d.owners[serverID]; current == entry {
-			entry.removalInProgress = false
-		}
+		finishOwnerRemovalAttemptLocked(entry)
 		d.mu.Unlock()
 		if scheduleRetry {
 			d.scheduleOwnerFinalizationRetry(serverID, entry, reason, soft)
@@ -182,14 +189,50 @@ func (d *Daemon) finalizeAndRemoveOwner(serverID string, expected *OwnerEntry, r
 	d.mu.Lock()
 	current, ok := d.owners[serverID]
 	if !ok || current != entry {
+		finishOwnerRemovalAttemptLocked(entry)
 		d.mu.Unlock()
 		return result, finalizationErr
 	}
+	if entry.snapshotPins > 0 {
+		finishOwnerRemovalAttemptLocked(entry)
+		d.mu.Unlock()
+		pinErr := fmt.Errorf("owner %s gained a snapshot pin during finalization", shortServerID(serverID))
+		if scheduleRetry {
+			d.scheduleOwnerFinalizationRetry(serverID, entry, reason, soft)
+		}
+		return result, errors.Join(finalizationErr, pinErr)
+	}
+	finishOwnerRemovalAttemptLocked(entry)
 	prepared := d.prepareOwnerRemovalLocked(serverID, entry, reason, soft)
 	prepared.exitCode = exitCode
 	prepared.finalizationErr = finalizationErr
 	d.mu.Unlock()
 	return prepared.result, errors.Join(finalizationErr, d.finishOwnerRemoval(prepared))
+}
+
+func finishOwnerRemovalAttemptLocked(entry *OwnerEntry) {
+	if entry == nil || !entry.removalInProgress {
+		return
+	}
+	entry.removalInProgress = false
+	if entry.removalDone != nil {
+		close(entry.removalDone)
+		entry.removalDone = nil
+	}
+}
+
+func waitForOwnerRemovalAttempt(serverID string, settled <-chan struct{}) error {
+	if settled == nil {
+		return fmt.Errorf("server %s removal attempt missing completion signal", serverID)
+	}
+	timer := time.NewTimer(snapshotPinWaitTimeout)
+	defer timer.Stop()
+	select {
+	case <-settled:
+		return nil
+	case <-timer.C:
+		return fmt.Errorf("server %s removal attempt did not settle within %s", serverID, snapshotPinWaitTimeout)
+	}
 }
 
 func (d *Daemon) finalizeOwnerWithRetry(ownerRef *owner.Owner, soft bool) (int, bool, error) {

--- a/muxcore/daemon/owner_lifecycle.go
+++ b/muxcore/daemon/owner_lifecycle.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -21,6 +22,16 @@ const (
 	ownerRemovalReasonUpstreamExit  ownerRemovalReason = "upstream_exit"
 )
 
+const (
+	snapshotPinWaitTimeout      = 30 * time.Second
+	ownerFinalizationAttempts   = 3
+	ownerFinalizationRetryDelay = 10 * time.Millisecond
+)
+
+var finalizeOwnerForRemoval = func(o *owner.Owner, soft bool) (int, bool, error) {
+	return o.FinalizeForRemoval(soft, 30*time.Second)
+}
+
 type ownerRemovalResult struct {
 	ServerID             string
 	Reason               ownerRemovalReason
@@ -38,9 +49,10 @@ type ownerRemovalStats struct {
 }
 
 type preparedOwnerRemoval struct {
-	result   ownerRemovalResult
-	token    suture.ServiceToken
-	ownerRef *owner.Owner
+	result          ownerRemovalResult
+	token           suture.ServiceToken
+	exitCode        int
+	finalizationErr error
 }
 
 func newOwnerRemovalStats() ownerRemovalStats {
@@ -65,60 +77,40 @@ func (d *Daemon) removeOwner(serverID string, reason ownerRemovalReason, soft bo
 }
 
 func (d *Daemon) removeOwnerIfCurrent(serverID string, expected *OwnerEntry, reason ownerRemovalReason, soft bool) (ownerRemovalResult, error) {
-	result := ownerRemovalResult{ServerID: serverID, Reason: reason, Soft: soft}
-
-	d.mu.Lock()
-	entry, ok := d.owners[serverID]
-	if !ok {
-		d.mu.Unlock()
-		return result, fmt.Errorf("server %s not found", serverID)
-	}
-	if expected != nil && entry != expected {
-		d.mu.Unlock()
-		return result, nil
-	}
-	if entry.Owner == nil {
-		d.mu.Unlock()
-		return result, fmt.Errorf("server %s is still being created", serverID)
-	}
-
-	prepared := d.prepareOwnerRemovalLocked(serverID, entry, reason, soft)
-	d.mu.Unlock()
-
-	return prepared.result, d.finishOwnerRemoval(prepared)
+	return d.finalizeAndRemoveOwner(serverID, expected, reason, soft, nil, true)
 }
 
 func (d *Daemon) removeOwnerIfCurrentAndZeroIdle(serverID string, expected *OwnerEntry, zeroAt time.Time, idleTimeout time.Duration) (ownerRemovalResult, bool, error) {
 	result := ownerRemovalResult{ServerID: serverID, Reason: ownerRemovalReasonIdle, Soft: true}
-
-	d.mu.Lock()
+	d.mu.RLock()
 	entry, ok := d.owners[serverID]
-	if !ok || (expected != nil && entry != expected) || entry.Owner == nil {
-		d.mu.Unlock()
+	if !ok || (expected != nil && entry != expected) || entry == nil || entry.Owner == nil || !entry.LastSession.Equal(zeroAt) {
+		d.mu.RUnlock()
 		return result, false, nil
 	}
-	if !entry.LastSession.Equal(zeroAt) {
-		d.mu.Unlock()
-		return result, false, nil
-	}
+	ownerRef := entry.Owner
+	persistent := entry.Persistent
+	lastSession := entry.LastSession
+	d.mu.RUnlock()
 
 	sample := evictionSample{
-		Sessions:             entry.Owner.SessionCount(),
-		PendingSessions:      entry.Owner.SessionMgr().PendingCount(),
-		Persistent:           entry.Persistent,
-		PendingRequests:      entry.Owner.PendingRequests(),
-		ActiveProgressTokens: entry.Owner.ActiveProgressTokens(),
-		HasBusyWork:          entry.Owner.HasActiveBusyWork(),
-		UpstreamDead:         entry.Owner.UpstreamDead(),
-		IdleTimeout:          idleTimeout,
-		OwnerIdleOverride:    entry.Owner.IdleTimeout(),
-		LastSession:          entry.LastSession,
-		LastActivity:         entry.Owner.LastActivity(),
-		IsolatedClassified:   entry.Owner.IsClassifiedIsolated(),
+		Sessions:               ownerRef.SessionCount(),
+		PendingSessions:        ownerRef.SessionMgr().PendingCount(),
+		Persistent:             persistent,
+		PendingRequests:        ownerRef.PendingRequests(),
+		ActiveProgressTokens:   ownerRef.ActiveProgressTokens(),
+		HasBusyWork:            ownerRef.HasActiveBusyWork(),
+		UpstreamDead:           ownerRef.UpstreamDead(),
+		CacheReady:             ownerRef.CacheReady(),
+		MaterializationBlocked: ownerRef.MaterializationBlocksEviction(),
+		IdleTimeout:            idleTimeout,
+		OwnerIdleOverride:      ownerRef.IdleTimeout(),
+		LastSession:            lastSession,
+		LastActivity:           ownerRef.LastActivity(),
+		IsolatedClassified:     ownerRef.IsClassifiedIsolated(),
 	}
 	decision := shouldEvict(sample, time.Now(), idleTimeout, 0)
 	if !decision.evict {
-		d.mu.Unlock()
 		return result, false, nil
 	}
 
@@ -128,25 +120,152 @@ func (d *Daemon) removeOwnerIfCurrentAndZeroIdle(serverID string, expected *Owne
 		reason = ownerRemovalReasonZombie
 		soft = false
 	}
-	prepared := d.prepareOwnerRemovalLocked(serverID, entry, reason, soft)
-	d.mu.Unlock()
+	removed, err := d.finalizeAndRemoveOwner(serverID, entry, reason, soft, func(current *OwnerEntry) bool {
+		return current.LastSession.Equal(zeroAt)
+	}, true)
+	return removed, removed.Removed, err
+}
 
-	return prepared.result, true, d.finishOwnerRemoval(prepared)
+func (d *Daemon) finalizeAndRemoveOwner(serverID string, expected *OwnerEntry, reason ownerRemovalReason, soft bool, eligible func(*OwnerEntry) bool, scheduleRetry bool) (ownerRemovalResult, error) {
+	result := ownerRemovalResult{ServerID: serverID, Reason: reason, Soft: soft}
+	var entry *OwnerEntry
+	for {
+		d.mu.Lock()
+		current, ok := d.owners[serverID]
+		if !ok {
+			d.mu.Unlock()
+			if expected == nil {
+				return result, fmt.Errorf("server %s not found", serverID)
+			}
+			return result, nil
+		}
+		if expected != nil && current != expected {
+			d.mu.Unlock()
+			return result, nil
+		}
+		if current.Owner == nil {
+			d.mu.Unlock()
+			return result, fmt.Errorf("server %s is still being created", serverID)
+		}
+		if eligible != nil && !eligible(current) {
+			d.mu.Unlock()
+			return result, nil
+		}
+		if current.snapshotPins > 0 {
+			unpinned := current.snapshotUnpinned
+			d.mu.Unlock()
+			if err := waitForSnapshotUnpin(serverID, unpinned); err != nil {
+				return result, err
+			}
+			continue
+		}
+		current.removalInProgress = true
+		current.terminationHint = terminationHintForRemoval(reason)
+		entry = current
+		d.mu.Unlock()
+		break
+	}
+
+	exitCode, finalized, finalizationErr := d.finalizeOwnerWithRetry(entry.Owner, soft)
+	if !finalized {
+		d.mu.Lock()
+		if current := d.owners[serverID]; current == entry {
+			entry.removalInProgress = false
+		}
+		d.mu.Unlock()
+		if scheduleRetry {
+			d.scheduleOwnerFinalizationRetry(serverID, entry, reason, soft)
+		}
+		return result, finalizationErr
+	}
+
+	d.mu.Lock()
+	current, ok := d.owners[serverID]
+	if !ok || current != entry {
+		d.mu.Unlock()
+		return result, finalizationErr
+	}
+	prepared := d.prepareOwnerRemovalLocked(serverID, entry, reason, soft)
+	prepared.exitCode = exitCode
+	prepared.finalizationErr = finalizationErr
+	d.mu.Unlock()
+	return prepared.result, errors.Join(finalizationErr, d.finishOwnerRemoval(prepared))
+}
+
+func (d *Daemon) finalizeOwnerWithRetry(ownerRef *owner.Owner, soft bool) (int, bool, error) {
+	exitCode := 0
+	var lastErr error
+	for attempt := 1; attempt <= ownerFinalizationAttempts; attempt++ {
+		var finalized bool
+		exitCode, finalized, lastErr = finalizeOwnerForRemoval(ownerRef, soft)
+		if finalized {
+			return exitCode, true, lastErr
+		}
+		if lastErr == nil {
+			lastErr = errors.New("whole-tree finalization remains unproven")
+		}
+		if attempt < ownerFinalizationAttempts {
+			time.Sleep(ownerFinalizationRetryDelay)
+		}
+	}
+	return exitCode, false, fmt.Errorf("owner finalization unproven after %d attempts: %w", ownerFinalizationAttempts, lastErr)
+}
+
+func (d *Daemon) scheduleOwnerFinalizationRetry(serverID string, entry *OwnerEntry, reason ownerRemovalReason, soft bool) {
+	d.mu.Lock()
+	if d.owners[serverID] != entry || entry.removalRetrying {
+		d.mu.Unlock()
+		return
+	}
+	entry.removalRetrying = true
+	d.mu.Unlock()
+	go func() {
+		defer func() {
+			d.mu.Lock()
+			if d.owners[serverID] == entry {
+				entry.removalRetrying = false
+			}
+			d.mu.Unlock()
+		}()
+		for {
+			timer := time.NewTimer(100 * time.Millisecond)
+			select {
+			case <-timer.C:
+			case <-d.done:
+				timer.Stop()
+				return
+			}
+			result, err := d.finalizeAndRemoveOwner(serverID, entry, reason, soft, nil, false)
+			if result.Removed || err == nil {
+				return
+			}
+			d.logger.Printf("owner %s: retryable finalization still blocked: %v", shortServerID(serverID), err)
+		}
+	}()
+}
+
+func waitForSnapshotUnpin(serverID string, unpinned <-chan struct{}) error {
+	if unpinned == nil {
+		return fmt.Errorf("server %s snapshot pin missing release signal", serverID)
+	}
+	timer := time.NewTimer(snapshotPinWaitTimeout)
+	defer timer.Stop()
+	select {
+	case <-unpinned:
+		return nil
+	case <-timer.C:
+		return fmt.Errorf("server %s snapshot pin did not release within %s", serverID, snapshotPinWaitTimeout)
+	}
 }
 
 func (d *Daemon) prepareOwnerRemovalLocked(serverID string, entry *OwnerEntry, reason ownerRemovalReason, soft bool) preparedOwnerRemoval {
 	result := ownerRemovalResult{ServerID: serverID, Reason: reason, Soft: soft}
-	entry.terminationHint = terminationHintForRemoval(reason)
-	result.PendingTokensRemoved = entry.Owner.SessionMgr().RemovePendingForOwner(serverID)
+	result.PendingTokensRemoved = entry.Owner.PendingAdmissionsPurged() + entry.Owner.SessionMgr().RemovePendingForOwner(serverID)
 	result.BoundHistoryRemoved = entry.Owner.SessionMgr().RemoveBoundForOwner(serverID)
 	d.recordOwnerRemovalLocked(result)
 	d.deleteOwnerEntryLocked(serverID)
 	result.Removed = true
-	return preparedOwnerRemoval{
-		result:   result,
-		token:    entry.serviceToken,
-		ownerRef: entry.Owner,
-	}
+	return preparedOwnerRemoval{result: result, token: entry.serviceToken}
 }
 
 func (d *Daemon) finishOwnerRemoval(prepared preparedOwnerRemoval) error {
@@ -163,37 +282,26 @@ func (d *Daemon) finishOwnerRemoval(prepared preparedOwnerRemoval) error {
 	}
 
 	if prepared.result.Soft {
-		exitCode, err := prepared.ownerRef.SoftShutdown(30 * time.Second)
-		if err != nil {
-			d.logger.Printf("soft-removed owner %s: forced kill (exit=%d err=%v)", shortServerID(prepared.result.ServerID), exitCode, err)
-		} else if exitCode == 0 {
+		if prepared.finalizationErr != nil {
+			d.logger.Printf("soft-removed owner %s after finalization warning (exit=%d err=%v)", shortServerID(prepared.result.ServerID), prepared.exitCode, prepared.finalizationErr)
+		} else if prepared.exitCode == 0 {
 			d.logger.Printf("soft-removed owner %s: upstream exited cleanly (code 0)", shortServerID(prepared.result.ServerID))
 		} else {
-			d.logger.Printf("soft-removed owner %s: upstream exited with code %d", shortServerID(prepared.result.ServerID), exitCode)
+			d.logger.Printf("soft-removed owner %s: upstream exited with code %d", shortServerID(prepared.result.ServerID), prepared.exitCode)
 		}
+	} else if prepared.finalizationErr != nil {
+		d.logger.Printf("removed owner %s after finalization warning: %v", shortServerID(prepared.result.ServerID), prepared.finalizationErr)
 	} else {
-		prepared.ownerRef.Shutdown()
 		d.logger.Printf("removed owner %s", shortServerID(prepared.result.ServerID))
 	}
-
 	return supErr
 }
 
 func (d *Daemon) forgetOwnerIfCurrent(serverID string, expected *OwnerEntry, reason ownerRemovalReason) ownerRemovalResult {
-	result := ownerRemovalResult{ServerID: serverID, Reason: reason}
-	d.mu.Lock()
-	entry, ok := d.owners[serverID]
-	if !ok || (expected != nil && entry != expected) {
-		d.mu.Unlock()
-		return result
+	result, err := d.removeOwnerIfCurrent(serverID, expected, reason, false)
+	if err != nil {
+		d.logger.Printf("owner %s removal deferred: %v", shortServerID(serverID), err)
 	}
-	if entry.Owner != nil {
-		result.PendingTokensRemoved = entry.Owner.SessionMgr().RemovePendingForOwner(serverID)
-		result.BoundHistoryRemoved = entry.Owner.SessionMgr().RemoveBoundForOwner(serverID)
-	}
-	d.recordOwnerRemovalLocked(result)
-	d.deleteOwnerEntryLocked(serverID)
-	d.mu.Unlock()
 	return result
 }
 

--- a/muxcore/daemon/owner_lifecycle_test.go
+++ b/muxcore/daemon/owner_lifecycle_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"strings"
 	"sync"
@@ -188,6 +189,93 @@ func TestOwnerRemovalRetriesBeforeForgettingEntry(t *testing.T) {
 	}
 	if d.Entry(sid) != nil {
 		t.Fatal("owner entry survived proven finalization")
+	}
+}
+
+func TestConcurrentOwnerRemovalsSerializeAcrossSnapshotPin(t *testing.T) {
+	d := testDaemon(t)
+	d.supervisor = nil
+	sid := "owner-concurrent-removal"
+	o := testReconnectOwner(t, sid)
+	entry := &OwnerEntry{Owner: o, ServerID: sid, OwnerGeneration: "owner_gen_concurrent"}
+	d.mu.Lock()
+	d.owners[sid] = entry
+	d.mu.Unlock()
+
+	registryPins, err := d.acquireSnapshotOwnerPins()
+	if err != nil {
+		t.Fatalf("acquireSnapshotOwnerPins: %v", err)
+	}
+
+	original := finalizeOwnerForRemoval
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var enteredOnce sync.Once
+	var releaseOnce sync.Once
+	var calls atomic.Int32
+	finalizeOwnerForRemoval = func(got *owner.Owner, soft bool) (int, bool, error) {
+		if got != o || soft {
+			return 0, false, fmt.Errorf("unexpected finalizer owner=%p soft=%v", got, soft)
+		}
+		calls.Add(1)
+		enteredOnce.Do(func() { close(entered) })
+		<-release
+		return 0, true, nil
+	}
+	t.Cleanup(func() {
+		releaseOnce.Do(func() { close(release) })
+		finalizeOwnerForRemoval = original
+		o.Shutdown()
+	})
+
+	type removeResult struct {
+		result ownerRemovalResult
+		err    error
+	}
+	results := make(chan removeResult, 2)
+	for range 2 {
+		go func() {
+			result, removeErr := d.removeOwnerIfCurrent(sid, entry, ownerRemovalReasonOperatorHard, false)
+			results <- removeResult{result: result, err: removeErr}
+		}()
+	}
+	select {
+	case <-entered:
+		t.Fatal("owner finalization started while snapshot pin was held")
+	case <-time.After(100 * time.Millisecond):
+	}
+	d.releaseSnapshotOwnerPins(registryPins)
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("owner finalization did not start after snapshot pin release")
+	}
+	time.Sleep(50 * time.Millisecond)
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("concurrent removers started %d finalizers, want 1", got)
+	}
+	if pins, pinErr := d.acquireSnapshotOwnerPins(); pinErr == nil {
+		d.releaseSnapshotOwnerPins(pins)
+		t.Fatal("snapshot pinned owner while removal was in progress")
+	}
+
+	releaseOnce.Do(func() { close(release) })
+	removed := 0
+	for range 2 {
+		select {
+		case got := <-results:
+			if got.err != nil {
+				t.Fatalf("concurrent remove error: %v", got.err)
+			}
+			if got.result.Removed {
+				removed++
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("concurrent remover did not settle")
+		}
+	}
+	if removed != 1 || calls.Load() != 1 {
+		t.Fatalf("removed=%d finalizer_calls=%d, want one serialized removal", removed, calls.Load())
 	}
 }
 

--- a/muxcore/daemon/owner_lifecycle_test.go
+++ b/muxcore/daemon/owner_lifecycle_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -307,6 +308,163 @@ func TestOwnerRemovalKeepsEntryWhenFinalizationUnproven(t *testing.T) {
 	d.mu.RUnlock()
 	if removalInProgress {
 		t.Fatal("blocked removal did not release retryable registry state")
+	}
+}
+
+func TestRestartFallbackWaitsForBlockedOwnerRetirementProof(t *testing.T) {
+	d := testDaemon(t)
+	d.supervisor = nil
+	d.sessionHandler = noopSessionHandler{}
+
+	blockerSID := "restart-blocker-owner"
+	blockerOwner := testReconnectOwner(t, blockerSID)
+	blocker := &OwnerEntry{
+		Owner:           blockerOwner,
+		ServerID:        blockerSID,
+		OwnerGeneration: "owner_gen_restart_blocker",
+	}
+	d.mu.Lock()
+	d.owners[blockerSID] = blocker
+	d.mu.Unlock()
+
+	fallbackSnapshot := daemonMaterializationSnapshot(false)
+	fallbackSnapshot.ServerID = blockerSID
+	fallbackSnapshot.Cwd = t.TempDir()
+	fallbackSnapshot.Mode = "global"
+	plan := d.makeSnapshotRestorePlan(fallbackSnapshot)
+	plan.blockedBy = blocker
+	d.mu.Lock()
+	d.restartStaging = []snapshotRestorePlan{plan}
+	d.mu.Unlock()
+
+	original := finalizeOwnerForRemoval
+	proofStarted := make(chan struct{})
+	releaseProof := make(chan struct{})
+	var startedOnce sync.Once
+	finalizeOwnerForRemoval = func(got *owner.Owner, soft bool) (int, bool, error) {
+		if got != blockerOwner || soft {
+			return original(got, soft)
+		}
+		startedOnce.Do(func() { close(proofStarted) })
+		<-releaseProof
+		return 0, true, nil
+	}
+	t.Cleanup(func() { finalizeOwnerForRemoval = original })
+
+	removalDone := make(chan error, 1)
+	go func() {
+		_, removeErr := d.removeOwnerIfCurrent(blockerSID, blocker, ownerRemovalReasonIdle, false)
+		removalDone <- removeErr
+	}()
+	select {
+	case <-proofStarted:
+	case <-time.After(time.Second):
+		t.Fatal("blocked owner finalization did not start")
+	}
+
+	type activationResult struct {
+		activated int
+		err       error
+	}
+	activationDone := make(chan activationResult, 1)
+	go func() {
+		activated, activateErr := d.activateRestartStaging()
+		activationDone <- activationResult{activated: activated, err: activateErr}
+	}()
+	select {
+	case result := <-activationDone:
+		t.Fatalf("fallback activated before retirement proof: %+v", result)
+	case <-time.After(100 * time.Millisecond):
+	}
+	if entry := d.Entry(fallbackSnapshot.ServerID); entry != blocker {
+		t.Fatalf("blocker registry identity changed before retirement proof: %#v", entry)
+	}
+
+	close(releaseProof)
+	select {
+	case removeErr := <-removalDone:
+		if removeErr != nil {
+			t.Fatalf("removeOwnerIfCurrent() error: %v", removeErr)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("blocked owner removal did not finish after retirement proof")
+	}
+	select {
+	case result := <-activationDone:
+		if result.err != nil || result.activated != 1 {
+			t.Fatalf("activateRestartStaging() = %+v, want one activated fallback", result)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("fallback activation did not resume after retirement proof")
+	}
+	if entry := d.Entry(fallbackSnapshot.ServerID); entry == nil || entry == blocker || entry.Owner == nil {
+		t.Fatalf("fallback owner was not restored after retirement proof: %#v", entry)
+	}
+}
+
+func TestDaemonShutdownWaitsForOwnerRetirementBeforeSuccessorActivation(t *testing.T) {
+	d := testDaemon(t)
+	d.supervisor = nil
+	sid := "shutdown-retirement-barrier"
+	o := testReconnectOwner(t, sid)
+	entry := &OwnerEntry{Owner: o, ServerID: sid, OwnerGeneration: "owner_gen_shutdown_barrier"}
+	d.mu.Lock()
+	d.owners[sid] = entry
+	d.mu.Unlock()
+
+	original := finalizeOwnerForRemoval
+	var allowProof atomic.Bool
+	var calls atomic.Int32
+	finalizeOwnerForRemoval = func(got *owner.Owner, soft bool) (int, bool, error) {
+		if got != o || soft {
+			t.Fatalf("finalizer got owner=%p soft=%v, want owner=%p soft=false", got, soft, o)
+		}
+		calls.Add(1)
+		if !allowProof.Load() {
+			return 0, false, errors.New("synthetic retirement proof pending")
+		}
+		return 0, true, nil
+	}
+	t.Cleanup(func() {
+		finalizeOwnerForRemoval = original
+		o.Shutdown()
+	})
+
+	activated := make(chan struct{})
+	go d.shutdown(func() { close(activated) })
+	waitForDaemonCondition(t, time.Second, func() bool {
+		return calls.Load() >= ownerFinalizationAttempts
+	}, "shutdown did not attempt owner finalization")
+	select {
+	case <-activated:
+		t.Fatal("successor activation ran before owner retirement proof")
+	default:
+	}
+	select {
+	case <-d.Done():
+		t.Fatal("daemon completed before owner retirement proof")
+	default:
+	}
+	if d.Entry(sid) != entry {
+		t.Fatal("owner registry entry was forgotten before retirement proof")
+	}
+	if err := d.HandleRemove(sid); !errors.Is(err, ErrDaemonShuttingDown) {
+		t.Fatalf("HandleRemove during shutdown error=%v, want ErrDaemonShuttingDown", err)
+	}
+
+	allowProof.Store(true)
+	select {
+	case <-activated:
+	case <-time.After(2 * time.Second):
+		t.Fatal("successor activation did not run after retirement proof")
+	}
+	select {
+	case <-d.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("daemon did not complete after retirement proof")
+	}
+	if d.Entry(sid) != nil {
+		t.Fatal("owner registry entry survived proven shutdown finalization")
 	}
 }
 

--- a/muxcore/daemon/owner_lifecycle_test.go
+++ b/muxcore/daemon/owner_lifecycle_test.go
@@ -2,10 +2,13 @@ package daemon
 
 import (
 	"errors"
+	"os"
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/thebtf/mcp-mux/muxcore/control"
 	"github.com/thebtf/mcp-mux/muxcore/owner"
 	"github.com/thebtf/mcp-mux/muxcore/serverid"
 	"github.com/thebtf/mcp-mux/muxcore/session"
@@ -136,6 +139,174 @@ func TestStopOwnerResultMessageTreatsPostRemovalErrorAsWarning(t *testing.T) {
 	_, err = stopOwnerResultMessage("stopped", ownerRemovalResult{Removed: false}, errors.New("server not found"))
 	if err == nil {
 		t.Fatal("expected pre-removal error to remain an error")
+	}
+}
+
+func TestOwnerRemovalRetriesBeforeForgettingEntry(t *testing.T) {
+	d := testDaemon(t)
+	d.supervisor = nil
+	sid := "owner-finalization-retry"
+	o := testReconnectOwner(t, sid)
+	entry := &OwnerEntry{Owner: o, ServerID: sid, OwnerGeneration: "owner_gen_retry"}
+	o.SessionMgr().PreRegisterForOwner("pending-finalization", sid, "/owned", nil)
+	d.mu.Lock()
+	d.owners[sid] = entry
+	d.mu.Unlock()
+
+	original := finalizeOwnerForRemoval
+	t.Cleanup(func() {
+		finalizeOwnerForRemoval = original
+		o.Shutdown()
+	})
+	var calls atomic.Int32
+	finalizeOwnerForRemoval = func(got *owner.Owner, soft bool) (int, bool, error) {
+		if got != o || soft {
+			t.Fatalf("finalizer got owner=%p soft=%v, want owner=%p soft=false", got, soft, o)
+		}
+		d.mu.RLock()
+		current := d.owners[sid]
+		d.mu.RUnlock()
+		if current != entry {
+			t.Fatal("owner entry was forgotten before finalization proof")
+		}
+		if !o.SessionMgr().IsPreRegistered("pending-finalization") {
+			t.Fatal("owner tokens were removed before finalization proof")
+		}
+		if calls.Add(1) == 1 {
+			return 0, false, errors.New("retirement not yet proven")
+		}
+		return 0, true, nil
+	}
+
+	result, err := d.removeOwnerIfCurrent(sid, entry, ownerRemovalReasonOperatorHard, false)
+	if err != nil {
+		t.Fatalf("removeOwnerIfCurrent() error: %v", err)
+	}
+	if !result.Removed || calls.Load() != 2 {
+		t.Fatalf("result=%+v finalizer_calls=%d, want removed after second proof", result, calls.Load())
+	}
+	if d.Entry(sid) != nil {
+		t.Fatal("owner entry survived proven finalization")
+	}
+}
+
+func TestReaperFinalizationRetryRetainsLivePIDAndOwnerState(t *testing.T) {
+	d := testDaemon(t)
+	generationFile := t.TempDir() + string(os.PathSeparator) + "reaper-generation.txt"
+	command, args, env := daemonRespawnHelperCommand(generationFile)
+	path, sid, token, err := d.Spawn(control.Request{Cmd: "spawn", Command: command, Args: args, Env: env, Mode: "global"})
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	entry := d.Entry(sid)
+	if entry == nil || entry.Owner == nil {
+		t.Fatal("spawned owner missing")
+	}
+	conn, _ := connectSpawnedOwner(t, path, token)
+	waitForDaemonCondition(t, 3*time.Second, func() bool {
+		return entry.Owner.SessionCount() == 1 && entry.Owner.MaterializationState() == owner.MaterializationReady
+	}, "owner did not become ready while session was retained")
+	_ = conn.Close()
+	waitForDaemonCondition(t, 3*time.Second, func() bool {
+		return entry.Owner.SessionCount() == 0 && entry.Owner.SessionMgr().PendingCount() == 0
+	}, "owner did not become idle after session close")
+	pid, _ := entry.Owner.Status()["upstream_pid"].(int)
+	if !daemonTestProcessAlive(pid) {
+		t.Fatalf("upstream pid %d is not live before reaper retry", pid)
+	}
+	if ownerKey, _, _, ok := entry.Owner.SessionMgr().LookupHistory(token); !ok || ownerKey != sid {
+		t.Fatalf("reconnect history before reaper=(%q,%v), want owner %q", ownerKey, ok, sid)
+	}
+
+	d.mu.Lock()
+	entry.LastSession = time.Now().Add(-time.Second)
+	entry.IdleTimeout = time.Millisecond
+	d.mu.Unlock()
+	time.Sleep(20 * time.Millisecond)
+
+	original := finalizeOwnerForRemoval
+	t.Cleanup(func() { finalizeOwnerForRemoval = original })
+	var calls atomic.Int32
+	finalizeOwnerForRemoval = func(got *owner.Owner, soft bool) (int, bool, error) {
+		call := calls.Add(1)
+		if got != entry.Owner || !soft {
+			t.Fatalf("finalizer call %d got owner=%p soft=%v, want owner=%p soft=true", call, got, soft, entry.Owner)
+		}
+		if call <= ownerFinalizationAttempts {
+			if current := d.Entry(sid); current != entry {
+				t.Fatalf("call %d forgot owner before process retirement proof", call)
+			}
+			if !daemonTestProcessAlive(pid) {
+				t.Fatalf("call %d lost live pid %d before retryable finalization", call, pid)
+			}
+			if ownerKey, _, _, ok := entry.Owner.SessionMgr().LookupHistory(token); !ok || ownerKey != sid {
+				t.Fatalf("call %d removed owner history before proof: owner=%q ok=%v", call, ownerKey, ok)
+			}
+			return 0, false, errors.New("synthetic whole-tree proof pending")
+		}
+		return original(got, soft)
+	}
+
+	if affected := (&Reaper{daemon: d, logger: d.logger}).sweep(); affected != 0 {
+		t.Fatalf("first reaper sweep affected=%d, want retained owner while finalization is retryable", affected)
+	}
+	if got := calls.Load(); got != ownerFinalizationAttempts {
+		t.Fatalf("synchronous finalizer calls=%d, want %d", got, ownerFinalizationAttempts)
+	}
+	if current := d.Entry(sid); current != entry {
+		t.Fatal("reaper forgot owner after unproven finalization")
+	}
+	if !daemonTestProcessAlive(pid) {
+		t.Fatalf("upstream pid %d died before scheduled finalization retry", pid)
+	}
+
+	waitForDaemonCondition(t, 5*time.Second, func() bool {
+		return d.Entry(sid) == nil && !daemonTestProcessAlive(pid)
+	}, "scheduled finalization retry did not retire process and remove owner")
+	if calls.Load() < ownerFinalizationAttempts+1 {
+		t.Fatalf("finalizer calls=%d, want scheduled retry after %d synchronous attempts", calls.Load(), ownerFinalizationAttempts)
+	}
+	if _, _, _, ok := entry.Owner.SessionMgr().LookupHistory(token); ok {
+		t.Fatal("owner history survived proven final removal")
+	}
+}
+
+func TestOwnerRemovalKeepsEntryWhenFinalizationUnproven(t *testing.T) {
+	d := testDaemon(t)
+	d.supervisor = nil
+	sid := "owner-finalization-blocked"
+	o := testReconnectOwner(t, sid)
+	entry := &OwnerEntry{Owner: o, ServerID: sid, OwnerGeneration: "owner_gen_blocked"}
+	d.mu.Lock()
+	d.owners[sid] = entry
+	d.mu.Unlock()
+
+	original := finalizeOwnerForRemoval
+	t.Cleanup(func() {
+		finalizeOwnerForRemoval = original
+		o.Shutdown()
+	})
+	var calls atomic.Int32
+	finalizeOwnerForRemoval = func(*owner.Owner, bool) (int, bool, error) {
+		calls.Add(1)
+		return 0, false, errors.New("retirement unproven")
+	}
+
+	result, err := d.finalizeAndRemoveOwner(sid, entry, ownerRemovalReasonOperatorHard, false, nil, false)
+	if err == nil || result.Removed {
+		t.Fatalf("result=%+v err=%v, want blocked removal", result, err)
+	}
+	if calls.Load() != ownerFinalizationAttempts {
+		t.Fatalf("finalizer calls=%d, want %d", calls.Load(), ownerFinalizationAttempts)
+	}
+	if d.Entry(sid) != entry {
+		t.Fatal("owner entry was forgotten without finalization proof")
+	}
+	d.mu.RLock()
+	removalInProgress := entry.removalInProgress
+	d.mu.RUnlock()
+	if removalInProgress {
+		t.Fatal("blocked removal did not release retryable registry state")
 	}
 }
 

--- a/muxcore/daemon/persistent_idle_parity_test.go
+++ b/muxcore/daemon/persistent_idle_parity_test.go
@@ -240,35 +240,36 @@ func TestPersistentIdleParityPersistsThroughSnapshotRestore(t *testing.T) {
 	}
 }
 
-func TestPersistentIdleParityPersistentRespawnGetsNewGeneration(t *testing.T) {
+func TestPersistentIdleParityReaperDoesNotReplaceOwnerGeneration(t *testing.T) {
 	d, r := testLifecycleDaemon(t, false)
 
-	_, sid, _ := spawnLifecycleOwner(t, d, "persistent-respawn")
+	_, sid, _ := spawnLifecycleOwner(t, d, "persistent-no-replacement")
 	d.SetPersistent(sid, true)
 	before := d.Entry(sid)
 	if before == nil || before.Owner == nil {
 		t.Fatal("persistent owner missing before shutdown")
 	}
 	beforeGeneration := before.OwnerGeneration
-	before.Owner.Shutdown()
+	beforeOwner := before.Owner
+	beforeOwner.Shutdown()
 	select {
-	case <-before.Owner.Done():
+	case <-beforeOwner.Done():
 	case <-time.After(2 * time.Second):
 		t.Fatal("owner did not shut down")
 	}
 
-	if affected := r.sweep(); affected != 1 {
-		t.Fatalf("persistent dead-owner sweep affected %d owners, want 1", affected)
+	if affected := r.sweep(); affected != 0 {
+		t.Fatalf("persistent dead-owner sweep affected %d owners, want 0", affected)
 	}
 	after := d.Entry(sid)
-	if after == nil || after.Owner == nil {
-		t.Fatal("persistent owner missing after respawn")
+	if after != before || after.Owner != beforeOwner {
+		t.Fatal("reaper replaced persistent owner generation")
 	}
 	if !after.Persistent {
-		t.Fatal("persistent flag lost after respawn")
+		t.Fatal("persistent flag lost")
 	}
-	if after.OwnerGeneration == "" || after.OwnerGeneration == beforeGeneration {
-		t.Fatalf("respawned owner generation = %q, want fresh non-empty generation distinct from %q", after.OwnerGeneration, beforeGeneration)
+	if after.OwnerGeneration != beforeGeneration {
+		t.Fatalf("owner generation = %q, want unchanged %q", after.OwnerGeneration, beforeGeneration)
 	}
 
 	status := d.HandleStatus()
@@ -276,10 +277,7 @@ func TestPersistentIdleParityPersistentRespawnGetsNewGeneration(t *testing.T) {
 	if len(servers) != 1 {
 		t.Fatalf("status servers = %d, want 1", len(servers))
 	}
-	if got := servers[0]["owner_generation"]; got != after.OwnerGeneration {
-		t.Fatalf("status owner_generation = %#v, want %q", got, after.OwnerGeneration)
-	}
-	if got := servers[0]["owner_generation"]; got == beforeGeneration {
-		t.Fatalf("status still reports stale owner_generation %q", beforeGeneration)
+	if got := servers[0]["owner_generation"]; got != beforeGeneration {
+		t.Fatalf("status owner_generation = %#v, want %q", got, beforeGeneration)
 	}
 }

--- a/muxcore/daemon/reaper.go
+++ b/muxcore/daemon/reaper.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/thebtf/mcp-mux/muxcore/control"
+	"github.com/thebtf/mcp-mux/muxcore/owner"
 )
 
 // Reaper periodically sweeps daemon owners for cleanup.
@@ -26,8 +26,8 @@ import (
 // The default idleTimeout is 10 minutes (was 30s grace in v0.10.x).
 // Overridable via MCP_MUX_OWNER_IDLE env or per-owner via x-mux.idleTimeout.
 //
-// Dead upstreams on persistent owners are still re-spawned, and the daemon
-// still auto-exits after its own idle period when it has zero owners.
+// Live and persistent upstream recovery is owner-controller owned. The reaper
+// never replaces an Owner generation.
 type Reaper struct {
 	daemon   *Daemon
 	interval time.Duration
@@ -135,49 +135,47 @@ func (r *Reaper) sweep() int {
 			continue
 		}
 
-		// Check if upstream is dead
+		// Terminal owners are never replaced here. Normal upstream loss stays
+		// inside the owner-local controller; explicit teardown is completed by
+		// the removal path that owns it.
 		select {
 		case <-entry.Owner.Done():
-			// Owner is shut down (upstream exited and was cleaned up)
-			if entry.Persistent {
-				r.logger.Printf("reaper: persistent owner %s dead, re-spawning", sid[:8])
-				r.respawn(entry)
-				affected++
-			}
 			continue
 		default:
 		}
 
 		sample := evictionSample{
-			Sessions:             entry.Owner.SessionCount(),
-			PendingSessions:      entry.Owner.SessionMgr().PendingCount(),
-			Persistent:           entry.Persistent,
-			PendingRequests:      entry.Owner.PendingRequests(),
-			ActiveProgressTokens: entry.Owner.ActiveProgressTokens(),
-			HasBusyWork:          entry.Owner.HasActiveBusyWork(),
-			UpstreamDead:         entry.Owner.UpstreamDead(),
-			IdleTimeout:          entry.IdleTimeout,
-			OwnerIdleOverride:    entry.Owner.IdleTimeout(),
-			LastSession:          entry.LastSession,
-			LastActivity:         entry.Owner.LastActivity(),
-			IsolatedClassified:   entry.Owner.IsClassifiedIsolated(),
+			Sessions:               entry.Owner.SessionCount(),
+			PendingSessions:        entry.Owner.SessionMgr().PendingCount(),
+			Persistent:             entry.Persistent,
+			PendingRequests:        entry.Owner.PendingRequests(),
+			ActiveProgressTokens:   entry.Owner.ActiveProgressTokens(),
+			HasBusyWork:            entry.Owner.HasActiveBusyWork(),
+			UpstreamDead:           entry.Owner.UpstreamDead(),
+			CacheReady:             entry.Owner.CacheReady(),
+			MaterializationBlocked: entry.Owner.MaterializationBlocksEviction(),
+			IdleTimeout:            entry.IdleTimeout,
+			OwnerIdleOverride:      entry.Owner.IdleTimeout(),
+			LastSession:            entry.LastSession,
+			LastActivity:           entry.Owner.LastActivity(),
+			IsolatedClassified:     entry.Owner.IsClassifiedIsolated(),
 		}
 		decision := shouldEvict(sample, now, r.daemon.ownerIdleTimeout, r.daemon.isolatedIdleTimeout)
 		if decision.evict {
+			var result ownerRemovalResult
 			if decision.reason == "zombie" {
-				// Upstream is already dead — hard remove (no point in stdin close).
 				r.logger.Printf("reaper: owner %s upstream dead with 0 sessions, removing", sid[:8])
-				_, _ = r.daemon.removeOwner(sid, ownerRemovalReasonZombie, false)
+				result, _ = r.daemon.removeOwnerIfCurrent(sid, entry, ownerRemovalReasonZombie, false)
 			} else {
-				// Idle eviction: give upstream a chance to exit cleanly via stdin close.
-				// SoftRemove closes stdin and waits up to 30s before SIGTERM/SIGKILL (US3).
 				r.logger.Printf(
 					"reaper: owner %s %s for %.0fs (timeout %.0fs), soft-removing",
 					sid[:8], decision.reason, decision.elapsed.Seconds(), decision.idleTimeout.Seconds(),
 				)
-				_, _ = r.daemon.removeOwner(sid, ownerRemovalReasonIdle, true)
+				result, _ = r.daemon.removeOwnerIfCurrent(sid, entry, ownerRemovalReasonIdle, true)
 			}
-			affected++
+			if result.Removed {
+				affected++
+			}
 		}
 	}
 
@@ -189,13 +187,15 @@ func (r *Reaper) sweep() int {
 // logic (shouldEvict) is a pure function and can be unit-tested without
 // constructing a real Owner.
 type evictionSample struct {
-	Sessions             int
-	PendingSessions      int
-	Persistent           bool
-	PendingRequests      int64
-	ActiveProgressTokens int
-	HasBusyWork          bool
-	UpstreamDead         bool
+	Sessions               int
+	PendingSessions        int
+	Persistent             bool
+	PendingRequests        int64
+	ActiveProgressTokens   int
+	HasBusyWork            bool
+	UpstreamDead           bool
+	CacheReady             bool
+	MaterializationBlocked bool
 	// IdleTimeout is the owner-entry idle timeout (set at Spawn time
 	// from daemon defaults).
 	IdleTimeout time.Duration
@@ -241,9 +241,12 @@ func shouldEvict(s evictionSample, now time.Time, daemonDefault, isolatedIdleTim
 	if s.PendingSessions > 0 {
 		return evictionDecision{}
 	}
+	if s.MaterializationBlocked {
+		return evictionDecision{}
+	}
 	// Zombie: upstream dead + zero sessions = evict immediately once reconnect
 	// reservations have either rolled back or expired.
-	if s.UpstreamDead && s.Sessions == 0 {
+	if s.UpstreamDead && s.Sessions == 0 && !s.CacheReady {
 		return evictionDecision{evict: true, reason: "zombie"}
 	}
 	if s.Sessions != 0 {
@@ -294,39 +297,19 @@ func shouldEvict(s evictionSample, now time.Time, daemonDefault, isolatedIdleTim
 	}
 }
 
-// respawn attempts to re-create a persistent owner after upstream death.
-func (r *Reaper) respawn(entry *OwnerEntry) {
-	sid := entry.ServerID
-	// Remove the dead entry first
-	_ = r.daemon.Remove(sid)
-
-	// Re-spawn with same parameters
-	_, newSID, _, err := r.daemon.Spawn(control.Request{
-		Command: entry.Command,
-		Args:    entry.Args,
-		Cwd:     entry.Cwd,
-		Mode:    entry.Mode,
-		Env:     entry.Env,
-	})
-	if err != nil {
-		r.logger.Printf("reaper: failed to re-spawn %s: %v", sid[:8], err)
-		return
-	}
-
-	// Preserve persistent flag
-	r.daemon.SetPersistent(newSID, true)
-	r.logger.Printf("reaper: re-spawned %s as %s", sid[:8], newSID[:8])
-}
-
 // totalSessions returns the total number of sessions across all owners.
 func (r *Reaper) totalSessions() int {
 	r.daemon.mu.RLock()
-	defer r.daemon.mu.RUnlock()
-	total := 0
-	for _, e := range r.daemon.owners {
-		if e.Owner != nil {
-			total += e.Owner.SessionCount()
+	owners := make([]*owner.Owner, 0, len(r.daemon.owners))
+	for _, entry := range r.daemon.owners {
+		if entry.Owner != nil {
+			owners = append(owners, entry.Owner)
 		}
+	}
+	r.daemon.mu.RUnlock()
+	total := 0
+	for _, ownerRef := range owners {
+		total += ownerRef.SessionCount()
 	}
 	return total
 }

--- a/muxcore/daemon/reaper.go
+++ b/muxcore/daemon/reaper.go
@@ -244,15 +244,15 @@ func shouldEvict(s evictionSample, now time.Time, daemonDefault, isolatedIdleTim
 	if s.MaterializationBlocked {
 		return evictionDecision{}
 	}
+	if s.Persistent {
+		return evictionDecision{}
+	}
 	// Zombie: upstream dead + zero sessions = evict immediately once reconnect
 	// reservations have either rolled back or expired.
 	if s.UpstreamDead && s.Sessions == 0 && !s.CacheReady {
 		return evictionDecision{evict: true, reason: "zombie"}
 	}
 	if s.Sessions != 0 {
-		return evictionDecision{}
-	}
-	if s.Persistent {
 		return evictionDecision{}
 	}
 	if s.PendingRequests > 0 {

--- a/muxcore/daemon/reaper_gate_test.go
+++ b/muxcore/daemon/reaper_gate_test.go
@@ -248,3 +248,25 @@ func TestShouldEvict_IsolatedDisabledByZero(t *testing.T) {
 		t.Errorf("reason = %q, want %q when isolated short-timeout disabled", d.reason, "idle")
 	}
 }
+
+func TestShouldEvict_MaterializationBlocksZombieAndIdleRemoval(t *testing.T) {
+	s := baseSample()
+	s.UpstreamDead = true
+	s.MaterializationBlocked = true
+	if decision := shouldEvict(s, time.Now(), 10*time.Minute, 60*time.Second); decision.evict {
+		t.Fatalf("materializing owner was evicted: %+v", decision)
+	}
+}
+
+func TestShouldEvict_CacheOnlyOwnerIsNotZombie(t *testing.T) {
+	s := baseSample()
+	s.UpstreamDead = true
+	s.CacheReady = true
+	decision := shouldEvict(s, time.Now(), 10*time.Minute, 60*time.Second)
+	if !decision.evict {
+		t.Fatal("cache-only owner past idle timeout should follow ordinary idle eviction")
+	}
+	if decision.reason != "idle" {
+		t.Fatalf("cache-only owner reason=%q, want idle", decision.reason)
+	}
+}

--- a/muxcore/daemon/reaper_gate_test.go
+++ b/muxcore/daemon/reaper_gate_test.go
@@ -249,6 +249,16 @@ func TestShouldEvict_IsolatedDisabledByZero(t *testing.T) {
 	}
 }
 
+func TestShouldEvict_PersistentDeadCachelessOwnerIsNotZombie(t *testing.T) {
+	s := baseSample()
+	s.Persistent = true
+	s.UpstreamDead = true
+	s.CacheReady = false
+	if decision := shouldEvict(s, time.Now(), 10*time.Minute, 60*time.Second); decision.evict {
+		t.Fatalf("persistent recovering owner was evicted as zombie: %+v", decision)
+	}
+}
+
 func TestShouldEvict_MaterializationBlocksZombieAndIdleRemoval(t *testing.T) {
 	s := baseSample()
 	s.UpstreamDead = true

--- a/muxcore/daemon/snapshot.go
+++ b/muxcore/daemon/snapshot.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"regexp"
 	"strconv"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -64,6 +65,8 @@ func (d *Daemon) rehydrateRetryCounter(sid, cmd string, args []string, cwd strin
 	}
 }
 
+const restartMaterializationBarrierTimeout = 15 * time.Second
+
 // DaemonSnapshot is an alias for mcpsnapshot.DaemonSnapshot.
 // Re-exported here so daemon-internal code can reference it without
 // the package qualifier while tests continue to use the type directly.
@@ -74,36 +77,96 @@ func SnapshotPath() string {
 	return mcpsnapshot.SnapshotPath("")
 }
 
-// SerializeSnapshot walks all owners, exports their state, and delegates
-// to mcpsnapshot.Serialize for the atomic write.
-func (d *Daemon) SerializeSnapshot() (string, error) {
-	d.mu.RLock()
-	owners := make([]mcpsnapshot.OwnerSnapshot, 0, len(d.owners))
-	sessions := make([]mcpsnapshot.SessionSnapshot, 0)
+// snapshotOwnerPin is an immutable daemon-side view paired with an owner
+// lifetime lease. Owner-local state is exported only after d.mu is released.
+type snapshotOwnerPin struct {
+	entry                       *OwnerEntry
+	owner                       *owner.Owner
+	serverID                    string
+	mode                        string
+	env                         map[string]string
+	persistent                  bool
+	ownerGeneration             string
+	restoredFromOwnerGeneration string
+	restoreSource               string
+}
 
-	for sid, entry := range d.owners {
-		if entry.Owner == nil {
-			continue // skip placeholders
+type snapshotRestartLease struct {
+	once sync.Once
+	pins []*owner.RestartPin
+}
+
+func (l *snapshotRestartLease) Release() {
+	if l == nil {
+		return
+	}
+	l.once.Do(func() {
+		for _, pin := range l.pins {
+			pin.Release()
 		}
-		snap := entry.Owner.ExportSnapshot()
-		snap.ServerID = sid
-		snap.Mode = entry.Mode
+	})
+}
+
+// SerializeSnapshot walks all owners, exports their state, and delegates
+// to mcpsnapshot.Serialize for the atomic write. Standalone callers release
+// restart pins after the snapshot is durable; graceful restart uses the
+// pinned variant below and retains the lease through predecessor shutdown.
+func (d *Daemon) SerializeSnapshot() (string, error) {
+	path, lease, err := d.serializeSnapshotPinned()
+	lease.Release()
+	return path, err
+}
+
+func (d *Daemon) serializeSnapshotPinned() (string, *snapshotRestartLease, error) {
+	pins, err := d.acquireSnapshotOwnerPins()
+	if err != nil {
+		return "", nil, err
+	}
+	defer d.releaseSnapshotOwnerPins(pins)
+
+	barrierCtx, cancelBarrier := context.WithTimeout(context.Background(), restartMaterializationBarrierTimeout)
+	defer cancelBarrier()
+	ownerPins := make([]*owner.RestartPin, 0, len(pins))
+	keepOwnerPins := false
+	defer func() {
+		if keepOwnerPins {
+			return
+		}
+		for _, pin := range ownerPins {
+			pin.Release()
+		}
+	}()
+	for _, pin := range pins {
+		if d.beforeSnapshotOwnerExport != nil {
+			d.beforeSnapshotOwnerExport()
+		}
+		ownerPin, err := pin.owner.AcquireRestartPin(barrierCtx)
+		if err != nil {
+			return "", nil, fmt.Errorf("serialize owner %s materialization: %w", pin.serverID, err)
+		}
+		ownerPins = append(ownerPins, ownerPin)
+	}
+
+	owners := make([]mcpsnapshot.OwnerSnapshot, 0, len(pins))
+	sessions := make([]mcpsnapshot.SessionSnapshot, 0)
+	for i, pin := range pins {
+		snap, ownerSessions := ownerPins[i].Snapshot, ownerPins[i].Sessions
+		snap.ServerID = pin.serverID
+		snap.Mode = pin.mode
 		if snap.Env == nil {
-			snap.Env = entry.Env
+			snap.Env = cloneSnapshotStringMap(pin.env)
 		}
-		snap.Persistent = entry.Persistent
-		snap.OwnerGeneration = entry.OwnerGeneration
-		snap.RestoredFromGeneration = entry.RestoredFromOwnerGeneration
-		snap.RestoreSource = entry.RestoreSource
+		snap.Persistent = pin.persistent || snap.Persistent
+		snap.OwnerGeneration = pin.ownerGeneration
+		snap.RestoredFromGeneration = pin.restoredFromOwnerGeneration
+		snap.RestoreSource = pin.restoreSource
 		owners = append(owners, snap)
 
-		// Collect session metadata from this owner.
-		for _, ss := range entry.Owner.ExportSessions() {
-			ss.OwnerServerID = sid
+		for _, ss := range ownerSessions {
+			ss.OwnerServerID = pin.serverID
 			sessions = append(sessions, ss)
 		}
 	}
-	d.mu.RUnlock()
 
 	data := &DaemonSnapshot{
 		Version:          mcpsnapshot.SnapshotVersion,
@@ -115,7 +178,71 @@ func (d *Daemon) SerializeSnapshot() (string, error) {
 		Sessions:         sessions,
 	}
 
-	return mcpsnapshot.Serialize(data, d.logger)
+	path, err := mcpsnapshot.Serialize(data, d.logger)
+	if err != nil {
+		return "", nil, err
+	}
+	keepOwnerPins = true
+	return path, &snapshotRestartLease{pins: ownerPins}, nil
+}
+
+func (d *Daemon) acquireSnapshotOwnerPins() ([]snapshotOwnerPin, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	for sid, entry := range d.owners {
+		if entry != nil && entry.Owner != nil && entry.removalInProgress {
+			return nil, fmt.Errorf("snapshot owner %s removal is still finalizing", shortServerID(sid))
+		}
+	}
+	pins := make([]snapshotOwnerPin, 0, len(d.owners))
+	for sid, entry := range d.owners {
+		if entry.Owner == nil {
+			continue
+		}
+		if entry.snapshotPins == 0 {
+			entry.snapshotUnpinned = make(chan struct{})
+		}
+		entry.snapshotPins++
+		pins = append(pins, snapshotOwnerPin{
+			entry:                       entry,
+			owner:                       entry.Owner,
+			serverID:                    sid,
+			mode:                        entry.Mode,
+			env:                         cloneSnapshotStringMap(entry.Env),
+			persistent:                  entry.Persistent,
+			ownerGeneration:             entry.OwnerGeneration,
+			restoredFromOwnerGeneration: entry.RestoredFromOwnerGeneration,
+			restoreSource:               entry.RestoreSource,
+		})
+	}
+	return pins, nil
+}
+
+func (d *Daemon) releaseSnapshotOwnerPins(pins []snapshotOwnerPin) {
+	d.mu.Lock()
+	for _, pin := range pins {
+		entry := pin.entry
+		if entry.snapshotPins <= 0 {
+			continue
+		}
+		entry.snapshotPins--
+		if entry.snapshotPins == 0 {
+			close(entry.snapshotUnpinned)
+			entry.snapshotUnpinned = nil
+		}
+	}
+	d.mu.Unlock()
+}
+
+func cloneSnapshotStringMap(src map[string]string) map[string]string {
+	if len(src) == 0 {
+		return nil
+	}
+	dst := make(map[string]string, len(src))
+	for key, value := range src {
+		dst[key] = value
+	}
+	return dst
 }
 
 // DeserializeSnapshot reads and validates a snapshot from the well-known path.
@@ -171,6 +298,159 @@ func (d *Daemon) tryHandoffReceive(ctx context.Context) *handoffReceipt {
 	return receipt
 }
 
+type snapshotRestorePlan struct {
+	snapshot mcpsnapshot.OwnerSnapshot
+	cfg      owner.OwnerConfig
+	env      map[string]string
+}
+
+func (d *Daemon) makeSnapshotRestorePlan(ownerSnap mcpsnapshot.OwnerSnapshot) snapshotRestorePlan {
+	restoredEnv := mergeEnv(ownerSnap.Env)
+	command := ownerSnap.Command
+	args := append([]string(nil), ownerSnap.Args...)
+	cfg := owner.OwnerConfig{
+		Command:               command,
+		Args:                  args,
+		Env:                   restoredEnv,
+		Cwd:                   ownerSnap.Cwd,
+		IPCPath:               serverid.IPCPath("", d.namespace, ownerSnap.ServerID),
+		ControlPath:           serverid.ControlPath("", d.namespace, ownerSnap.ServerID),
+		ServerID:              ownerSnap.ServerID,
+		TokenHandshake:        true,
+		MaterializationPolicy: owner.MaterializationOnDemand,
+		PersistentPending:     ownerSnap.Persistent,
+		PersistentRequired:    d.persistent,
+		HandlerFunc:           d.handlerFunc,
+		SessionHandler:        d.sessionHandler,
+		AuthorizeSession:      d.authorizeSession,
+		OnFrameReceived:       d.onFrameReceived,
+		OnZeroSessions:        d.onZeroSessions,
+		OnUpstreamExit:        d.onUpstreamExit,
+		OnPersistentDetected: func(expected *owner.Owner) {
+			d.setOwnerPersistent(expected, true)
+		},
+		OnPersistentResolved: d.resolveOwnerPersistent,
+		OnCacheReady:         d.publishOwnerCache,
+		OnCacheInvalidated:   d.invalidateOwnerTemplate,
+		Logger:               log.New(d.logger.Writer(), fmt.Sprintf("[mcp-mux:%s] ", shortServerID(ownerSnap.ServerID)), log.LstdFlags|log.Lmicroseconds),
+	}
+	if d.persistent || ownerSnap.Persistent {
+		cfg.MaterializationPolicy = owner.MaterializationPersistent
+	}
+	return snapshotRestorePlan{snapshot: ownerSnap, cfg: cfg, env: restoredEnv}
+}
+
+func (d *Daemon) restoreSnapshotPlan(plan snapshotRestorePlan, handoff *HandoffUpstream, restoreSource string, eager, publishTemplate bool) (*OwnerEntry, bool, error) {
+	snap := plan.snapshot
+	if isRestartRestoreMode() {
+		d.retireOldOwnerSockets(plan.cfg.IPCPath, plan.cfg.ControlPath)
+	}
+
+	var restoredOwner *owner.Owner
+	reattached := false
+	var err error
+	if handoff != nil {
+		plan.cfg.CachedClassification = snap.Classification
+		plan.cfg.AdoptedSnapshot = &snap
+		payload := owner.HandoffPayload{
+			ServerID:    snap.ServerID,
+			PID:         handoff.PID,
+			StdinFD:     handoff.StdinFD,
+			StdoutFD:    handoff.StdoutFD,
+			StderrFD:    handoff.StderrFD,
+			AuthorityFD: handoff.AuthorityFD,
+			Command:     handoff.Command,
+			Args:        snap.Args,
+			Cwd:         snap.Cwd,
+		}
+		restoredOwner, err = owner.NewOwnerFromHandoff(plan.cfg, payload)
+		reattached = err == nil
+	} else {
+		restoredOwner, err = owner.NewOwnerFromSnapshot(plan.cfg, snap)
+	}
+	if err != nil {
+		return nil, false, err
+	}
+
+	ownerGeneration, err := generateGeneration("owner")
+	if err != nil {
+		restoredOwner.Shutdown()
+		d.logger.Printf("snapshot: failed to generate owner generation for %s: %v", shortServerID(snap.ServerID), err)
+		return nil, false, err
+	}
+	var serviceToken suture.ServiceToken
+	if d.supervisor != nil {
+		serviceToken = d.supervisor.Add(restoredOwner)
+	}
+	effectivePersistent := d.persistent || snap.Persistent
+	entry := &OwnerEntry{
+		Owner:                       restoredOwner,
+		ServerID:                    snap.ServerID,
+		Command:                     snap.Command,
+		Args:                        append([]string(nil), snap.Args...),
+		Cwd:                         snap.Cwd,
+		Mode:                        snap.Mode,
+		Env:                         plan.env,
+		Persistent:                  effectivePersistent,
+		LastSession:                 time.Now(),
+		OwnerGeneration:             ownerGeneration,
+		RestoredFromOwnerGeneration: snap.OwnerGeneration,
+		RestoreSource:               restoreSource,
+		IdleTimeout:                 d.ownerIdleTimeout,
+		serviceToken:                serviceToken,
+	}
+	d.mu.Lock()
+	if _, exists := d.owners[snap.ServerID]; exists {
+		d.mu.Unlock()
+		if d.supervisor != nil {
+			d.supervisor.Remove(serviceToken)
+		}
+		restoredOwner.Shutdown()
+		return nil, false, fmt.Errorf("snapshot owner %s already registered", shortServerID(snap.ServerID))
+	}
+	d.owners[snap.ServerID] = entry
+	d.mu.Unlock()
+	restoredOwner.ResolvePersistent(effectivePersistent)
+	d.rehydrateRetryCounter(snap.ServerID, snap.Command, snap.Args, snap.Cwd)
+	if publishTemplate && snap.CachedInit != "" && snap.CachedTools != "" {
+		snap.Persistent = effectivePersistent
+		if !d.publishOwnerCache(restoredOwner, snap) {
+			d.logger.Printf("snapshot: cache publish rejected for stale owner %s", shortServerID(snap.ServerID))
+		}
+	}
+	if eager && !reattached {
+		restoredOwner.SpawnUpstreamBackground()
+	}
+	if reattached {
+		d.logger.Printf("snapshot: reattached owner %s from handoff (pid=%d)", shortServerID(snap.ServerID), handoff.PID)
+	} else {
+		d.logger.Printf("snapshot: restored owner %s for %s %v source=%s eager=%v", shortServerID(snap.ServerID), snap.Command, snap.Args, restoreSource, eager)
+	}
+	return entry, reattached, nil
+}
+
+func (d *Daemon) activateRestartStaging() int {
+	d.mu.Lock()
+	plans := append([]snapshotRestorePlan(nil), d.restartStaging...)
+	d.restartStaging = nil
+	d.mu.Unlock()
+
+	restored := 0
+	for _, plan := range plans {
+		if _, _, err := d.restoreSnapshotPlan(plan, nil, "snapshot_fallback", true, true); err != nil {
+			d.logger.Printf("snapshot: staged restore failed for %s (%s): %v", shortServerID(plan.snapshot.ServerID), plan.snapshot.Command, err)
+			continue
+		}
+		restored++
+	}
+	if restored > 0 {
+		d.restoredOwnerCount.Add(uint64(restored))
+		d.runRestoreHealthGate()
+	}
+	d.logger.Printf("snapshot: activated %d/%d staged owners after predecessor finalization", restored, len(plans))
+	return restored
+}
+
 // loadSnapshot checks for a snapshot file and restores owners from it.
 // Called on daemon startup. If no snapshot exists, returns 0 (cold start).
 // Returns the number of owners restored.
@@ -181,7 +461,7 @@ func (d *Daemon) loadSnapshot() int {
 		return 0
 	}
 	if snap == nil {
-		return 0 // cold start
+		return 0
 	}
 
 	d.mu.Lock()
@@ -189,282 +469,101 @@ func (d *Daemon) loadSnapshot() int {
 	d.predecessorDaemonGeneration = snap.DaemonGeneration
 	d.mu.Unlock()
 
-	// Check for handoff env vars. If both are set, receive transferred FDs from
-	// the old daemon instead of respawning upstreams from scratch (FR-1 to FR-3).
-	// Returns nil if env vars are absent or handoff fails (FR-8 fallback for all owners).
+	restartMode := isRestartRestoreMode()
 	handoffReceipt := d.tryHandoffReceive(context.Background())
 	handoffAccepted := make([]string, 0)
 	type adoptedHandoffOwner struct {
-		snapshot mcpsnapshot.OwnerSnapshot
-		cfg      owner.OwnerConfig
-		entry    *OwnerEntry
+		plan  snapshotRestorePlan
+		entry *OwnerEntry
 	}
-	handoffOwners := make([]adoptedHandoffOwner, 0)
-
+	adopted := make([]adoptedHandoffOwner, 0)
+	staged := make([]snapshotRestorePlan, 0)
 	restored := 0
-	for _, ownerSnap := range snap.Owners {
-		sid := ownerSnap.ServerID
-		ipcPath := serverid.IPCPath("", d.namespace, sid)
-		controlPath := serverid.ControlPath("", d.namespace, sid)
 
-		if ownerSnap.Classification == classify.ModeIsolated &&
-			len(ownerSnap.CwdSet) > 1 {
-			shortSID := sid
-			if len(shortSID) > 8 {
-				shortSID = shortSID[:8]
-			}
-			d.logger.Printf("snapshot: healing poisoned isolated owner %s: cwdSet %v → [%s]",
-				shortSID, ownerSnap.CwdSet, ownerSnap.Cwd)
+	for _, ownerSnap := range snap.Owners {
+		if ownerSnap.Classification == classify.ModeIsolated && len(ownerSnap.CwdSet) > 1 {
+			d.logger.Printf("snapshot: healing poisoned isolated owner %s: cwdSet %v -> [%s]",
+				shortServerID(ownerSnap.ServerID), ownerSnap.CwdSet, ownerSnap.Cwd)
 			ownerSnap.CwdSet = []string{ownerSnap.Cwd}
 		}
+		plan := d.makeSnapshotRestorePlan(ownerSnap)
 
-		// Merge daemon os.Environ() into the snapshotted env on restore. A
-		// pre-fix daemon may have serialised an owner with a trimmed shim env
-		// (missing GITHUB_PERSONAL_ACCESS_TOKEN, etc.); without this merge,
-		// loading that snapshot after the fix would re-install the trimmed
-		// env and session-aware upstreams would fail with "No GitHub token
-		// available for session ..." until the next cold spawn. Daemon env
-		// values fill gaps but cannot override whatever the snapshot stored.
-		restoredEnv := mergeEnv(ownerSnap.Env)
-		cmd, args := ownerSnap.Command, ownerSnap.Args
-		cfg := owner.OwnerConfig{
-			Command:        cmd,
-			Args:           args,
-			Env:            restoredEnv,
-			Cwd:            ownerSnap.Cwd,
-			IPCPath:        ipcPath,
-			ControlPath:    controlPath,
-			ServerID:       sid,
-			TokenHandshake: true,
-			HandlerFunc:    d.handlerFunc,
-			SessionHandler: d.sessionHandler,
-			// Forward v0.24 multi-tenant callbacks to restored owners. Fresh
-			// spawn in spawnOnce already does this; without it, snapshot/
-			// handoff-restored owners would silently lose AuthorizeSession +
-			// OnFrameReceived after a graceful daemon restart, breaking the
-			// pre-dispatch admission gate and per-frame hook for the
-			// reattached upstream. Closes CodeRabbit CRIT review on PR #113.
-			AuthorizeSession: d.authorizeSession,
-			OnFrameReceived:  d.onFrameReceived,
-			OnZeroSessions: func(serverID string) {
-				d.onZeroSessions(serverID)
-			},
-			OnUpstreamExit: func(serverID string) {
-				d.onUpstreamExit(serverID)
-			},
-			OnPersistentDetected: func(serverID string) {
-				d.SetPersistent(serverID, true)
-			},
-			OnCacheReady: func(serverID string) {
-				d.mu.RLock()
-				entry, ok := d.owners[serverID]
-				d.mu.RUnlock()
-				if !ok || entry.Owner == nil {
-					return
+		if restartMode {
+			if handoffReceipt != nil {
+				if transferred, ok := handoffReceipt.take(ownerSnap.ServerID); ok {
+					entry, _, restoreErr := d.restoreSnapshotPlan(plan, &transferred, "snapshot_handoff", false, false)
+					if restoreErr == nil {
+						handoffAccepted = append(handoffAccepted, ownerSnap.ServerID)
+						adopted = append(adopted, adoptedHandoffOwner{plan: plan, entry: entry})
+						restored++
+						continue
+					}
+					d.logger.Printf("snapshot: handoff reattach failed for %s: %v; staging eager fallback",
+						shortServerID(ownerSnap.ServerID), restoreErr)
 				}
-				s := entry.Owner.ExportSnapshot()
-				d.updateTemplate(cmd, args, s)
-			},
-			Logger: log.New(d.logger.Writer(), fmt.Sprintf("[mcp-mux:%s] ", sid[:8]), log.LstdFlags|log.Lmicroseconds),
-		}
-
-		// During restart restore, predecessor's owner sockets may still be
-		// active. Unconditionally remove them — predecessor is shutting down
-		// (#101). Snapshot-only SessionHandler restart needs the same path as
-		// FD handoff because there is no upstream process to keep the socket
-		// alive across daemons.
-		if isRestartRestoreMode() {
-			d.retireOldOwnerSockets(ipcPath, controlPath)
-		}
-
-		var o *owner.Owner
-		reattachedFromHandoff := false
-
-		// FR-7 partial fallback: take ownership only while constructing this owner.
-		var hu HandoffUpstream
-		var hasHandoff bool
-		if handoffReceipt != nil {
-			hu, hasHandoff = handoffReceipt.take(sid)
-		}
-		if hasHandoff {
-			cfg.CachedClassification = ownerSnap.Classification
-			payload := owner.HandoffPayload{
-				ServerID:    sid,
-				PID:         hu.PID,
-				StdinFD:     hu.StdinFD,
-				StdoutFD:    hu.StdoutFD,
-				StderrFD:    hu.StderrFD,
-				AuthorityFD: hu.AuthorityFD,
-				Command:     hu.Command,
-				Args:        ownerSnap.Args,
-				Cwd:         ownerSnap.Cwd,
 			}
-			var handoffErr error
-			o, handoffErr = owner.NewOwnerFromHandoff(cfg, payload)
-			if handoffErr != nil {
-				d.logger.Printf("snapshot: handoff reattach failed for %s: %v — falling back to spawn",
-					sid[:8], handoffErr)
-				o = nil
-			} else {
-				reattachedFromHandoff = true
-				d.logger.Printf("snapshot: reattached owner %s from handoff (pid=%d)", sid[:8], hu.PID)
-			}
-		}
-
-		// Legacy path: restore from snapshot (runs when handoff not available or failed).
-		if o == nil {
-			var snapErr error
-			o, snapErr = owner.NewOwnerFromSnapshot(cfg, ownerSnap)
-			if snapErr != nil {
-				d.logger.Printf("snapshot: failed to restore owner %s (%s): %v", sid[:8], ownerSnap.Command, snapErr)
-				continue
-			}
-		}
-
-		ownerGeneration, genErr := generateGeneration("owner")
-		if genErr != nil {
-			d.logger.Printf("snapshot: failed to generate owner generation for %s: %v", sid[:8], genErr)
-			o.Shutdown()
+			// No transferred process authority: keep metadata successor-local.
+			// IPC binding, supervisor registration, and process start wait until
+			// final ACK plus control-socket takeover prove predecessor finalization.
+			staged = append(staged, plan)
 			continue
 		}
-		restoreSource := "snapshot_fallback"
-		if reattachedFromHandoff {
-			restoreSource = "snapshot_handoff"
-		}
 
-		// Register with supervisor only after generation metadata is ready.
-		var serviceToken suture.ServiceToken
-		if d.supervisor != nil {
-			serviceToken = d.supervisor.Add(o)
+		if _, _, restoreErr := d.restoreSnapshotPlan(plan, nil, "snapshot_fallback", true, true); restoreErr != nil {
+			d.logger.Printf("snapshot: failed to restore owner %s (%s): %v", shortServerID(ownerSnap.ServerID), ownerSnap.Command, restoreErr)
+			continue
 		}
-
-		entry := &OwnerEntry{
-			Owner:                       o,
-			ServerID:                    sid,
-			Command:                     ownerSnap.Command,
-			Args:                        ownerSnap.Args,
-			Cwd:                         ownerSnap.Cwd,
-			Mode:                        ownerSnap.Mode,
-			Env:                         restoredEnv,
-			Persistent:                  ownerSnap.Persistent,
-			LastSession:                 time.Now(),
-			OwnerGeneration:             ownerGeneration,
-			RestoredFromOwnerGeneration: ownerSnap.OwnerGeneration,
-			RestoreSource:               restoreSource,
-			IdleTimeout:                 d.ownerIdleTimeout,
-			serviceToken:                serviceToken,
-		}
-		d.mu.Lock()
-		d.owners[sid] = entry
-		d.mu.Unlock()
-		if reattachedFromHandoff {
-			handoffAccepted = append(handoffAccepted, sid)
-			handoffOwners = append(handoffOwners, adoptedHandoffOwner{
-				snapshot: ownerSnap,
-				cfg:      cfg,
-				entry:    entry,
-			})
-		}
-
-		// Rehydrate forced-isolated retry counter when the restored sid carries
-		// a `-rN` suffix. Without this, a fresh Spawn for the same (cmd,args,cwd)
-		// after restart would compute the base `isolated-<hex16>` sid (counter
-		// starts at 0 in memory), miss the restored owner's `-r1` sid, and
-		// create a duplicate owner — exactly the continuity break codex flagged
-		// on PR #121.
-		d.rehydrateRetryCounter(sid, ownerSnap.Command, ownerSnap.Args, ownerSnap.Cwd)
-
-		// Seed template cache from snapshot so new isolated spawns can use it immediately.
-		if ownerSnap.CachedInit != "" && ownerSnap.CachedTools != "" {
-			d.updateTemplate(ownerSnap.Command, ownerSnap.Args, ownerSnap)
-		}
-
-		// Only spawn a fresh upstream when not reattached from handoff.
-		if !reattachedFromHandoff {
-			o.SpawnUpstreamBackground()
-		}
-
-		d.logger.Printf("snapshot: restored owner %s for %s %v", sid[:8], ownerSnap.Command, ownerSnap.Args)
 		restored++
 	}
+
 	if handoffReceipt != nil {
-		if err := handoffReceipt.finalize(handoffAccepted); err != nil {
-			d.logger.Printf("handoff.receive.commit_fail accepted=%d reason=%v", len(handoffAccepted), err)
-			for _, adopted := range handoffOwners {
-				sid := adopted.snapshot.ServerID
-				result, removeErr := d.removeOwnerIfCurrent(sid, adopted.entry, ownerRemovalReasonRestoreFailed, false)
+		if finalizeErr := handoffReceipt.finalize(handoffAccepted); finalizeErr != nil {
+			d.logger.Printf("handoff.receive.commit_fail accepted=%d reason=%v", len(handoffAccepted), finalizeErr)
+			fallback := make([]snapshotRestorePlan, 0, len(adopted))
+			for _, item := range adopted {
+				sid := item.plan.snapshot.ServerID
+				result, removeErr := d.removeOwnerIfCurrent(sid, item.entry, ownerRemovalReasonRestoreFailed, false)
 				if removeErr != nil {
 					d.logger.Printf("handoff.receive.rollback_remove_fail server_id=%s reason=%v", shortServerID(sid), removeErr)
 				}
 				if !result.Removed {
-					adopted.entry.Owner.Shutdown()
+					item.entry.Owner.Shutdown()
 				}
-
-				o, restoreErr := owner.NewOwnerFromSnapshot(adopted.cfg, adopted.snapshot)
-				if restoreErr != nil {
-					restored--
-					d.logger.Printf("handoff.receive.rollback_respawn_fail server_id=%s reason=%v", shortServerID(sid), restoreErr)
-					continue
-				}
-				ownerGeneration, generationErr := generateGeneration("owner")
-				if generationErr != nil {
-					restored--
-					o.Shutdown()
-					d.logger.Printf("handoff.receive.rollback_generation_fail server_id=%s reason=%v", shortServerID(sid), generationErr)
-					continue
-				}
-				var serviceToken suture.ServiceToken
-				if d.supervisor != nil {
-					serviceToken = d.supervisor.Add(o)
-				}
-				entry := &OwnerEntry{
-					Owner:                       o,
-					ServerID:                    sid,
-					Command:                     adopted.snapshot.Command,
-					Args:                        adopted.snapshot.Args,
-					Cwd:                         adopted.snapshot.Cwd,
-					Mode:                        adopted.snapshot.Mode,
-					Env:                         adopted.cfg.Env,
-					Persistent:                  adopted.snapshot.Persistent,
-					LastSession:                 time.Now(),
-					OwnerGeneration:             ownerGeneration,
-					RestoredFromOwnerGeneration: adopted.snapshot.OwnerGeneration,
-					RestoreSource:               "snapshot_fallback",
-					IdleTimeout:                 d.ownerIdleTimeout,
-					serviceToken:                serviceToken,
-				}
-				d.mu.Lock()
-				d.owners[sid] = entry
-				d.mu.Unlock()
-				d.rehydrateRetryCounter(sid, adopted.snapshot.Command, adopted.snapshot.Args, adopted.snapshot.Cwd)
-				if adopted.snapshot.CachedInit != "" && adopted.snapshot.CachedTools != "" {
-					d.updateTemplate(adopted.snapshot.Command, adopted.snapshot.Args, adopted.snapshot)
-				}
-				o.SpawnUpstreamBackground()
-				d.logger.Printf("handoff.receive.rollback_respawn_ok server_id=%s", shortServerID(sid))
+				fallback = append(fallback, item.plan)
 			}
+			// A failed global final ACK discards cache-only/no-handle staging.
+			// Only previously detached owners receive one post-barrier fallback.
+			d.logger.Printf("handoff.receive.discard_staging count=%d", len(staged))
+			staged = fallback
+			restored = 0
 		} else {
-			d.logger.Printf("handoff.receive.ok upstreams=%d", len(handoffAccepted))
+			for _, item := range adopted {
+				snapshot := item.plan.snapshot
+				if snapshot.CachedInit != "" && snapshot.CachedTools != "" {
+					d.updateTemplate(snapshot.Command, snapshot.Args, snapshot)
+				}
+			}
+			d.logger.Printf("handoff.receive.ok upstreams=%d staged=%d", len(handoffAccepted), len(staged))
 		}
 	}
-	if restored > 0 {
-		d.restoredOwnerCount.Add(uint64(restored))
+
+	if restartMode {
+		d.mu.Lock()
+		d.restartStaging = append([]snapshotRestorePlan(nil), staged...)
+		d.mu.Unlock()
+		if restored > 0 {
+			d.restoredOwnerCount.Add(uint64(restored))
+		}
+		planned := restored + len(staged)
+		d.logger.Printf("snapshot: restored %d process-backed owners; staged %d/%d metadata owners", restored, len(staged), len(snap.Owners))
+		return planned
 	}
 
+	if restored > 0 {
+		d.restoredOwnerCount.Add(uint64(restored))
+		d.runRestoreHealthGate()
+	}
 	d.logger.Printf("snapshot: restored %d/%d owners", restored, len(snap.Owners))
-
-	// FR-3 — post-restore listener health gate.
-	//
-	// Snapshot restore synchronously calls ipc.Listen, so a bind failure would
-	// already have aborted the entry above. But the listener can die AFTER
-	// successful bind for reasons that do not flow through closeListener()
-	// and therefore leave IsAccepting() lying. Observed in production on
-	// 2026-04-17 after a graceful-restart: 6/9 restored owners passed
-	// IsAccepting but refused ipc.Dial from a fresh shim. Until the exact
-	// trigger is pinned down, validate every restored owner defensively and
-	// tear down the zombies so the next shim request cold-spawns a fresh one.
-	d.runRestoreHealthGate()
-
 	return restored
 }
 

--- a/muxcore/daemon/snapshot.go
+++ b/muxcore/daemon/snapshot.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -92,19 +93,45 @@ type snapshotOwnerPin struct {
 }
 
 type snapshotRestartLease struct {
-	once sync.Once
-	pins []*owner.RestartPin
+	daemon       *Daemon
+	snapshot     *DaemonSnapshot
+	registryOnce sync.Once
+	ownerOnce    sync.Once
+	registryPins []snapshotOwnerPin
+	ownerPins    []*owner.RestartPin
+}
+
+func (l *snapshotRestartLease) ReleaseRegistryPins() {
+	if l == nil || l.daemon == nil {
+		return
+	}
+	l.registryOnce.Do(func() { l.daemon.releaseSnapshotOwnerPins(l.registryPins) })
+}
+
+func (l *snapshotRestartLease) ReleaseOwnerPins() {
+	if l == nil {
+		return
+	}
+	l.ownerOnce.Do(func() {
+		for _, pin := range l.ownerPins {
+			pin.Release()
+		}
+	})
 }
 
 func (l *snapshotRestartLease) Release() {
 	if l == nil {
 		return
 	}
-	l.once.Do(func() {
-		for _, pin := range l.pins {
-			pin.Release()
-		}
-	})
+	l.ReleaseRegistryPins()
+	l.ReleaseOwnerPins()
+}
+
+func (l *snapshotRestartLease) RewriteSnapshot() (string, error) {
+	if l == nil || l.daemon == nil || l.snapshot == nil {
+		return "", errors.New("restart snapshot lease has no retained payload")
+	}
+	return mcpsnapshot.Serialize(l.snapshot, l.daemon.logger)
 }
 
 // SerializeSnapshot walks all owners, exports their state, and delegates
@@ -118,25 +145,22 @@ func (d *Daemon) SerializeSnapshot() (string, error) {
 }
 
 func (d *Daemon) serializeSnapshotPinned() (string, *snapshotRestartLease, error) {
-	pins, err := d.acquireSnapshotOwnerPins()
+	registryPins, err := d.acquireSnapshotOwnerPins()
 	if err != nil {
 		return "", nil, err
 	}
-	defer d.releaseSnapshotOwnerPins(pins)
+	lease := &snapshotRestartLease{daemon: d, registryPins: registryPins}
+	releaseOnError := true
+	defer func() {
+		if releaseOnError {
+			lease.Release()
+		}
+	}()
 
 	barrierCtx, cancelBarrier := context.WithTimeout(context.Background(), restartMaterializationBarrierTimeout)
 	defer cancelBarrier()
-	ownerPins := make([]*owner.RestartPin, 0, len(pins))
-	keepOwnerPins := false
-	defer func() {
-		if keepOwnerPins {
-			return
-		}
-		for _, pin := range ownerPins {
-			pin.Release()
-		}
-	}()
-	for _, pin := range pins {
+	lease.ownerPins = make([]*owner.RestartPin, 0, len(registryPins))
+	for _, pin := range registryPins {
 		if d.beforeSnapshotOwnerExport != nil {
 			d.beforeSnapshotOwnerExport()
 		}
@@ -144,13 +168,13 @@ func (d *Daemon) serializeSnapshotPinned() (string, *snapshotRestartLease, error
 		if err != nil {
 			return "", nil, fmt.Errorf("serialize owner %s materialization: %w", pin.serverID, err)
 		}
-		ownerPins = append(ownerPins, ownerPin)
+		lease.ownerPins = append(lease.ownerPins, ownerPin)
 	}
 
-	owners := make([]mcpsnapshot.OwnerSnapshot, 0, len(pins))
+	owners := make([]mcpsnapshot.OwnerSnapshot, 0, len(registryPins))
 	sessions := make([]mcpsnapshot.SessionSnapshot, 0)
-	for i, pin := range pins {
-		snap, ownerSessions := ownerPins[i].Snapshot, ownerPins[i].Sessions
+	for i, pin := range registryPins {
+		snap, ownerSessions := lease.ownerPins[i].Snapshot, lease.ownerPins[i].Sessions
 		snap.ServerID = pin.serverID
 		snap.Mode = pin.mode
 		if snap.Env == nil {
@@ -177,13 +201,14 @@ func (d *Daemon) serializeSnapshotPinned() (string, *snapshotRestartLease, error
 		Owners:           owners,
 		Sessions:         sessions,
 	}
+	lease.snapshot = data
 
 	path, err := mcpsnapshot.Serialize(data, d.logger)
 	if err != nil {
 		return "", nil, err
 	}
-	keepOwnerPins = true
-	return path, &snapshotRestartLease{pins: ownerPins}, nil
+	releaseOnError = false
+	return path, lease, nil
 }
 
 func (d *Daemon) acquireSnapshotOwnerPins() ([]snapshotOwnerPin, error) {
@@ -245,6 +270,73 @@ func cloneSnapshotStringMap(src map[string]string) map[string]string {
 	return dst
 }
 
+func cloneOwnerSnapshotForRecovery(src mcpsnapshot.OwnerSnapshot) mcpsnapshot.OwnerSnapshot {
+	dst := src
+	dst.Args = append([]string(nil), src.Args...)
+	dst.Env = cloneSnapshotStringMap(src.Env)
+	dst.CwdSet = append([]string(nil), src.CwdSet...)
+	dst.ClassificationReason = append([]string(nil), src.ClassificationReason...)
+	dst.BoundTokens = append([]mcpsnapshot.BoundTokenSnapshot(nil), src.BoundTokens...)
+	for i := range dst.BoundTokens {
+		dst.BoundTokens[i].Env = cloneSnapshotStringMap(src.BoundTokens[i].Env)
+	}
+	return dst
+}
+
+func cloneSessionSnapshotForRecovery(src mcpsnapshot.SessionSnapshot) mcpsnapshot.SessionSnapshot {
+	dst := src
+	dst.Env = cloneSnapshotStringMap(src.Env)
+	return dst
+}
+
+func buildRestartRecoverySnapshot(base *DaemonSnapshot, plans []snapshotRestorePlan) *DaemonSnapshot {
+	if base == nil || len(plans) == 0 {
+		return nil
+	}
+	recovery := *base
+	recovery.Owners = make([]mcpsnapshot.OwnerSnapshot, 0, len(plans))
+	selected := make(map[string]struct{}, len(plans))
+	for _, plan := range plans {
+		sid := plan.snapshot.ServerID
+		if _, duplicate := selected[sid]; duplicate {
+			continue
+		}
+		selected[sid] = struct{}{}
+		recovery.Owners = append(recovery.Owners, cloneOwnerSnapshotForRecovery(plan.snapshot))
+	}
+	recovery.Sessions = make([]mcpsnapshot.SessionSnapshot, 0, len(base.Sessions))
+	for _, session := range base.Sessions {
+		if _, keep := selected[session.OwnerServerID]; keep {
+			recovery.Sessions = append(recovery.Sessions, cloneSessionSnapshotForRecovery(session))
+		}
+	}
+	return &recovery
+}
+
+func (d *Daemon) rewriteRestartRecoverySnapshot() (string, error) {
+	d.mu.RLock()
+	retained := d.restartRecoverySnapshot
+	if retained == nil {
+		d.mu.RUnlock()
+		return "", errors.New("restart recovery snapshot is unavailable")
+	}
+	recovery := *retained
+	recovery.Owners = make([]mcpsnapshot.OwnerSnapshot, len(retained.Owners))
+	for i, ownerSnap := range retained.Owners {
+		recovery.Owners[i] = cloneOwnerSnapshotForRecovery(ownerSnap)
+	}
+	recovery.Sessions = make([]mcpsnapshot.SessionSnapshot, len(retained.Sessions))
+	for i, session := range retained.Sessions {
+		recovery.Sessions[i] = cloneSessionSnapshotForRecovery(session)
+	}
+	d.mu.RUnlock()
+
+	recovery.Timestamp = time.Now().UTC().Format(time.RFC3339Nano)
+	recovery.DaemonGeneration = d.daemonGeneration
+	recovery.PredecessorPID = os.Getpid()
+	return mcpsnapshot.Serialize(&recovery, d.logger)
+}
+
 // DeserializeSnapshot reads and validates a snapshot from the well-known path.
 // Returns nil, nil if no snapshot exists (cold start). Deletes the file after
 // successful load or if stale. Logs warnings for corrupt/stale snapshots.
@@ -299,13 +391,14 @@ func (d *Daemon) tryHandoffReceive(ctx context.Context) *handoffReceipt {
 }
 
 type snapshotRestorePlan struct {
-	snapshot mcpsnapshot.OwnerSnapshot
-	cfg      owner.OwnerConfig
-	env      map[string]string
+	snapshot  mcpsnapshot.OwnerSnapshot
+	cfg       owner.OwnerConfig
+	env       map[string]string
+	blockedBy *OwnerEntry
 }
 
 func (d *Daemon) makeSnapshotRestorePlan(ownerSnap mcpsnapshot.OwnerSnapshot) snapshotRestorePlan {
-	restoredEnv := mergeEnv(ownerSnap.Env)
+	restoredEnv := cloneSnapshotStringMap(ownerSnap.Env)
 	command := ownerSnap.Command
 	args := append([]string(nil), ownerSnap.Args...)
 	cfg := owner.OwnerConfig{
@@ -342,6 +435,16 @@ func (d *Daemon) makeSnapshotRestorePlan(ownerSnap mcpsnapshot.OwnerSnapshot) sn
 
 func (d *Daemon) restoreSnapshotPlan(plan snapshotRestorePlan, handoff *HandoffUpstream, restoreSource string, eager, publishTemplate bool) (*OwnerEntry, bool, error) {
 	snap := plan.snapshot
+	if isRestartRestoreMode() {
+		// Snapshot capture cannot exclude a late list_changed or discovery
+		// response from the predecessor. Preserve initialize for protocol and
+		// runtime policy, but force every secondary discovery list through the
+		// adopted live generation before replay or template publication.
+		snap.CachedTools = ""
+		snap.CachedPrompts = ""
+		snap.CachedResources = ""
+		snap.CachedResourceTemplates = ""
+	}
 	if isRestartRestoreMode() {
 		d.retireOldOwnerSockets(plan.cfg.IPCPath, plan.cfg.ControlPath)
 	}
@@ -429,26 +532,92 @@ func (d *Daemon) restoreSnapshotPlan(plan snapshotRestorePlan, handoff *HandoffU
 	return entry, reattached, nil
 }
 
-func (d *Daemon) activateRestartStaging() int {
-	d.mu.Lock()
+func (d *Daemon) activateRestartStaging() (int, error) {
+	d.mu.RLock()
 	plans := append([]snapshotRestorePlan(nil), d.restartStaging...)
-	d.restartStaging = nil
-	d.mu.Unlock()
+	d.mu.RUnlock()
+	if err := d.waitForRestartStagingBlockers(plans); err != nil {
+		return 0, err
+	}
 
-	restored := 0
+	type activatedOwner struct {
+		plan  snapshotRestorePlan
+		entry *OwnerEntry
+	}
+	activated := make([]activatedOwner, 0, len(plans))
 	for _, plan := range plans {
-		if _, _, err := d.restoreSnapshotPlan(plan, nil, "snapshot_fallback", true, true); err != nil {
-			d.logger.Printf("snapshot: staged restore failed for %s (%s): %v", shortServerID(plan.snapshot.ServerID), plan.snapshot.Command, err)
+		entry, _, err := d.restoreSnapshotPlan(plan, nil, "snapshot_fallback", false, true)
+		if err == nil {
+			activated = append(activated, activatedOwner{plan: plan, entry: entry})
 			continue
 		}
-		restored++
+
+		activationErr := fmt.Errorf("snapshot: staged restore failed for %s (%s): %w", shortServerID(plan.snapshot.ServerID), plan.snapshot.Command, err)
+		rollbackErrs := make([]error, 0, len(activated))
+		for i := len(activated) - 1; i >= 0; i-- {
+			item := activated[i]
+			result, removeErr := d.removeOwnerIfCurrent(item.plan.snapshot.ServerID, item.entry, ownerRemovalReasonRestoreFailed, false)
+			if removeErr != nil {
+				rollbackErrs = append(rollbackErrs, fmt.Errorf("rollback staged owner %s: %w", shortServerID(item.plan.snapshot.ServerID), removeErr))
+			} else if !result.Removed {
+				rollbackErrs = append(rollbackErrs, fmt.Errorf("rollback staged owner %s: owner remained registered", shortServerID(item.plan.snapshot.ServerID)))
+			}
+		}
+		if len(rollbackErrs) > 0 {
+			return 0, errors.Join(append([]error{activationErr}, rollbackErrs...)...)
+		}
+		return 0, activationErr
 	}
+
+	d.mu.Lock()
+	d.restartStaging = nil
+	d.restartRecoverySnapshot = nil
+	d.mu.Unlock()
+	// Construct and register the complete staged set before any fallback process
+	// starts. A later registration failure can then roll back inert owners without
+	// creating a transient extra process generation.
+	for _, item := range activated {
+		item.entry.Owner.SpawnUpstreamBackground()
+	}
+	restored := len(activated)
 	if restored > 0 {
 		d.restoredOwnerCount.Add(uint64(restored))
 		d.runRestoreHealthGate()
 	}
 	d.logger.Printf("snapshot: activated %d/%d staged owners after predecessor finalization", restored, len(plans))
-	return restored
+	return restored, nil
+}
+
+func (d *Daemon) waitForRestartStagingBlockers(plans []snapshotRestorePlan) error {
+	deadline := time.NewTimer(restartMaterializationBarrierTimeout)
+	defer deadline.Stop()
+	for _, plan := range plans {
+		if plan.blockedBy == nil {
+			continue
+		}
+		for {
+			d.mu.RLock()
+			current := d.owners[plan.snapshot.ServerID]
+			d.mu.RUnlock()
+			if current == nil {
+				break
+			}
+			if current != plan.blockedBy {
+				return fmt.Errorf("restart fallback owner %s was replaced before rollback finalization", shortServerID(plan.snapshot.ServerID))
+			}
+			timer := time.NewTimer(10 * time.Millisecond)
+			select {
+			case <-timer.C:
+			case <-deadline.C:
+				timer.Stop()
+				return fmt.Errorf("restart fallback owner %s finalization remained unproven after %s", shortServerID(plan.snapshot.ServerID), restartMaterializationBarrierTimeout)
+			case <-d.done:
+				timer.Stop()
+				return errors.New("daemon stopped while waiting for restart rollback finalization")
+			}
+		}
+	}
+	return nil
 }
 
 // loadSnapshot checks for a snapshot file and restores owners from it.
@@ -528,6 +697,7 @@ func (d *Daemon) loadSnapshot() int {
 				}
 				if !result.Removed {
 					item.entry.Owner.Shutdown()
+					item.plan.blockedBy = item.entry
 				}
 				fallback = append(fallback, item.plan)
 			}
@@ -537,19 +707,23 @@ func (d *Daemon) loadSnapshot() int {
 			staged = fallback
 			restored = 0
 		} else {
-			for _, item := range adopted {
-				snapshot := item.plan.snapshot
-				if snapshot.CachedInit != "" && snapshot.CachedTools != "" {
-					d.updateTemplate(snapshot.Command, snapshot.Args, snapshot)
-				}
-			}
+			// Adopted owners intentionally begin with secondary discovery caches
+			// invalidated. Their first live tools/list response republishes a fresh
+			// template through publishOwnerCache.
 			d.logger.Printf("handoff.receive.ok upstreams=%d staged=%d", len(handoffAccepted), len(staged))
 		}
 	}
 
 	if restartMode {
+		recoveryPlans := append([]snapshotRestorePlan(nil), staged...)
+		if restored > 0 {
+			for _, item := range adopted {
+				recoveryPlans = append(recoveryPlans, item.plan)
+			}
+		}
 		d.mu.Lock()
 		d.restartStaging = append([]snapshotRestorePlan(nil), staged...)
+		d.restartRecoverySnapshot = buildRestartRecoverySnapshot(snap, recoveryPlans)
 		d.mu.Unlock()
 		if restored > 0 {
 			d.restoredOwnerCount.Add(uint64(restored))
@@ -582,8 +756,9 @@ func (d *Daemon) loadSnapshotMetadataOnly(reason string) int {
 	d.predecessorDaemonGeneration = snap.DaemonGeneration
 	d.mu.Unlock()
 
+	restoreCaches := !isRestartRestoreMode()
 	for _, ownerSnap := range snap.Owners {
-		if ownerSnap.CachedInit != "" && ownerSnap.CachedTools != "" {
+		if restoreCaches && ownerSnap.CachedInit != "" && ownerSnap.CachedTools != "" {
 			d.updateTemplate(ownerSnap.Command, ownerSnap.Args, ownerSnap)
 		}
 		d.rehydrateRetryCounter(ownerSnap.ServerID, ownerSnap.Command, ownerSnap.Args, ownerSnap.Cwd)

--- a/muxcore/daemon/snapshot_reattach_test.go
+++ b/muxcore/daemon/snapshot_reattach_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -11,12 +12,15 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/thebtf/mcp-mux/muxcore/classify"
+	"github.com/thebtf/mcp-mux/muxcore/control"
+	"github.com/thebtf/mcp-mux/muxcore/owner"
 	mcpsnapshot "github.com/thebtf/mcp-mux/muxcore/snapshot"
 	"github.com/thebtf/mcp-mux/muxcore/upstream"
 )
@@ -207,6 +211,296 @@ func TestSnapshotRestartModeRestoresSessionHandlerOwner(t *testing.T) {
 	}
 }
 
+func TestSnapshotRestartDefersFreshGenerationUntilControlTakeover(t *testing.T) {
+	const roleEnv = "MCPMUX_TEST_SNAPSHOT_RESTART_BARRIER_ROLE"
+	if os.Getenv(roleEnv) == "upstream" {
+		pidFile, err := os.OpenFile(os.Getenv("MCPMUX_TEST_SNAPSHOT_RESTART_BARRIER_PIDS"), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+		if err != nil {
+			t.Fatalf("open pid file: %v", err)
+		}
+		_, _ = fmt.Fprintln(pidFile, os.Getpid())
+		_ = pidFile.Close()
+		scanner := bufio.NewScanner(os.Stdin)
+		for scanner.Scan() {
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+				t.Fatalf("decode upstream request: %v", err)
+			}
+			switch req.Method {
+			case "initialize":
+				_, err = fmt.Fprintf(os.Stdout, `{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":"2025-11-25","capabilities":{},"serverInfo":{"name":"snapshot-barrier","version":"1"}}}`+"\n", req.ID)
+			case "tools/list":
+				_, err = fmt.Fprintf(os.Stdout, `{"jsonrpc":"2.0","id":%s,"result":{"tools":[]}}`+"\n", req.ID)
+			}
+			if err != nil {
+				t.Fatalf("write upstream response: %v", err)
+			}
+		}
+		return
+	}
+
+	os.Remove(SnapshotPath())
+	t.Cleanup(func() { _ = os.Remove(SnapshotPath()) })
+	pidPath := filepath.Join(t.TempDir(), "upstream-pids.txt")
+	ctlPath := shortSocketPath(t, "snapshot-restart-barrier.ctl.sock")
+
+	predecessor, err := New(Config{
+		Name:        "snapshot-restart-barrier",
+		ControlPath: ctlPath,
+		GracePeriod: time.Second,
+		IdleTimeout: 5 * time.Second,
+		Logger:      testLogger(t),
+	})
+	if err != nil {
+		t.Fatalf("New(predecessor): %v", err)
+	}
+	predecessorStopped := false
+	t.Cleanup(func() {
+		if !predecessorStopped {
+			predecessor.Shutdown()
+		}
+	})
+
+	_, sid, _, err := predecessor.Spawn(control.Request{
+		Cmd:     "spawn",
+		Command: os.Args[0],
+		Args:    []string{"-test.run=^TestSnapshotRestartDefersFreshGenerationUntilControlTakeover$"},
+		Env: map[string]string{
+			roleEnv: "upstream",
+			"MCPMUX_TEST_SNAPSHOT_RESTART_BARRIER_PIDS": pidPath,
+		},
+		Cwd:  t.TempDir(),
+		Mode: "global",
+	})
+	if err != nil {
+		t.Fatalf("Spawn(predecessor): %v", err)
+	}
+	waitForDaemonCondition(t, 3*time.Second, func() bool {
+		return len(uniquePIDsFromFile(pidPath)) == 1
+	}, "predecessor upstream did not start")
+	if _, err := predecessor.SerializeSnapshot(); err != nil {
+		t.Fatalf("SerializeSnapshot(): %v", err)
+	}
+
+	origDelay := snapshotRestartControlBindDelay
+	origInterval := controlBindRetryInterval
+	origAttempts := controlBindMaxAttempts
+	snapshotRestartControlBindDelay = 0
+	controlBindRetryInterval = 20 * time.Millisecond
+	controlBindMaxAttempts = 200
+	t.Cleanup(func() {
+		snapshotRestartControlBindDelay = origDelay
+		controlBindRetryInterval = origInterval
+		controlBindMaxAttempts = origAttempts
+	})
+	t.Setenv(snapshotRestartEnv, "1")
+	t.Setenv("MCPMUX_HANDOFF_TOKEN_PATH", "")
+	t.Setenv("MCPMUX_HANDOFF_SOCKET", "")
+
+	logBuf := &syncBuffer{}
+	type newResult struct {
+		d   *Daemon
+		err error
+	}
+	successorDone := make(chan newResult, 1)
+	go func() {
+		d, newErr := New(Config{
+			Name:        "snapshot-restart-barrier",
+			ControlPath: ctlPath,
+			GracePeriod: time.Second,
+			IdleTimeout: 5 * time.Second,
+			Logger:      log.New(logBuf, "[successor] ", log.LstdFlags),
+		})
+		successorDone <- newResult{d: d, err: newErr}
+	}()
+
+	waitForDaemonCondition(t, 3*time.Second, func() bool {
+		return strings.Contains(logBuf.String(), "handoff.control_bind_wait")
+	}, "successor did not reach control-takeover barrier")
+	time.Sleep(100 * time.Millisecond)
+	if pids := uniquePIDsFromFile(pidPath); len(pids) != 1 {
+		t.Fatalf("successor started process before control takeover: pids=%v logs:\n%s", pids, logBuf.String())
+	}
+
+	predecessor.Shutdown()
+	predecessorStopped = true
+	result := <-successorDone
+	if result.err != nil {
+		t.Fatalf("New(successor): %v; logs:\n%s", result.err, logBuf.String())
+	}
+	successor := result.d
+	t.Cleanup(func() { successor.Shutdown() })
+
+	waitForDaemonCondition(t, 3*time.Second, func() bool {
+		return len(uniquePIDsFromFile(pidPath)) == 2
+	}, "successor did not start exactly one post-barrier generation")
+	time.Sleep(150 * time.Millisecond)
+	if pids := uniquePIDsFromFile(pidPath); len(pids) != 2 {
+		t.Fatalf("snapshot restart created duplicate generations: pids=%v logs:\n%s", pids, logBuf.String())
+	}
+	entry := successor.Entry(sid)
+	if entry == nil || entry.Owner == nil {
+		t.Fatalf("successor owner %s missing; logs:\n%s", sid, logBuf.String())
+	}
+	if entry.RestoreSource != "snapshot_fallback" {
+		t.Fatalf("restore_source=%q, want snapshot_fallback", entry.RestoreSource)
+	}
+	if state := entry.Owner.MaterializationState(); state == owner.MaterializationCacheOnly {
+		t.Fatalf("post-barrier owner state=%s, want eager generation", state)
+	}
+}
+
+func uniquePIDsFromFile(path string) []int {
+	data, _ := os.ReadFile(path)
+	seen := make(map[int]struct{})
+	for _, field := range strings.Fields(string(data)) {
+		pid, err := strconv.Atoi(field)
+		if err == nil && pid > 0 {
+			seen[pid] = struct{}{}
+		}
+	}
+	pids := make([]int, 0, len(seen))
+	for pid := range seen {
+		pids = append(pids, pid)
+	}
+	return pids
+}
+func TestMixedReadyCacheOnlyRestartHandoffKeepsOneAuthorityPerOwner(t *testing.T) {
+	const roleEnv = "MCPMUX_TEST_MIXED_RESTART_HANDOFF_ROLE"
+	const pidPathEnv = "MCPMUX_TEST_MIXED_RESTART_HANDOFF_PIDS"
+	if os.Getenv(roleEnv) == "upstream" {
+		pidFile, err := os.OpenFile(os.Getenv(pidPathEnv), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+		if err != nil {
+			t.Fatalf("open mixed restart pid file: %v", err)
+		}
+		_, _ = fmt.Fprintln(pidFile, os.Getpid())
+		_ = pidFile.Close()
+		scanner := bufio.NewScanner(os.Stdin)
+		for scanner.Scan() {
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+				t.Fatalf("decode mixed restart upstream request: %v", err)
+			}
+			switch req.Method {
+			case "initialize":
+				_, err = fmt.Fprintf(os.Stdout, `{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":"2025-11-25","capabilities":{"x-mux":{"sharing":"shared"}},"serverInfo":{"name":"mixed-restart","version":"1"}}}`+"\n", req.ID)
+			case "tools/list":
+				_, err = fmt.Fprintf(os.Stdout, `{"jsonrpc":"2.0","id":%s,"result":{"tools":[]}}`+"\n", req.ID)
+			default:
+				continue
+			}
+			if err != nil {
+				t.Fatalf("write mixed restart upstream response: %v", err)
+			}
+		}
+		return
+	}
+
+	pidPath := filepath.Join(t.TempDir(), "mixed-restart-pids.txt")
+	command := os.Args[0]
+	args := []string{"-test.run=^TestMixedReadyCacheOnlyRestartHandoffKeepsOneAuthorityPerOwner$"}
+	launchEnv := mergeEnv(map[string]string{roleEnv: "upstream", pidPathEnv: pidPath})
+	proc, err := upstream.Start(command, args, launchEnv, t.TempDir(), testLogger(t))
+	if err != nil {
+		t.Fatalf("start adopted handoff process: %v", err)
+	}
+	t.Cleanup(func() { _ = proc.AbortDetach() })
+	waitForDaemonCondition(t, 3*time.Second, func() bool { return len(uniquePIDsFromFile(pidPath)) == 1 }, "adopted handoff process did not start")
+
+	pid, stdinFD, stdoutFD, stderrFD, authorityFD, err := proc.DetachWithAuthority()
+	if err != nil {
+		t.Fatalf("DetachWithAuthority: %v", err)
+	}
+	stdinDup := dupRawHandoffHandle(t, stdinFD)
+	stdoutDup := dupRawHandoffHandle(t, stdoutFD)
+	stderrDup := dupRawHandoffHandle(t, stderrFD)
+	authorityDup := dupRawHandoffHandle(t, authorityFD)
+	transferred := false
+	t.Cleanup(func() {
+		if transferred {
+			return
+		}
+		for _, handle := range []uintptr{stdinDup, stdoutDup, stderrDup, authorityDup} {
+			closeRawHandoffHandle(handle)
+		}
+	})
+
+	d := testDaemon(t)
+	adoptedSnapshot := daemonMaterializationSnapshot(false)
+	adoptedSnapshot.ServerID = "mixed-ready-adopted-owner"
+	adoptedSnapshot.Command = command
+	adoptedSnapshot.Args = args
+	adoptedSnapshot.Cwd = t.TempDir()
+	adoptedSnapshot.Env = map[string]string{roleEnv: "upstream", pidPathEnv: pidPath}
+	adoptedSnapshot.Mode = "global"
+	adoptedPlan := d.makeSnapshotRestorePlan(adoptedSnapshot)
+	adoptedEntry, reattached, err := d.restoreSnapshotPlan(adoptedPlan, &HandoffUpstream{
+		ServerID:    adoptedSnapshot.ServerID,
+		Command:     command,
+		PID:         pid,
+		StdinFD:     stdinDup,
+		StdoutFD:    stdoutDup,
+		StderrFD:    stderrDup,
+		AuthorityFD: authorityDup,
+	}, "snapshot_handoff", false, false)
+	if err != nil {
+		t.Fatalf("restore adopted plan: %v", err)
+	}
+	if !reattached {
+		t.Fatal("process-backed owner was not reattached")
+	}
+	transferred = true
+	if err := proc.CommitDetach(); err != nil {
+		t.Fatalf("CommitDetach: %v", err)
+	}
+	if state := adoptedEntry.Owner.MaterializationState(); state != owner.MaterializationReady {
+		t.Fatalf("adopted owner state=%s, want READY", state)
+	}
+
+	cacheSnapshot := daemonMaterializationSnapshot(false)
+	cacheSnapshot.ServerID = "mixed-cache-only-owner"
+	cacheSnapshot.Command = command
+	cacheSnapshot.Args = args
+	cacheSnapshot.Cwd = t.TempDir()
+	cacheSnapshot.Env = map[string]string{roleEnv: "upstream", pidPathEnv: pidPath}
+	cacheSnapshot.Mode = "global"
+	cacheEntry, reattached, err := d.restoreSnapshotPlan(d.makeSnapshotRestorePlan(cacheSnapshot), nil, "snapshot_fallback", false, true)
+	if err != nil {
+		t.Fatalf("restore cache-only plan: %v", err)
+	}
+	if reattached {
+		t.Fatal("no-handle owner unexpectedly reported reattached")
+	}
+	if state := cacheEntry.Owner.MaterializationState(); state != owner.MaterializationCacheOnly {
+		t.Fatalf("no-handle owner state=%s, want CACHE_ONLY", state)
+	}
+	if pids := uniquePIDsFromFile(pidPath); len(pids) != 1 {
+		t.Fatalf("mixed READY/CACHE_ONLY state has pids=%v, want sole adopted authority", pids)
+	}
+	if pid, _ := cacheEntry.Owner.Status()["upstream_pid"].(int); pid != 0 {
+		t.Fatalf("cache-only owner upstream pid=%d, want 0 before activation", pid)
+	}
+
+	cacheEntry.Owner.SpawnUpstreamBackground()
+	waitForDaemonCondition(t, 3*time.Second, func() bool {
+		return cacheEntry.Owner.MaterializationState() == owner.MaterializationReady && len(uniquePIDsFromFile(pidPath)) == 2
+	}, "cache-only owner did not activate exactly one eager generation")
+	adoptedPID, _ := adoptedEntry.Owner.Status()["upstream_pid"].(int)
+	cachePID, _ := cacheEntry.Owner.Status()["upstream_pid"].(int)
+	if adoptedPID <= 0 || cachePID <= 0 || adoptedPID == cachePID {
+		t.Fatalf("final owner authorities adopted=%d cache=%d, want two distinct positive pids", adoptedPID, cachePID)
+	}
+	if pids := uniquePIDsFromFile(pidPath); len(pids) != 2 {
+		t.Fatalf("mixed restart created duplicate process authorities: %v", pids)
+	}
+}
+
 func TestLoadSnapshot_Reattach_HappyPath(t *testing.T) {
 	os.Remove(SnapshotPath())
 
@@ -326,6 +620,15 @@ func TestLoadSnapshot_Reattach_HappyPath(t *testing.T) {
 	if restored != 1 {
 		t.Fatalf("loadSnapshot() restored %d owners, want 1", restored)
 	}
+	// loadSnapshot keeps no-handle entries metadata-only until the caller
+	// proves predecessor finalization. This direct unit test models that gate.
+	wantActivated := 0
+	if runtime.GOOS == "windows" {
+		wantActivated = 1
+	}
+	if activated := d.activateRestartStaging(); activated != wantActivated {
+		t.Fatalf("activateRestartStaging()=%d, want %d; logs:\n%s", activated, wantActivated, logBuf.String())
+	}
 
 	// Assert the handoff result via structural log inspection rather
 	// than polling d.owners. The supervisor goroutine started by
@@ -343,8 +646,8 @@ func TestLoadSnapshot_Reattach_HappyPath(t *testing.T) {
 		if strings.Contains(logs, wantHandoff) {
 			t.Errorf("did not expect Windows fixture without Job authority to reattach the owner.\nLogs:\n%s", logs)
 		}
-		if !strings.Contains(logs, "Windows handoff missing Job authority — falling back to spawn") {
-			t.Errorf("missing safe Windows snapshot fallback marker.\nLogs:\n%s", logs)
+		if !strings.Contains(logs, "Windows handoff missing Job authority") || !strings.Contains(logs, "staging eager fallback") {
+			t.Errorf("missing safe Windows staged fallback marker.\nLogs:\n%s", logs)
 		}
 	} else if !strings.Contains(logs, wantHandoff) {
 		t.Errorf("expected log %q (handoff path marker), not found.\nLogs:\n%s",
@@ -413,6 +716,7 @@ func TestLoadSnapshot_Reattach_SocketUnreachable(t *testing.T) {
 	if restored != 1 {
 		t.Fatalf("loadSnapshot() restored %d owners (want 1); FR-8 fallback failed", restored)
 	}
+	d.activateRestartStaging()
 
 	// Structural log assertions replace the d.owners poll (which races with
 	// OnUpstreamExit on fast schedulers — see F80-4 and the happy-path fix
@@ -517,15 +821,25 @@ func TestLoadSnapshot_Reattach_LegacyV1FallsBackToFreshSpawn(t *testing.T) {
 		t.Fatalf("loadSnapshot() restored %d owners, want 1", restored)
 	}
 
-	deadline := time.Now().Add(10 * time.Second)
-	for {
-		if _, err := os.Stat(spawnMarker); err == nil {
-			break
-		}
-		if time.Now().After(deadline) {
-			t.Fatalf("snapshot fallback did not spawn a fresh upstream; logs:\n%s", logBuf.String())
-		}
-		time.Sleep(20 * time.Millisecond)
+	if _, err := os.Stat(spawnMarker); !os.IsNotExist(err) {
+		t.Fatalf("snapshot stage started an upstream before predecessor barrier: err=%v logs:\n%s", err, logBuf.String())
+	}
+	if entry := d.Entry(sid); entry != nil {
+		t.Fatalf("snapshot stage bound owner IPC before predecessor barrier: %#v", entry)
+	}
+	if activated := d.activateRestartStaging(); activated != 1 {
+		t.Fatalf("activateRestartStaging()=%d, want 1", activated)
+	}
+	waitForDaemonCondition(t, 2*time.Second, func() bool {
+		_, err := os.Stat(spawnMarker)
+		return err == nil
+	}, "snapshot fallback did not start one eager restore generation")
+	entry := d.Entry(sid)
+	if entry == nil || entry.Owner == nil || !entry.Owner.CacheReady() {
+		t.Fatalf("eager fallback owner missing cached discovery; logs:\n%s", logBuf.String())
+	}
+	if state := entry.Owner.MaterializationState(); state == owner.MaterializationCacheOnly {
+		t.Fatalf("fallback state=%s after predecessor barrier, want eager materialization", state)
 	}
 
 	logs := logBuf.String()
@@ -586,16 +900,15 @@ func TestLoadSnapshot_SessionHandlerRestoreDoesNotSpawnCommand(t *testing.T) {
 		t.Fatalf("loadSnapshot() restored %d owners, want 1", restored)
 	}
 
-	deadline := time.Now().Add(2 * time.Second)
-	for {
-		logs := buf.String()
-		if strings.Contains(logs, "background SessionHandler-only spawn: no upstream process") {
-			break
-		}
-		if time.Now().After(deadline) {
-			t.Fatalf("missing SessionHandler-only no-op marker in logs:\n%s", logs)
-		}
-		time.Sleep(10 * time.Millisecond)
+	entry := d.Entry(sid)
+	if entry == nil || entry.Owner == nil {
+		t.Fatal("restored SessionHandler owner missing")
+	}
+	if state := entry.Owner.MaterializationState(); state != owner.MaterializationReady {
+		t.Fatalf("SessionHandler materialization state=%s, want ready", state)
+	}
+	if pid, _ := entry.Owner.Status()["upstream_pid"].(int); pid != 0 {
+		t.Fatalf("SessionHandler restore spawned upstream pid %d", pid)
 	}
 
 	logs := buf.String()
@@ -778,17 +1091,12 @@ func TestLoadSnapshot_Reattach_PartialHandoff(t *testing.T) {
 	if restored != 2 {
 		t.Fatalf("loadSnapshot() restored %d owners, want 2", restored)
 	}
+	d.activateRestartStaging()
 
-	// FR-7 is verified by structural log inspection rather than by probing
-	// d.owners — in the partial scenario both owners get removed from the
-	// map almost immediately after insertion (sid1's proactive init writes
-	// to a stub pipe with no reader and errors out; sid2 spawns "echo two"
-	// which exits cleanly after ~1ms). The code path that routes each
-	// owner through handoff vs. legacy is already complete by the time
-	// loadSnapshot returns, and daemon.Logger emits a stable marker per
-	// path: "snapshot: reattached owner <sid> from handoff" for the
-	// handoff path, "snapshot: restored owner <sid> for <cmd> <args>"
-	// for every successful registration regardless of path.
+	// After the modeled predecessor barrier, structural logs show which
+	// entries retained transferred authority and which started one fresh
+	// fallback generation. The map itself is intentionally ephemeral here:
+	// the test fixtures exit quickly after registration.
 	logs := logBuf.String()
 
 	wantSid1Handoff := "snapshot: reattached owner " + sid1[:8] + " from handoff"
@@ -796,8 +1104,8 @@ func TestLoadSnapshot_Reattach_PartialHandoff(t *testing.T) {
 		if strings.Contains(logs, wantSid1Handoff) {
 			t.Errorf("did not expect Windows fixture without Job authority to reattach sid1.\nLogs:\n%s", logs)
 		}
-		if !strings.Contains(logs, "Windows handoff missing Job authority — falling back to spawn") {
-			t.Errorf("missing safe Windows snapshot fallback marker.\nLogs:\n%s", logs)
+		if !strings.Contains(logs, "Windows handoff missing Job authority") || !strings.Contains(logs, "staging eager fallback") {
+			t.Errorf("missing safe Windows staged fallback marker.\nLogs:\n%s", logs)
 		}
 	} else if !strings.Contains(logs, wantSid1Handoff) {
 		t.Errorf("expected log %q for sid1 (handoff path), not found.\nLogs:\n%s", wantSid1Handoff, logs)
@@ -809,11 +1117,13 @@ func TestLoadSnapshot_Reattach_PartialHandoff(t *testing.T) {
 		t.Errorf("did not expect log %q for sid2 — sid2 was absent from handoff payload.\nLogs:\n%s", dontWantSid2Handoff, logs)
 	}
 
-	// Both owners must have been registered (positive check for both).
-	for _, expected := range []string{
-		"snapshot: restored owner " + sid1[:8] + " for echo [one]",
-		"snapshot: restored owner " + sid2[:8] + " for echo [two]",
-	} {
+	// The absent sid2 always takes the fresh-generation path. On Windows the
+	// fixture intentionally lacks transferable Job authority, so sid1 does too.
+	expectedFresh := []string{"snapshot: restored owner " + sid2[:8] + " for echo [two]"}
+	if runtime.GOOS == "windows" {
+		expectedFresh = append(expectedFresh, "snapshot: restored owner "+sid1[:8]+" for echo [one]")
+	}
+	for _, expected := range expectedFresh {
 		if !strings.Contains(logs, expected) {
 			t.Errorf("expected log %q, not found.\nLogs:\n%s", expected, logs)
 		}

--- a/muxcore/daemon/snapshot_reattach_test.go
+++ b/muxcore/daemon/snapshot_reattach_test.go
@@ -129,8 +129,47 @@ func TestLoadSnapshotMetadataOnlyConsumesWithoutRestoringOwners(t *testing.T) {
 	if d.predecessorDaemonGeneration != "daemon_previous" {
 		t.Fatalf("predecessorDaemonGeneration = %q, want daemon_previous", d.predecessorDaemonGeneration)
 	}
+	if _, ok := d.getTemplate("", nil); !ok {
+		t.Fatal("ordinary metadata-only load did not retain coherent template cache")
+	}
 	if !strings.Contains(logBuf.String(), "snapshot: deferred restore of 1 owners (test)") {
 		t.Fatalf("missing deferred restore log:\n%s", logBuf.String())
+	}
+}
+
+func TestRestartMetadataOnlyLoadSuppressesStaleTemplateCache(t *testing.T) {
+	os.Remove(SnapshotPath())
+	t.Cleanup(func() { os.Remove(SnapshotPath()) })
+	t.Setenv(snapshotRestartEnv, "1")
+
+	const command = "restart-metadata-cache"
+	snapshot := DaemonSnapshot{
+		Version:   mcpsnapshot.SnapshotVersion,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Owners: []mcpsnapshot.OwnerSnapshot{{
+			ServerID:       "restart-metadata-cache-owner",
+			Command:        command,
+			Cwd:            t.TempDir(),
+			Mode:           "global",
+			Classification: classify.ModeShared,
+			CachedInit:     "e30=",
+			CachedTools:    "e30=",
+		}},
+	}
+	data, err := json.Marshal(snapshot)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	if err := os.WriteFile(SnapshotPath(), data, 0o644); err != nil {
+		t.Fatalf("WriteFile snapshot: %v", err)
+	}
+
+	d, _ := testDaemonWithLog(t)
+	if deferred := d.loadSnapshotMetadataOnly("restart-test"); deferred != 1 {
+		t.Fatalf("loadSnapshotMetadataOnly() = %d, want 1", deferred)
+	}
+	if _, ok := d.getTemplate(command, nil); ok {
+		t.Fatal("restart metadata-only load published stale template cache")
 	}
 }
 
@@ -368,6 +407,7 @@ func uniquePIDsFromFile(path string) []int {
 	}
 	return pids
 }
+
 func TestMixedReadyCacheOnlyRestartHandoffKeepsOneAuthorityPerOwner(t *testing.T) {
 	const roleEnv = "MCPMUX_TEST_MIXED_RESTART_HANDOFF_ROLE"
 	const pidPathEnv = "MCPMUX_TEST_MIXED_RESTART_HANDOFF_PIDS"
@@ -626,7 +666,11 @@ func TestLoadSnapshot_Reattach_HappyPath(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		wantActivated = 1
 	}
-	if activated := d.activateRestartStaging(); activated != wantActivated {
+	activated, err := d.activateRestartStaging()
+	if err != nil {
+		t.Fatalf("activateRestartStaging() error: %v; logs:\n%s", err, logBuf.String())
+	}
+	if activated != wantActivated {
 		t.Fatalf("activateRestartStaging()=%d, want %d; logs:\n%s", activated, wantActivated, logBuf.String())
 	}
 
@@ -716,7 +760,9 @@ func TestLoadSnapshot_Reattach_SocketUnreachable(t *testing.T) {
 	if restored != 1 {
 		t.Fatalf("loadSnapshot() restored %d owners (want 1); FR-8 fallback failed", restored)
 	}
-	d.activateRestartStaging()
+	if _, err := d.activateRestartStaging(); err != nil {
+		t.Fatalf("activateRestartStaging() error: %v", err)
+	}
 
 	// Structural log assertions replace the d.owners poll (which races with
 	// OnUpstreamExit on fast schedulers — see F80-4 and the happy-path fix
@@ -827,7 +873,11 @@ func TestLoadSnapshot_Reattach_LegacyV1FallsBackToFreshSpawn(t *testing.T) {
 	if entry := d.Entry(sid); entry != nil {
 		t.Fatalf("snapshot stage bound owner IPC before predecessor barrier: %#v", entry)
 	}
-	if activated := d.activateRestartStaging(); activated != 1 {
+	activated, err := d.activateRestartStaging()
+	if err != nil {
+		t.Fatalf("activateRestartStaging() error: %v", err)
+	}
+	if activated != 1 {
 		t.Fatalf("activateRestartStaging()=%d, want 1", activated)
 	}
 	waitForDaemonCondition(t, 2*time.Second, func() bool {
@@ -835,8 +885,11 @@ func TestLoadSnapshot_Reattach_LegacyV1FallsBackToFreshSpawn(t *testing.T) {
 		return err == nil
 	}, "snapshot fallback did not start one eager restore generation")
 	entry := d.Entry(sid)
-	if entry == nil || entry.Owner == nil || !entry.Owner.CacheReady() {
-		t.Fatalf("eager fallback owner missing cached discovery; logs:\n%s", logBuf.String())
+	if entry == nil || entry.Owner == nil {
+		t.Fatalf("eager fallback owner missing after activation; logs:\n%s", logBuf.String())
+	}
+	if entry.Owner.CacheReady() {
+		t.Fatalf("eager fallback owner exposed stale cached discovery; logs:\n%s", logBuf.String())
 	}
 	if state := entry.Owner.MaterializationState(); state == owner.MaterializationCacheOnly {
 		t.Fatalf("fallback state=%s after predecessor barrier, want eager materialization", state)
@@ -1091,7 +1144,9 @@ func TestLoadSnapshot_Reattach_PartialHandoff(t *testing.T) {
 	if restored != 2 {
 		t.Fatalf("loadSnapshot() restored %d owners, want 2", restored)
 	}
-	d.activateRestartStaging()
+	if _, err := d.activateRestartStaging(); err != nil {
+		t.Fatalf("activateRestartStaging() error: %v", err)
+	}
 
 	// After the modeled predecessor barrier, structural logs show which
 	// entries retained transferred authority and which started one fresh

--- a/muxcore/daemon/snapshot_test.go
+++ b/muxcore/daemon/snapshot_test.go
@@ -12,6 +12,37 @@ import (
 	mcpsnapshot "github.com/thebtf/mcp-mux/muxcore/snapshot"
 )
 
+func TestSerializeSnapshotPinnedRetainsOwnerBarrierUntilRelease(t *testing.T) {
+	_ = os.Remove(SnapshotPath())
+	t.Cleanup(func() { _ = os.Remove(SnapshotPath()) })
+
+	d := testDaemon(t)
+	command := "pinned-snapshot-owner"
+	d.updateTemplate(command, nil, daemonMaterializationSnapshot(false))
+	_, sid, _, err := d.Spawn(control.Request{Command: command, Mode: "global", Cwd: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+
+	path, lease, err := d.serializeSnapshotPinned()
+	if err != nil {
+		t.Fatalf("serializeSnapshotPinned: %v", err)
+	}
+	if path == "" || lease == nil {
+		t.Fatalf("pinned snapshot result path=%q lease=%v", path, lease)
+	}
+	entry := d.Entry(sid)
+	if entry == nil || entry.Owner.Status()["restart_pin_count"] != int64(1) {
+		t.Fatalf("restart barrier was released before predecessor completion: entry=%+v", entry)
+	}
+
+	lease.Release()
+	lease.Release()
+	if got := entry.Owner.Status()["restart_pin_count"]; got != int64(0) {
+		t.Fatalf("restart lease release count = %v, want 0", got)
+	}
+}
+
 func TestSnapshotRoundTrip(t *testing.T) {
 	d := testDaemon(t)
 
@@ -67,6 +98,76 @@ func TestSnapshotRoundTrip(t *testing.T) {
 	// Verify file was consumed (deleted)
 	if _, err := os.Stat(SnapshotPath()); !os.IsNotExist(err) {
 		t.Error("snapshot file should be deleted after successful load")
+	}
+}
+
+func TestSerializeSnapshotPinsOwnerAgainstConcurrentRemoval(t *testing.T) {
+	d := testDaemon(t)
+	req := control.Request{
+		Cmd:     "spawn",
+		Command: "go",
+		Args:    []string{"run", "../../testdata/mock_server.go"},
+		Mode:    "global",
+	}
+	_, sid, _, err := d.Spawn(req)
+	if err != nil {
+		t.Fatalf("Spawn() error: %v", err)
+	}
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	d.beforeSnapshotOwnerExport = func() {
+		close(entered)
+		<-release
+	}
+	t.Cleanup(func() { d.beforeSnapshotOwnerExport = nil })
+
+	type serializeResult struct {
+		path string
+		err  error
+	}
+	serializeDone := make(chan serializeResult, 1)
+	go func() {
+		path, serializeErr := d.SerializeSnapshot()
+		serializeDone <- serializeResult{path: path, err: serializeErr}
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("SerializeSnapshot did not reach pinned owner export")
+	}
+
+	removeDone := make(chan error, 1)
+	go func() { removeDone <- d.Remove(sid) }()
+	select {
+	case err := <-removeDone:
+		t.Fatalf("Remove completed while snapshot held owner pin: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(release)
+	result := <-serializeDone
+	if result.err != nil {
+		t.Fatalf("SerializeSnapshot() error: %v", result.err)
+	}
+	defer os.Remove(result.path)
+
+	select {
+	case err := <-removeDone:
+		if err != nil {
+			t.Fatalf("Remove() after snapshot release: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Remove remained blocked after snapshot released owner pin")
+	}
+
+	snap, err := DeserializeSnapshot(testLogger(t))
+	if err != nil {
+		t.Fatalf("DeserializeSnapshot() error: %v", err)
+	}
+	if snap == nil || len(snap.Owners) != 1 || snap.Owners[0].ServerID != sid {
+		t.Fatalf("snapshot lost pinned owner %s: %#v", sid, snap)
 	}
 }
 

--- a/muxcore/daemon/snapshot_test.go
+++ b/muxcore/daemon/snapshot_test.go
@@ -1,9 +1,13 @@
 package daemon
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -33,13 +37,69 @@ func TestSerializeSnapshotPinnedRetainsOwnerBarrierUntilRelease(t *testing.T) {
 	}
 	entry := d.Entry(sid)
 	if entry == nil || entry.Owner.Status()["restart_pin_count"] != int64(1) {
-		t.Fatalf("restart barrier was released before predecessor completion: entry=%+v", entry)
+		t.Fatalf("owner restart barrier was released before predecessor completion: entry=%+v", entry)
+	}
+	d.mu.RLock()
+	registryPins := entry.snapshotPins
+	d.mu.RUnlock()
+	if registryPins != 1 {
+		t.Fatalf("daemon registry pin count=%d, want 1 through takeover", registryPins)
 	}
 
-	lease.Release()
-	lease.Release()
+	lease.ReleaseOwnerPins()
+	lease.ReleaseOwnerPins()
 	if got := entry.Owner.Status()["restart_pin_count"]; got != int64(0) {
-		t.Fatalf("restart lease release count = %v, want 0", got)
+		t.Fatalf("owner restart lease release count=%v, want 0", got)
+	}
+	d.mu.RLock()
+	registryPins = entry.snapshotPins
+	d.mu.RUnlock()
+	if registryPins != 1 {
+		t.Fatalf("owner-pin release also dropped daemon registry pin: %d", registryPins)
+	}
+
+	lease.ReleaseRegistryPins()
+	lease.ReleaseRegistryPins()
+	d.mu.RLock()
+	registryPins = entry.snapshotPins
+	d.mu.RUnlock()
+	if registryPins != 0 {
+		t.Fatalf("daemon registry pin count=%d after release, want 0", registryPins)
+	}
+	lease.Release()
+}
+
+func TestRestartRestoreInvalidatesSecondaryDiscoveryCaches(t *testing.T) {
+	t.Setenv(snapshotRestartEnv, "1")
+	d := testDaemon(t)
+	snap := daemonMaterializationSnapshot(false)
+	snap.ServerID = "restart-cache-invalidation"
+	snap.Command = "cache-invalidation-command"
+	snap.Classification = classify.ModeShared
+	snap.CachedPrompts = snap.CachedTools
+	snap.CachedResources = snap.CachedTools
+	snap.CachedResourceTemplates = snap.CachedTools
+
+	entry, reattached, err := d.restoreSnapshotPlan(d.makeSnapshotRestorePlan(snap), nil, "snapshot_fallback", false, true)
+	if err != nil {
+		t.Fatalf("restoreSnapshotPlan: %v", err)
+	}
+	if reattached || entry == nil || entry.Owner == nil {
+		t.Fatalf("restore result entry=%+v reattached=%v", entry, reattached)
+	}
+	restored := entry.Owner.ExportSnapshot()
+	if restored.CachedInit == "" {
+		t.Fatal("restart restore discarded cached initialize policy")
+	}
+	if restored.CachedTools != "" || restored.CachedPrompts != "" || restored.CachedResources != "" || restored.CachedResourceTemplates != "" {
+		t.Fatalf("restart restore exposed stale secondary discovery caches: tools=%t prompts=%t resources=%t templates=%t",
+			restored.CachedTools != "", restored.CachedPrompts != "", restored.CachedResources != "", restored.CachedResourceTemplates != "")
+	}
+	if entry.Owner.CacheReady() {
+		t.Fatal("restart-restored owner reported cache ready before live tools/list refresh")
+	}
+	if _, ok := d.getTemplate(snap.Command, snap.Args); ok {
+		t.Fatal("restart restore republished stale template cache")
 	}
 }
 
@@ -507,5 +567,186 @@ func TestLoadSnapshot_HealsIsolatedOwnerCwdSet(t *testing.T) {
 	}
 	if cwdSet[0] != primaryCwd {
 		t.Fatalf("cwd_set[0] = %q, want %q", cwdSet[0], primaryCwd)
+	}
+}
+
+func TestMakeSnapshotRestorePlanPreservesPinnedEnvironment(t *testing.T) {
+	t.Setenv("MCPMUX_TEST_SUCCESSOR_ONLY_ENV", "must-not-leak")
+	d := testDaemon(t)
+	snap := daemonMaterializationSnapshot(false)
+	snap.Env = map[string]string{
+		"CONFIG_PATH":  "captured-config",
+		"GITHUB_TOKEN": "captured-token",
+	}
+
+	plan := d.makeSnapshotRestorePlan(snap)
+	if len(plan.env) != len(snap.Env) {
+		t.Fatalf("restored env size=%d, want exact captured size %d", len(plan.env), len(snap.Env))
+	}
+	if _, leaked := plan.env["MCPMUX_TEST_SUCCESSOR_ONLY_ENV"]; leaked {
+		t.Fatal("successor daemon environment leaked into pinned snapshot launch context")
+	}
+	for key, want := range snap.Env {
+		if got := plan.env[key]; got != want {
+			t.Fatalf("restored env[%q]=%q, want %q", key, got, want)
+		}
+	}
+	plan.env["CONFIG_PATH"] = "mutated-plan"
+	if snap.Env["CONFIG_PATH"] != "captured-config" {
+		t.Fatal("restore plan aliases the snapshot environment map")
+	}
+}
+
+func TestActivateRestartStagingFailureRollsBackAndPreservesRetry(t *testing.T) {
+	_ = os.Remove(SnapshotPath())
+	t.Cleanup(func() { _ = os.Remove(SnapshotPath()) })
+	t.Setenv(snapshotRestartEnv, "1")
+	d := testDaemon(t)
+	d.handlerFunc = func(_ context.Context, stdin io.Reader, _ io.Writer) error {
+		_, err := io.Copy(io.Discard, stdin)
+		return err
+	}
+
+	makeSnapshot := func(serverID, command string) mcpsnapshot.OwnerSnapshot {
+		snap := daemonMaterializationSnapshot(false)
+		snap.ServerID = serverID
+		snap.Command = command
+		snap.Cwd = t.TempDir()
+		snap.Mode = "global"
+		snap.Env = map[string]string{"CONFIG_PATH": serverID}
+		return snap
+	}
+	first := makeSnapshot("restart-stage-first", "restart-stage-first-command")
+	second := makeSnapshot("restart-stage-second", "restart-stage-second-command")
+	plans := []snapshotRestorePlan{d.makeSnapshotRestorePlan(first), d.makeSnapshotRestorePlan(second)}
+	base := &DaemonSnapshot{
+		Version:   mcpsnapshot.SnapshotVersion,
+		Timestamp: time.Now().UTC().Format(time.RFC3339Nano),
+		Owners:    []mcpsnapshot.OwnerSnapshot{first, second},
+		Sessions: []mcpsnapshot.SessionSnapshot{
+			{MuxSessionID: "first-session", OwnerServerID: first.ServerID},
+			{MuxSessionID: "second-session", OwnerServerID: second.ServerID},
+		},
+	}
+	d.mu.Lock()
+	d.restartStaging = append([]snapshotRestorePlan(nil), plans...)
+	d.restartRecoverySnapshot = buildRestartRecoverySnapshot(base, plans)
+	d.mu.Unlock()
+
+	originalGenerateToken := generateTokenFunc
+	calls := 0
+	generateTokenFunc = func() (string, error) {
+		calls++
+		if calls == 2 {
+			return "", errors.New("synthetic second-owner generation failure")
+		}
+		return originalGenerateToken()
+	}
+	t.Cleanup(func() { generateTokenFunc = originalGenerateToken })
+
+	activated, err := d.activateRestartStaging()
+	if err == nil || activated != 0 {
+		t.Fatalf("activateRestartStaging()=(%d, %v), want transactional failure", activated, err)
+	}
+	if d.OwnerCount() != 0 {
+		t.Fatalf("partial staged activation left %d owners registered", d.OwnerCount())
+	}
+	d.mu.RLock()
+	retainedPlans := len(d.restartStaging)
+	retainedRecovery := d.restartRecoverySnapshot != nil
+	d.mu.RUnlock()
+	if retainedPlans != 2 || !retainedRecovery {
+		t.Fatalf("failed activation retained plans=%d recovery=%v, want 2/true", retainedPlans, retainedRecovery)
+	}
+
+	path, err := d.rewriteRestartRecoverySnapshot()
+	if err != nil || path == "" {
+		t.Fatalf("rewriteRestartRecoverySnapshot()=(%q, %v)", path, err)
+	}
+	recovered, err := DeserializeSnapshot(d.logger)
+	if err != nil || recovered == nil {
+		t.Fatalf("DeserializeSnapshot()=(%v, %v)", recovered, err)
+	}
+	if len(recovered.Owners) != 2 || len(recovered.Sessions) != 2 {
+		t.Fatalf("recovered snapshot owners/sessions=(%d, %d), want 2/2", len(recovered.Owners), len(recovered.Sessions))
+	}
+
+	generateTokenFunc = originalGenerateToken
+	activated, err = d.activateRestartStaging()
+	if err != nil || activated != 2 {
+		t.Fatalf("retry activateRestartStaging()=(%d, %v), want 2/nil", activated, err)
+	}
+	if d.OwnerCount() != 2 {
+		t.Fatalf("retry registered %d owners, want 2", d.OwnerCount())
+	}
+	d.mu.RLock()
+	stagingCleared := len(d.restartStaging) == 0 && d.restartRecoverySnapshot == nil
+	d.mu.RUnlock()
+	if !stagingCleared {
+		t.Fatal("successful activation did not clear retained restart recovery")
+	}
+}
+
+func TestNewRestartActivationFailureRewritesRecoverySnapshot(t *testing.T) {
+	_ = os.Remove(SnapshotPath())
+	t.Cleanup(func() { _ = os.Remove(SnapshotPath()) })
+	t.Setenv(snapshotRestartEnv, "1")
+	t.Setenv("MCPMUX_HANDOFF_TOKEN_PATH", "")
+	t.Setenv("MCPMUX_HANDOFF_SOCKET", "")
+	t.Setenv("MCPMUX_TEST_SUCCESSOR_ONLY_ENV", "must-not-leak")
+	originalDelay := snapshotRestartControlBindDelay
+	snapshotRestartControlBindDelay = 0
+	t.Cleanup(func() { snapshotRestartControlBindDelay = originalDelay })
+
+	ownerSnap := daemonMaterializationSnapshot(false)
+	ownerSnap.ServerID = "restart-constructor-recovery"
+	ownerSnap.Command = "restart-constructor-command"
+	ownerSnap.Cwd = t.TempDir()
+	ownerSnap.Mode = "global"
+	ownerSnap.Env = map[string]string{"CONFIG_PATH": "captured-only"}
+	_, err := mcpsnapshot.Serialize(&DaemonSnapshot{
+		Version:   mcpsnapshot.SnapshotVersion,
+		Timestamp: time.Now().UTC().Format(time.RFC3339Nano),
+		Owners:    []mcpsnapshot.OwnerSnapshot{ownerSnap},
+	}, testLogger(t))
+	if err != nil {
+		t.Fatalf("Serialize recovery fixture: %v", err)
+	}
+
+	originalGenerateToken := generateTokenFunc
+	calls := 0
+	generateTokenFunc = func() (string, error) {
+		calls++
+		if calls == 2 {
+			return "", errors.New("synthetic restart activation failure")
+		}
+		return originalGenerateToken()
+	}
+	t.Cleanup(func() { generateTokenFunc = originalGenerateToken })
+
+	d, err := New(Config{
+		Name:        "restart-recovery-test",
+		ControlPath: shortSocketPath(t, "restart-recovery.ctl.sock"),
+		GracePeriod: time.Second,
+		IdleTimeout: 5 * time.Second,
+		Logger:      testLogger(t),
+	})
+	if d != nil {
+		d.Shutdown()
+	}
+	if err == nil || !strings.Contains(err.Error(), "activate restart staging") {
+		t.Fatalf("New() error=%v, want restart activation failure", err)
+	}
+
+	generateTokenFunc = originalGenerateToken
+	recovered, err := DeserializeSnapshot(testLogger(t))
+	if err != nil || recovered == nil || len(recovered.Owners) != 1 {
+		t.Fatalf("rewritten recovery snapshot=(%v, %v)", recovered, err)
+	}
+	if got := recovered.Owners[0].Env; len(got) != 1 || got["CONFIG_PATH"] != "captured-only" {
+		t.Fatalf("rewritten recovery env=%v, want exact pinned context", got)
+	}
+	if _, leaked := recovered.Owners[0].Env["MCPMUX_TEST_SUCCESSOR_ONLY_ENV"]; leaked {
+		t.Fatal("rewritten recovery snapshot captured successor-only environment")
 	}
 }

--- a/muxcore/daemon/suspend_gate_test.go
+++ b/muxcore/daemon/suspend_gate_test.go
@@ -93,3 +93,31 @@ func TestHandleCanSuspendForOwnerUsesExactOwnerWithoutFanout(t *testing.T) {
 		t.Fatalf("recreated-owner lookups = %v, want only %q", lookups, targetSID)
 	}
 }
+
+func TestHandleCanSuspendBlocksPersistentDiscovery(t *testing.T) {
+	d := testDaemon(t)
+	const sid = "owner-suspend-materializing"
+	o, err := owner.NewOwnerFromSnapshot(owner.OwnerConfig{
+		IPCPath:           shortSocketPath(t, "suspend-materializing.sock"),
+		ServerID:          sid,
+		SessionHandler:    noopSessionHandler{},
+		PersistentPending: true,
+		Logger:            testLogger(t),
+	}, owner.OwnerSnapshot{})
+	if err != nil {
+		t.Fatalf("NewOwnerFromSnapshot: %v", err)
+	}
+	t.Cleanup(o.Shutdown)
+	seedReconnectHistory(t, o, "suspend-materializing-token", "/project/suspend", nil)
+	d.mu.Lock()
+	d.owners[sid] = &OwnerEntry{Owner: o, ServerID: sid}
+	d.mu.Unlock()
+
+	got, err := d.HandleCanSuspend("suspend-materializing-token")
+	if err != nil {
+		t.Fatalf("HandleCanSuspend: %v", err)
+	}
+	if got.Allowed || got.Reason != "pending_persistent" {
+		t.Fatalf("HandleCanSuspend=%+v, want pending_persistent denial", got)
+	}
+}

--- a/muxcore/daemon/template_identity_test.go
+++ b/muxcore/daemon/template_identity_test.go
@@ -1,0 +1,64 @@
+package daemon
+
+import (
+	"io"
+	"log"
+	"testing"
+)
+
+func TestTemplateCompatibilityUsesExactEnvAndIsolatedCwd(t *testing.T) {
+	d := &Daemon{
+		templateCache: make(map[string]*templateFamily),
+		logger:        log.New(io.Discard, "", 0),
+	}
+	command := "identity-template"
+	args := []string{"--serve"}
+	env := map[string]string{
+		"GITHUB_TOKEN":        "token-a",
+		"SERVICE_CONFIG_PATH": "/cfg/a",
+	}
+	snap := daemonMaterializationSnapshot(false)
+	snap.Classification = "shared"
+	snap.Cwd = "/project/a"
+	snap.Env = env
+	d.updateTemplate(command, args, snap)
+
+	compatible := mergeEnv(map[string]string{
+		"GITHUB_TOKEN":        "token-a",
+		"SERVICE_CONFIG_PATH": "/cfg/a",
+		"PWD":                 "/other/transient",
+	})
+	if _, ok := d.getCompatibleTemplate(command, args, "/project/elsewhere", compatible); !ok {
+		t.Fatal("shared template rejected exact env with transient differences")
+	}
+	changedCredential := mergeEnv(map[string]string{"GITHUB_TOKEN": "token-b", "SERVICE_CONFIG_PATH": "/cfg/a"})
+	if _, ok := d.getCompatibleTemplate(command, args, "/project/a", changedCredential); ok {
+		t.Fatal("template crossed changed credential boundary")
+	}
+	changedConfig := mergeEnv(map[string]string{"GITHUB_TOKEN": "token-a", "SERVICE_CONFIG_PATH": "/cfg/b"})
+	if _, ok := d.getCompatibleTemplate(command, args, "/project/a", changedConfig); ok {
+		t.Fatal("template crossed changed config boundary")
+	}
+	missingConfig := mergeEnv(map[string]string{"GITHUB_TOKEN": "token-a"})
+	if _, ok := d.getCompatibleTemplate(command, args, "/project/a", missingConfig); ok {
+		t.Fatal("template treated an incomplete exact projection as compatible")
+	}
+
+	snap.Classification = "isolated"
+	d.updateTemplate(command, args, snap)
+	if match, ok := d.getCompatibleTemplate(command, args, "/project/a", compatible); !ok || match.snapshot.Classification != "isolated" {
+		t.Fatalf("isolated template exact context did not match: match=%+v ok=%v", match, ok)
+	}
+	if _, ok := d.getCompatibleTemplate(command, args, "/project/b", compatible); ok {
+		t.Fatal("isolated template crossed canonical cwd boundary")
+	}
+
+	snap.Cwd = "/project/b"
+	d.updateTemplate(command, args, snap)
+	if _, ok := d.getCompatibleTemplate(command, args, "/project/a", compatible); !ok {
+		t.Fatal("second isolated template replaced the first CWD entry")
+	}
+	if _, ok := d.getCompatibleTemplate(command, args, "/project/b", compatible); !ok {
+		t.Fatal("second isolated template was not retained for its exact CWD")
+	}
+}

--- a/muxcore/daemon/template_identity_test.go
+++ b/muxcore/daemon/template_identity_test.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"io"
 	"log"
+	"os"
 	"testing"
 
 	"github.com/thebtf/mcp-mux/muxcore/classify"
@@ -22,7 +23,7 @@ func TestTemplateCompatibilityUsesExactEnvAndIsolatedCwd(t *testing.T) {
 	snap := daemonMaterializationSnapshot(false)
 	snap.Classification = "shared"
 	snap.Cwd = "/project/a"
-	snap.Env = env
+	snap.Env = mergeEnv(env)
 	d.updateTemplate(command, args, snap)
 
 	compatible := mergeEnv(map[string]string{
@@ -81,7 +82,7 @@ func TestTemplateIsolationBoundarySurvivesRelaxedFamilyPublish(t *testing.T) {
 			isolatedA := daemonMaterializationSnapshot(false)
 			isolatedA.Classification = "isolated"
 			isolatedA.Cwd = cwdA
-			isolatedA.Env = env
+			isolatedA.Env = mergeEnv(env)
 			d.updateTemplate(command, args, isolatedA)
 
 			relaxedB := isolatedA
@@ -118,5 +119,44 @@ func TestTemplateIsolationBoundarySurvivesRelaxedFamilyPublish(t *testing.T) {
 			assertTemplate(cwdB, "isolated")
 			assertTemplate(cwdC, "")
 		})
+	}
+}
+
+func TestSnapshotTemplatePublicationDoesNotMergeSuccessorEnvironment(t *testing.T) {
+	const successorOnlyKey = "MCPMUX_RESTORE_CONFIG_PATH"
+	original, existed := os.LookupEnv(successorOnlyKey)
+	if err := os.Unsetenv(successorOnlyKey); err != nil {
+		t.Fatalf("unset %s: %v", successorOnlyKey, err)
+	}
+	t.Cleanup(func() {
+		if existed {
+			_ = os.Setenv(successorOnlyKey, original)
+		} else {
+			_ = os.Unsetenv(successorOnlyKey)
+		}
+	})
+
+	predecessorEnv := mergeEnv(nil)
+	if _, leaked := predecessorEnv[successorOnlyKey]; leaked {
+		t.Fatalf("predecessor fixture unexpectedly contains %s", successorOnlyKey)
+	}
+	if err := os.Setenv(successorOnlyKey, "successor-only"); err != nil {
+		t.Fatalf("set %s: %v", successorOnlyKey, err)
+	}
+
+	d := &Daemon{
+		templateCache: make(map[string]*templateFamily),
+		logger:        log.New(io.Discard, "", 0),
+	}
+	snap := daemonMaterializationSnapshot(false)
+	snap.Env = predecessorEnv
+	d.updateTemplate("snapshot-template-env", nil, snap)
+
+	if _, ok := d.getCompatibleTemplate("snapshot-template-env", nil, "/project", predecessorEnv); !ok {
+		t.Fatal("snapshot template lost its captured predecessor environment")
+	}
+	successorEnv := mergeEnv(nil)
+	if _, ok := d.getCompatibleTemplate("snapshot-template-env", nil, "/project", successorEnv); ok {
+		t.Fatal("snapshot template inherited successor-only environment identity")
 	}
 }

--- a/muxcore/daemon/template_identity_test.go
+++ b/muxcore/daemon/template_identity_test.go
@@ -4,6 +4,8 @@ import (
 	"io"
 	"log"
 	"testing"
+
+	"github.com/thebtf/mcp-mux/muxcore/classify"
 )
 
 func TestTemplateCompatibilityUsesExactEnvAndIsolatedCwd(t *testing.T) {
@@ -60,5 +62,61 @@ func TestTemplateCompatibilityUsesExactEnvAndIsolatedCwd(t *testing.T) {
 	}
 	if _, ok := d.getCompatibleTemplate(command, args, "/project/b", compatible); !ok {
 		t.Fatal("second isolated template was not retained for its exact CWD")
+	}
+}
+
+func TestTemplateIsolationBoundarySurvivesRelaxedFamilyPublish(t *testing.T) {
+	for _, relaxed := range []classify.SharingMode{classify.ModeShared, classify.ModeSessionAware} {
+		t.Run(string(relaxed), func(t *testing.T) {
+			d := &Daemon{
+				templateCache: make(map[string]*templateFamily),
+				logger:        log.New(io.Discard, "", 0),
+			}
+			command := "template-isolation-boundary-" + string(relaxed)
+			args := []string{"--serve"}
+			cwdA, cwdB, cwdC := t.TempDir(), t.TempDir(), t.TempDir()
+			env := map[string]string{"SERVICE_CONFIG_PATH": "/cfg/same"}
+			effectiveEnv := mergeEnv(env)
+
+			isolatedA := daemonMaterializationSnapshot(false)
+			isolatedA.Classification = "isolated"
+			isolatedA.Cwd = cwdA
+			isolatedA.Env = env
+			d.updateTemplate(command, args, isolatedA)
+
+			relaxedB := isolatedA
+			relaxedB.Classification = relaxed
+			relaxedB.Cwd = cwdB
+			d.updateTemplate(command, args, relaxedB)
+
+			assertTemplate := func(cwd, want string) {
+				t.Helper()
+				match, ok := d.getCompatibleTemplate(command, args, cwd, effectiveEnv)
+				if want == "" {
+					if ok {
+						t.Fatalf("template for %q = %q, want no compatible template", cwd, match.snapshot.Classification)
+					}
+					return
+				}
+				if !ok {
+					t.Fatalf("template for %q missing, want classification %q", cwd, want)
+				}
+				if got := string(match.snapshot.Classification); got != want {
+					t.Fatalf("template for %q classification=%q, want %q", cwd, got, want)
+				}
+			}
+
+			assertTemplate(cwdA, "isolated")
+			assertTemplate(cwdB, string(relaxed))
+			assertTemplate(cwdC, string(relaxed))
+
+			isolatedB := relaxedB
+			isolatedB.Classification = "isolated"
+			d.updateTemplate(command, args, isolatedB)
+
+			assertTemplate(cwdA, "isolated")
+			assertTemplate(cwdB, "isolated")
+			assertTemplate(cwdC, "")
+		})
 	}
 }

--- a/muxcore/daemon/termination_test.go
+++ b/muxcore/daemon/termination_test.go
@@ -12,9 +12,9 @@ import (
 // but is not one of the known concrete event types. Used to test the default branch.
 type unknownEvent struct{}
 
-func (unknownEvent) String() string                  { return "unknown-event" }
-func (unknownEvent) Type() suture.EventType          { return suture.EventType(999) }
-func (unknownEvent) Map() map[string]interface{}     { return map[string]interface{}{} }
+func (unknownEvent) String() string              { return "unknown-event" }
+func (unknownEvent) Type() suture.EventType      { return suture.EventType(999) }
+func (unknownEvent) Map() map[string]interface{} { return map[string]interface{}{} }
 
 // Compile-time check: unknownEvent must implement suture.Event.
 var _ suture.Event = unknownEvent{}

--- a/muxcore/daemon/zero_session_cleanup_test.go
+++ b/muxcore/daemon/zero_session_cleanup_test.go
@@ -248,14 +248,26 @@ func TestZeroSessionCleanupReconnectReservationClosesWakeRace(t *testing.T) {
 		t.Fatalf("wake conn.Close() error = %v", err)
 	}
 	waitOwnerSessionCount(t, entry, 0)
+	waitForDaemonCondition(t, time.Second, func() bool {
+		d.mu.RLock()
+		defer d.mu.RUnlock()
+		return !entry.LastSession.Equal(zeroAt)
+	}, "wake disconnect did not publish zero-session timestamp")
 
 	d.mu.Lock()
 	zeroAt = time.Now().Add(-time.Second)
 	entry.LastSession = zeroAt
 	d.mu.Unlock()
-	if _, removed, err := d.removeOwnerIfCurrentAndZeroIdle(sid, entry, zeroAt, time.Millisecond); err != nil {
-		t.Fatalf("removeOwnerIfCurrentAndZeroIdle() after bind error = %v", err)
-	} else if !removed {
-		t.Fatal("zero-session cleanup did not remove owner after reservation was consumed")
+	var cleanupErr error
+	waitForDaemonCondition(t, 5*time.Second, func() bool {
+		_, removed, err := d.removeOwnerIfCurrentAndZeroIdle(sid, entry, zeroAt, time.Millisecond)
+		if err != nil {
+			cleanupErr = err
+			return true
+		}
+		return removed
+	}, "zero-session cleanup remained blocked after reservation was consumed")
+	if cleanupErr != nil {
+		t.Fatalf("removeOwnerIfCurrentAndZeroIdle() after bind error = %v", cleanupErr)
 	}
 }

--- a/muxcore/internal/envidentity/identity.go
+++ b/muxcore/internal/envidentity/identity.go
@@ -116,6 +116,12 @@ func writeField(h interface{ Write([]byte) (int, error) }, value string) {
 func IsCredentialKey(key string) bool {
 	upper := strings.ToUpper(key)
 	switch {
+	case upper == "TOKEN" || upper == "KEY" || upper == "API_KEY":
+		return true
+	case upper == "SECRET" || upper == "PASSWORD" || upper == "PASSWD":
+		return true
+	case upper == "CREDENTIAL" || upper == "CREDENTIALS" || upper == "AUTH":
+		return true
 	case strings.HasSuffix(upper, "_TOKEN"):
 		return true
 	case strings.HasSuffix(upper, "_KEY"):

--- a/muxcore/internal/envidentity/identity.go
+++ b/muxcore/internal/envidentity/identity.go
@@ -1,0 +1,241 @@
+package envidentity
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"sort"
+	"strings"
+)
+
+const fingerprintVersion = "mcp-mux-env-v1"
+
+// Identity is a versioned full SHA-256 digest. Raw identity values remain only
+// in the caller's effective launch environment or OwnerSnapshot.Env.
+type Identity struct {
+	Fingerprint string
+}
+
+// Build creates a deterministic, length-delimited digest from every
+// security-relevant environment field without retaining a second raw copy.
+func Build(env map[string]string) Identity {
+	keys := identityKeys(env)
+	h := sha256.New()
+	writeField(h, fingerprintVersion)
+	for _, key := range keys {
+		writeField(h, key)
+		writeField(h, env[key])
+	}
+	return Identity{Fingerprint: "v1:" + hex.EncodeToString(h.Sum(nil))}
+}
+
+func identityKeys(env map[string]string) []string {
+	keys := make([]string, 0, len(env))
+	for key := range env {
+		if IsTransient(key) || !IsIdentityKey(key) {
+			continue
+		}
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// Equal uses the digest as a fast path, then fail-closes against an exact
+// projection comparison computed from the two existing environment maps.
+func Equal(a, b Identity, aEnv, bEnv map[string]string) bool {
+	if a.Fingerprint != b.Fingerprint {
+		return false
+	}
+	for key, value := range aEnv {
+		if IsTransient(key) || !IsIdentityKey(key) {
+			continue
+		}
+		if other, ok := bEnv[key]; !ok || other != value {
+			return false
+		}
+	}
+	for key, value := range bEnv {
+		if IsTransient(key) || !IsIdentityKey(key) {
+			continue
+		}
+		if other, ok := aEnv[key]; !ok || other != value {
+			return false
+		}
+	}
+	return true
+}
+
+// Compatible preserves mcp-mux's global-owner compatibility rule: credential
+// presence must match on both sides; optional non-secret identity keys conflict
+// only when both sides provide different values.
+func Compatible(a, b map[string]string) bool {
+	for key, value := range a {
+		if IsTransient(key) || !IsIdentityKey(key) {
+			continue
+		}
+		other, ok := b[key]
+		if !ok {
+			if IsCredentialKey(key) {
+				return false
+			}
+			continue
+		}
+		if value != other {
+			return false
+		}
+	}
+	for key := range b {
+		if IsTransient(key) || !IsIdentityKey(key) {
+			continue
+		}
+		if _, ok := a[key]; !ok && IsCredentialKey(key) {
+			return false
+		}
+	}
+	return true
+}
+
+func ShortHash(env map[string]string) string {
+	if len(identityKeys(env)) == 0 {
+		return "00000000"
+	}
+	identity := Build(env)
+	return identity.Fingerprint[len("v1:") : len("v1:")+8]
+}
+
+func writeField(h interface{ Write([]byte) (int, error) }, value string) {
+	var size [8]byte
+	binary.BigEndian.PutUint64(size[:], uint64(len(value)))
+	_, _ = h.Write(size[:])
+	_, _ = h.Write([]byte(value))
+}
+
+// IsCredentialKey identifies variables whose presence asymmetry must split
+// owners because they likely carry authentication material.
+func IsCredentialKey(key string) bool {
+	upper := strings.ToUpper(key)
+	switch {
+	case strings.HasSuffix(upper, "_TOKEN"):
+		return true
+	case strings.HasSuffix(upper, "_KEY"):
+		return true
+	case strings.HasSuffix(upper, "_API_KEY"):
+		return true
+	case strings.HasSuffix(upper, "_SECRET"):
+		return true
+	case strings.HasSuffix(upper, "_PASSWORD"):
+		return true
+	case strings.HasSuffix(upper, "_PASSWD"):
+		return true
+	case strings.HasSuffix(upper, "_CREDENTIALS"):
+		return true
+	case strings.HasSuffix(upper, "_AUTH"):
+		return true
+	case upper == "GH_TOKEN" || upper == "GITHUB_TOKEN":
+		return true
+	case upper == "GITHUB_PERSONAL_ACCESS_TOKEN":
+		return true
+	case upper == "OPENAI_API_KEY" || upper == "ANTHROPIC_API_KEY":
+		return true
+	case upper == "TAVILY_API_KEY" || upper == "GOOGLE_API_KEY":
+		return true
+	case upper == "AWS_ACCESS_KEY_ID" || upper == "AWS_SECRET_ACCESS_KEY":
+		return true
+	case upper == "AWS_SESSION_TOKEN":
+		return true
+	case upper == "SSH_AUTH_SOCK" || upper == "SSH_AGENT_PID":
+		return true
+	case upper == "DOCKER_AUTH_CONFIG":
+		return true
+	}
+	return false
+}
+
+// IsIdentityKey identifies configuration, endpoint, proxy, certificate, and
+// credential variables that partition an upstream process identity.
+func IsIdentityKey(key string) bool {
+	if IsCredentialKey(key) {
+		return true
+	}
+	upper := strings.ToUpper(key)
+	switch {
+	case strings.HasSuffix(upper, "_CONFIG"):
+		return true
+	case strings.HasSuffix(upper, "_CONFIG_FILE"):
+		return true
+	case strings.HasSuffix(upper, "_CONFIG_PATH"):
+		return true
+	case strings.HasSuffix(upper, "_CONFIG_DIR"):
+		return true
+	case strings.HasSuffix(upper, "_ENDPOINT"):
+		return true
+	case strings.HasSuffix(upper, "_BASE_URL"):
+		return true
+	case strings.HasSuffix(upper, "_URL"):
+		return true
+	case strings.HasSuffix(upper, "_HOST"):
+		return true
+	case strings.HasSuffix(upper, "_PORT"):
+		return true
+	case strings.HasSuffix(upper, "_REGION"):
+		return true
+	case strings.HasSuffix(upper, "_PROFILE"):
+		return true
+	case strings.HasSuffix(upper, "_CERT_PATH") || strings.HasSuffix(upper, "_CERT_FILE"):
+		return true
+	case upper == "CONFIG" || upper == "CONFIG_FILE" || upper == "CONFIG_PATH" || upper == "CONFIG_DIR":
+		return true
+	case upper == "HOST" || upper == "PORT" || upper == "URL" || upper == "BASE_URL" || upper == "ENDPOINT":
+		return true
+	case upper == "REGION" || upper == "PROFILE":
+		return true
+	case upper == "KUBECONFIG" || upper == "NODE_EXTRA_CA_CERTS" || upper == "CERT_PATH" || upper == "CERT_FILE":
+		return true
+	case upper == "HTTP_PROXY" || upper == "HTTPS_PROXY" || upper == "ALL_PROXY" || upper == "NO_PROXY":
+		return true
+	case strings.HasPrefix(upper, "NPM_CONFIG_"):
+		return true
+	case upper == "SSL_CERT_FILE" || upper == "SSL_CERT_DIR":
+		return true
+	case upper == "REQUESTS_CA_BUNDLE" || upper == "CURL_CA_BUNDLE":
+		return true
+	}
+	return false
+}
+
+// IsTransient identifies host/session launch noise that must not fragment
+// otherwise compatible owners.
+func IsTransient(key string) bool {
+	switch {
+	case strings.HasPrefix(key, "CLAUDE_CODE_"):
+		return true
+	case strings.HasPrefix(key, "CLAUDE_AUTO"):
+		return true
+	case key == "CLAUDE_CODE_ENTRYPOINT":
+		return true
+	case strings.HasPrefix(key, "WT_"):
+		return true
+	case key == "SESSIONNAME" || key == "WSLENV":
+		return true
+	case key == "PWD" || key == "OLDPWD" || key == "INIT_CWD":
+		return true
+	case strings.HasPrefix(key, "npm_lifecycle_"):
+		return true
+	case strings.HasPrefix(key, "npm_package_"):
+		return true
+	case key == "npm_execpath" || key == "npm_node_execpath" || key == "npm_command":
+		return true
+	case key == "TERM" || key == "TERM_PROGRAM" || key == "TERM_PROGRAM_VERSION":
+		return true
+	case key == "COLORTERM" || key == "LINES" || key == "COLUMNS":
+		return true
+	case key == "_" || key == "SHLVL" || key == "SHELL":
+		return true
+	case key == "SSH_CLIENT" || key == "SSH_CONNECTION" || key == "SSH_TTY":
+		return true
+	case key == "DISPLAY" || key == "XAUTHORITY" || key == "WAYLAND_DISPLAY":
+		return true
+	}
+	return false
+}

--- a/muxcore/internal/envidentity/identity_test.go
+++ b/muxcore/internal/envidentity/identity_test.go
@@ -1,0 +1,108 @@
+package envidentity
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestBuildUsesFullVersionedExactDigest(t *testing.T) {
+	aEnv := map[string]string{"GITHUB_TOKEN": "ab", "CONFIG_PATH": "c", "PWD": "/session/a"}
+	bEnv := map[string]string{"GITHUB_TOKEN": "a", "CONFIG_PATH": "bc", "PWD": "/session/b"}
+	a := Build(aEnv)
+	b := Build(bEnv)
+	if a.Fingerprint == b.Fingerprint {
+		t.Fatalf("length-distinct identities collided: %q", a.Fingerprint)
+	}
+	if len(a.Fingerprint) != len("v1:")+64 {
+		t.Fatalf("fingerprint length=%d, want %d", len(a.Fingerprint), len("v1:")+64)
+	}
+	noiseOnly := Build(map[string]string{"GITHUB_TOKEN": "ab", "CONFIG_PATH": "c", "PWD": "/session/b"})
+	if a.Fingerprint != noiseOnly.Fingerprint {
+		t.Fatal("transient PWD changed identity digest")
+	}
+}
+
+func TestIdentityRetainsNoRawProjection(t *testing.T) {
+	const secret = "raw-credential-value"
+	identity := Build(map[string]string{"GITHUB_TOKEN": secret, "CONFIG_PATH": "/config"})
+	typeInfo := reflect.TypeOf(identity)
+	if typeInfo.NumField() != 1 || typeInfo.Field(0).Name != "Fingerprint" {
+		t.Fatalf("Identity exposes unexpected retained fields: %#v", typeInfo)
+	}
+	if strings.Contains(fmt.Sprintf("%+v", identity), secret) {
+		t.Fatal("Identity retained a raw credential value")
+	}
+}
+
+func TestEqualFailsClosedOnDigestCollision(t *testing.T) {
+	aEnv := map[string]string{"GITHUB_TOKEN": "secret", "CONFIG_PATH": "/a"}
+	bEnv := map[string]string{"GITHUB_TOKEN": "secret", "CONFIG_PATH": "/a"}
+	a := Build(aEnv)
+	b := Build(bEnv)
+	if !Equal(a, b, aEnv, bEnv) {
+		t.Fatal("identical identities were incompatible")
+	}
+	// Simulate a digest collision: exact on-demand projection comparison must
+	// still reject different existing launch environments.
+	bEnv["CONFIG_PATH"] = "/b"
+	if Equal(a, a, aEnv, bEnv) {
+		t.Fatal("exact projection mismatch passed identical-digest fast path")
+	}
+}
+
+func TestCompatiblePreservesCredentialPresenceBoundary(t *testing.T) {
+	if Compatible(map[string]string{"GITHUB_TOKEN": "secret"}, nil) {
+		t.Fatal("credential presence mismatch was compatible")
+	}
+	if !Compatible(map[string]string{"CONFIG_PATH": "/a"}, nil) {
+		t.Fatal("optional non-secret presence should remain compatible for owner dedup")
+	}
+}
+
+func TestDigestCoversMixedSecurityRelevantKeysAndExcludesLaunchNoise(t *testing.T) {
+	base := map[string]string{
+		"GITHUB_TOKEN":        "token",
+		"SERVICE_CONFIG_PATH": "/cfg/service.json",
+		"HTTPS_PROXY":         "https://proxy.example",
+		"NODE_EXTRA_CA_CERTS": "/certs/ca.pem",
+		"SERVICE_ENDPOINT":    "https://api.example",
+		"NPM_CONFIG_REGISTRY": "https://registry.example",
+		"PWD":                 "/project/a",
+	}
+	baseIdentity := Build(base)
+	for _, key := range []string{"GITHUB_TOKEN", "SERVICE_CONFIG_PATH", "HTTPS_PROXY", "NODE_EXTRA_CA_CERTS", "SERVICE_ENDPOINT", "NPM_CONFIG_REGISTRY"} {
+		changed := make(map[string]string, len(base))
+		for k, value := range base {
+			changed[k] = value
+		}
+		changed[key] += "-changed"
+		if Build(changed).Fingerprint == baseIdentity.Fingerprint {
+			t.Fatalf("identity digest ignored %s", key)
+		}
+	}
+	noise := make(map[string]string, len(base)+2)
+	for key, value := range base {
+		noise[key] = value
+	}
+	noise["PWD"] = "/project/b"
+	noise["CLAUDE_CODE_SESSION"] = "session-b"
+	if Build(noise).Fingerprint != baseIdentity.Fingerprint {
+		t.Fatal("launch noise changed identity digest")
+	}
+}
+
+func TestCompatibleRejectsChangedSecurityValuesButIgnoresTransientNoise(t *testing.T) {
+	base := map[string]string{"GITHUB_TOKEN": "token-a", "SERVICE_CONFIG_PATH": "/cfg/a", "PWD": "/project/a"}
+	noiseOnly := map[string]string{"GITHUB_TOKEN": "token-a", "SERVICE_CONFIG_PATH": "/cfg/a", "PWD": "/project/b", "CLAUDE_CODE_SESSION": "other-session"}
+	if !Compatible(base, noiseOnly) {
+		t.Fatal("transient launch noise split a compatible environment")
+	}
+	if Compatible(base, map[string]string{"GITHUB_TOKEN": "token-b", "SERVICE_CONFIG_PATH": "/cfg/a"}) {
+		t.Fatal("changed credential remained compatible")
+	}
+	if Compatible(base, map[string]string{"GITHUB_TOKEN": "token-a", "SERVICE_CONFIG_PATH": "/cfg/b"}) {
+		t.Fatal("changed configuration remained compatible")
+	}
+}

--- a/muxcore/internal/envidentity/identity_test.go
+++ b/muxcore/internal/envidentity/identity_test.go
@@ -61,6 +61,23 @@ func TestCompatiblePreservesCredentialPresenceBoundary(t *testing.T) {
 	}
 }
 
+func TestSimpleCredentialNamesPartitionIdentity(t *testing.T) {
+	for _, key := range []string{"TOKEN", "KEY", "API_KEY", "SECRET", "PASSWORD", "PASSWD", "CREDENTIAL", "CREDENTIALS", "AUTH"} {
+		t.Run(key, func(t *testing.T) {
+			withCredential := map[string]string{key: "secret"}
+			if !IsCredentialKey(key) || !IsIdentityKey(key) {
+				t.Fatalf("simple credential key %q was not identity-relevant", key)
+			}
+			if Compatible(withCredential, nil) {
+				t.Fatalf("simple credential key %q did not partition owner compatibility", key)
+			}
+			if Build(withCredential).Fingerprint == Build(nil).Fingerprint {
+				t.Fatalf("simple credential key %q did not affect template identity", key)
+			}
+		})
+	}
+}
+
 func TestDigestCoversMixedSecurityRelevantKeysAndExcludesLaunchNoise(t *testing.T) {
 	base := map[string]string{
 		"GITHUB_TOKEN":        "token",

--- a/muxcore/owner/coverage_test.go
+++ b/muxcore/owner/coverage_test.go
@@ -1134,6 +1134,14 @@ func TestIsAccepting_NewOwner(t *testing.T) {
 	}
 }
 
+func TestIsAccepting_AdmissionFreezeKeepsListenerLive(t *testing.T) {
+	o := newMinimalOwner()
+	o.admissionFrozen.Store(true)
+	if !o.IsAccepting() {
+		t.Error("IsAccepting() = false during admission freeze, want live listener")
+	}
+}
+
 func TestIsAccepting_AfterCloseListener(t *testing.T) {
 	o := newMinimalOwner()
 	// closeListener requires a real listener; signal the channel directly instead.

--- a/muxcore/owner/coverage_test.go
+++ b/muxcore/owner/coverage_test.go
@@ -277,6 +277,9 @@ func newMinimalOwner() *Owner {
 		logger:                 log.New(io.Discard, "", 0),
 		done:                   make(chan struct{}),
 		listenerDone:           make(chan struct{}),
+		materializationStop:    make(chan struct{}),
+		pendingDemands:         make(map[string]*localDemand),
+		materializationState:   MaterializationCacheOnly,
 	}
 }
 
@@ -492,8 +495,8 @@ func TestCheckPersistent_True(t *testing.T) {
 	o.serverID = "srv-1"
 
 	called := false
-	o.onPersistentDetected = func(id string) {
-		if id != "srv-1" {
+	o.onPersistentDetected = func(got *Owner) {
+		if got != o {
 			return
 		}
 		called = true
@@ -510,7 +513,7 @@ func TestCheckPersistent_True(t *testing.T) {
 func TestCheckPersistent_False(t *testing.T) {
 	o := newMinimalOwner()
 	called := false
-	o.onPersistentDetected = func(id string) { called = true }
+	o.onPersistentDetected = func(*Owner) { called = true }
 
 	initJSON := []byte(`{"jsonrpc":"2.0","id":1,"result":{"capabilities":{"x-mux":{"persistent":false}}}}`)
 	o.checkPersistent(initJSON)
@@ -523,7 +526,7 @@ func TestCheckPersistent_False(t *testing.T) {
 func TestCheckPersistent_NoXMux(t *testing.T) {
 	o := newMinimalOwner()
 	called := false
-	o.onPersistentDetected = func(id string) { called = true }
+	o.onPersistentDetected = func(*Owner) { called = true }
 
 	initJSON := []byte(`{"jsonrpc":"2.0","id":1,"result":{"capabilities":{}}}`)
 	o.checkPersistent(initJSON)

--- a/muxcore/owner/dispatch_test.go
+++ b/muxcore/owner/dispatch_test.go
@@ -900,6 +900,36 @@ func TestDispatch_WithSessionMetaPreferredOverLegacy(t *testing.T) {
 	}
 }
 
+func TestNewOwnerFromSnapshotPrefersSessionHandlerWithSessionMeta(t *testing.T) {
+	h := &mockSessionHandlerBoth{}
+	o, err := NewOwnerFromSnapshot(OwnerConfig{
+		IPCPath:        testIPCPath(t),
+		ServerID:       "snapshot-meta-dispatch",
+		SessionHandler: h,
+	}, OwnerSnapshot{})
+	if err != nil {
+		t.Fatalf("NewOwnerFromSnapshot: %v", err)
+	}
+	t.Cleanup(o.Shutdown)
+
+	sess, buf := newTestSession("/snapshot-meta")
+	defer sess.Close()
+	sess.SetMeta(muxcore.SessionMeta{TenantID: "snapshot-tenant", AuthorizedAt: time.Now()})
+	msg := parseMessage([]byte(`{"jsonrpc":"2.0","id":"1","method":"tools/list","params":{}}`))
+	if err := o.dispatchToSessionHandler(sess, msg); err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	if line := waitForWrite(t, buf, 2*time.Second); !strings.Contains(line, "meta-handled") {
+		t.Fatalf("response = %q, want meta handler", line)
+	}
+	if got := len(h.capturedMeta()); got != 1 {
+		t.Fatalf("WithSessionMeta calls = %d, want 1", got)
+	}
+	if got := len(h.captured()); got != 0 {
+		t.Fatalf("legacy calls = %d, want 0", got)
+	}
+}
+
 // TestDispatch_LegacyHandlerByteIdentical_v23 (T015) — legacy-only handler
 // (HandleRequest only) must be dispatched unchanged. SessionMeta is cached
 // regardless but never reaches the handler. Backward-compat regression for

--- a/muxcore/owner/handoff.go
+++ b/muxcore/owner/handoff.go
@@ -12,6 +12,10 @@ import (
 // ShutdownForHandoff) was already called on this Owner.
 var ErrAlreadyShutDown = errors.New("owner: already shut down")
 
+// ErrHandoffAlreadyPrepared is returned while an earlier prepared transfer
+// still awaits Commit or Abort settlement.
+var ErrHandoffAlreadyPrepared = errors.New("owner: handoff already prepared")
+
 // ErrNoUpstream is returned by ShutdownForHandoff if the owner has no upstream
 // process to detach (nil upstream — in-process handler or no spawn yet).
 var ErrNoUpstream = errors.New("owner: no upstream to hand off")
@@ -131,6 +135,14 @@ func (o *Owner) recordFailedHandoffTransition(proc *upstream.Process, err error,
 func (o *Owner) commitPreparedHandoff(proc *upstream.Process, pid int) error {
 	o.removalMu.Lock()
 	defer o.removalMu.Unlock()
+	if !o.handoffPrepared {
+		select {
+		case <-o.done:
+			return nil
+		default:
+			return ErrHandoffAlreadyPrepared
+		}
+	}
 	err := proc.CommitDetach()
 	if !proc.RetirementProven() {
 		o.recordFailedHandoffTransition(proc, err, false)
@@ -142,6 +154,7 @@ func (o *Owner) commitPreparedHandoff(proc *upstream.Process, pid int) error {
 		// not trigger cold fallback beside the accepted successor generation.
 		o.logger.Printf("owner handoff commit finalized with local release warning: %v", err)
 	}
+	o.handoffPrepared = false
 	o.recordFailedHandoffTransition(proc, nil, true)
 	o.completeShutdown(fmt.Sprintf("owner handed off (pid=%d)", pid))
 	return nil
@@ -150,9 +163,20 @@ func (o *Owner) commitPreparedHandoff(proc *upstream.Process, pid int) error {
 func (o *Owner) abortPreparedHandoff(proc *upstream.Process, pid int) error {
 	o.removalMu.Lock()
 	defer o.removalMu.Unlock()
+	if !o.handoffPrepared {
+		select {
+		case <-o.done:
+			return nil
+		default:
+			return ErrHandoffAlreadyPrepared
+		}
+	}
 	err := proc.AbortDetach()
 	proven := proc.RetirementProven()
 	o.recordFailedHandoffTransition(proc, err, proven)
+	if proven {
+		o.handoffPrepared = false
+	}
 	if proven {
 		o.completeShutdown(fmt.Sprintf("owner handoff aborted and finalized (pid=%d)", pid))
 	}
@@ -167,6 +191,7 @@ func (o *Owner) abortPreparedHandoff(proc *upstream.Process, pid int) error {
 //
 // Error cases:
 //   - ErrAlreadyShutDown — shutdown or a prior settled handoff completed.
+//   - ErrHandoffAlreadyPrepared — a prepared transfer still awaits settlement.
 //   - ErrNoUpstream — no subprocess exists; teardown completes immediately.
 //   - wrapped detach errors — cleanup is attempted and completion occurs only
 //     when process-tree retirement is proven.
@@ -177,6 +202,9 @@ func (o *Owner) ShutdownForHandoff() (HandoffPayload, error) {
 	case <-o.done:
 		return HandoffPayload{}, ErrAlreadyShutDown
 	default:
+	}
+	if o.handoffPrepared {
+		return HandoffPayload{}, ErrHandoffAlreadyPrepared
 	}
 
 	if err := o.quiesceMaterializationForHandoff(); err != nil {
@@ -220,6 +248,8 @@ func (o *Owner) ShutdownForHandoff() (HandoffPayload, error) {
 		o.logger.Printf("owner handoff failed: %v", retErr)
 		return HandoffPayload{}, retErr
 	}
+
+	o.handoffPrepared = true
 
 	payload := HandoffPayload{
 		ServerID:    o.serverID,

--- a/muxcore/owner/handoff.go
+++ b/muxcore/owner/handoff.go
@@ -143,6 +143,9 @@ func (o *Owner) commitPreparedHandoff(proc *upstream.Process, pid int) error {
 			return ErrHandoffAlreadyPrepared
 		}
 	}
+	if o.handoffAbortRequested {
+		return upstream.ErrDetachNotPrepared
+	}
 	err := proc.CommitDetach()
 	if !proc.RetirementProven() {
 		o.recordFailedHandoffTransition(proc, err, false)
@@ -155,6 +158,7 @@ func (o *Owner) commitPreparedHandoff(proc *upstream.Process, pid int) error {
 		o.logger.Printf("owner handoff commit finalized with local release warning: %v", err)
 	}
 	o.handoffPrepared = false
+	o.handoffAbortRequested = false
 	o.recordFailedHandoffTransition(proc, nil, true)
 	o.completeShutdown(fmt.Sprintf("owner handed off (pid=%d)", pid))
 	return nil
@@ -171,13 +175,24 @@ func (o *Owner) abortPreparedHandoff(proc *upstream.Process, pid int) error {
 			return ErrHandoffAlreadyPrepared
 		}
 	}
+	o.handoffAbortRequested = true
 	err := proc.AbortDetach()
+	proofErr := error(nil)
 	proven := proc.RetirementProven()
+	if o.materializationFinalizationProbe != nil {
+		proofErr = o.materializationFinalizationProbe(proc)
+		proven = proofErr == nil
+	}
+	if !proven {
+		if proofErr == nil {
+			proofErr = errFinalizationUnproven
+		}
+		err = errors.Join(err, proofErr)
+	}
 	o.recordFailedHandoffTransition(proc, err, proven)
 	if proven {
 		o.handoffPrepared = false
-	}
-	if proven {
+		o.handoffAbortRequested = false
 		o.completeShutdown(fmt.Sprintf("owner handoff aborted and finalized (pid=%d)", pid))
 	}
 	return err
@@ -250,6 +265,7 @@ func (o *Owner) ShutdownForHandoff() (HandoffPayload, error) {
 	}
 
 	o.handoffPrepared = true
+	o.handoffAbortRequested = false
 
 	payload := HandoffPayload{
 		ServerID:    o.serverID,

--- a/muxcore/owner/handoff.go
+++ b/muxcore/owner/handoff.go
@@ -67,24 +67,65 @@ func (o *Owner) HasHandoffUpstream() bool {
 // ShutdownForHandoff. Safe to call with an already-empty sessions map.
 // closeListenerOnce ensures the listener is closed at most once.
 func (o *Owner) teardownExceptUpstream() {
-	if o.controlServer != nil {
-		socketPath := o.controlServer.SocketPath()
-		o.controlServer.Close()
-		ipc.Cleanup(socketPath)
-	}
+	o.teardownOnce.Do(func() {
+		if o.controlServer != nil {
+			socketPath := o.controlServer.SocketPath()
+			o.controlServer.Close()
+			ipc.Cleanup(socketPath)
+		}
 
-	o.closeListener()
+		o.closeListener()
 
-	o.mu.Lock()
-	for _, s := range o.sessions {
-		s.Close()
-	}
-	o.sessions = make(map[int]*Session)
-	o.mu.Unlock()
+		o.mu.Lock()
+		for _, s := range o.sessions {
+			s.Close()
+		}
+		o.sessions = make(map[int]*Session)
+		o.mu.Unlock()
 
-	if o.rejectionLogger != nil {
-		o.rejectionLogger.Close()
+		if o.rejectionLogger != nil {
+			o.rejectionLogger.Close()
+		}
+	})
+}
+
+func (o *Owner) beginHandoffTransition() *upstream.Process {
+	o.upstreamEventMu.Lock()
+	o.materializationMu.Lock()
+	o.mu.RLock()
+	proc := o.upstream
+	o.mu.RUnlock()
+	if proc != nil {
+		o.retiringProcess = proc
+		o.materializationState = MaterializationFinalizing
+		o.upstreamDead.Store(true)
 	}
+	o.materializationMu.Unlock()
+	o.upstreamEventMu.Unlock()
+	return proc
+}
+
+func (o *Owner) recordFailedHandoffTransition(proc *upstream.Process, err error, proven bool) {
+	o.upstreamEventMu.Lock()
+	o.materializationMu.Lock()
+	if proven {
+		o.mu.Lock()
+		if o.upstream == proc {
+			o.upstream = nil
+		}
+		o.mu.Unlock()
+		if o.retiringProcess == proc {
+			o.retiringProcess = nil
+		}
+		o.materializationBlockedErr = nil
+		o.materializationState = MaterializationCacheOnly
+	} else {
+		o.materializationState = MaterializationFinalizeBlocked
+		o.materializationBlockedErr = errors.Join(errFinalizationUnproven, err)
+		o.retiringProcess = proc
+	}
+	o.materializationMu.Unlock()
+	o.upstreamEventMu.Unlock()
 }
 
 // ShutdownForHandoff performs the same cleanup as Shutdown (closes listener,
@@ -105,60 +146,69 @@ func (o *Owner) teardownExceptUpstream() {
 //     The upstream is aborted or closed, then o.done is closed. A failed handoff
 //     never leaves a torn-down owner or process tree in limbo.
 func (o *Owner) ShutdownForHandoff() (HandoffPayload, error) {
-	var payload HandoffPayload
-	var retErr error
-	attempted := false
-
-	o.shutdownOnce.Do(func() {
-		attempted = true
-
-		o.teardownExceptUpstream()
-
-		o.mu.Lock()
-		up := o.upstream
-		o.mu.Unlock()
-
-		if up == nil {
-			retErr = ErrNoUpstream
-			close(o.done)
-			return
-		}
-
-		pid, stdinFD, stdoutFD, stderrFD, authorityFD, err := up.DetachWithAuthority()
-		if err != nil {
-			cleanupErr := up.AbortDetach()
-			if errors.Is(cleanupErr, upstream.ErrDetachNotPrepared) {
-				cleanupErr = up.Close()
-			} else {
-				cleanupErr = errors.Join(cleanupErr, up.Close())
-			}
-			retErr = errors.Join(fmt.Errorf("owner: detach upstream: %w", err), cleanupErr)
-			o.logger.Printf("owner handoff failed; upstream terminated: %v", retErr)
-			close(o.done)
-			return
-		}
-
-		payload = HandoffPayload{
-			ServerID:    o.serverID,
-			PID:         pid,
-			StdinFD:     stdinFD,
-			StdoutFD:    stdoutFD,
-			StderrFD:    stderrFD,
-			AuthorityFD: authorityFD,
-			Command:     o.command,
-			Args:        o.args,
-			Cwd:         o.cwd,
-			abort:       up.AbortDetach,
-			commit:      up.CommitDetach,
-		}
-
-		o.logger.Printf("owner handed off (pid=%d)", pid)
-		close(o.done)
-	})
-
-	if !attempted {
-		// shutdownOnce already fired — either Shutdown or ShutdownForHandoff ran.
+	o.removalMu.Lock()
+	defer o.removalMu.Unlock()
+	select {
+	case <-o.done:
 		return HandoffPayload{}, ErrAlreadyShutDown
+	default:
 	}
-	return payload, retErr
+
+	if err := o.quiesceMaterializationForHandoff(); err != nil {
+		up := o.beginHandoffTransition()
+		o.teardownExceptUpstream()
+		closeErr := error(nil)
+		proven := up == nil
+		if up != nil {
+			closeErr = up.Close()
+			proven = up.RetirementProven()
+		}
+		retErr := errors.Join(fmt.Errorf("owner: quiesce materialization for handoff: %w", err), closeErr)
+		o.recordFailedHandoffTransition(up, retErr, proven)
+		if proven {
+			o.completeShutdown("owner handoff quiesce failed; upstream finalized")
+		}
+		return HandoffPayload{}, retErr
+	}
+
+	up := o.beginHandoffTransition()
+	o.teardownExceptUpstream()
+	if up == nil {
+		o.completeShutdown("owner handoff completed without upstream")
+		return HandoffPayload{}, ErrNoUpstream
+	}
+
+	pid, stdinFD, stdoutFD, stderrFD, authorityFD, err := up.DetachWithAuthority()
+	if err != nil {
+		cleanupErr := up.AbortDetach()
+		if errors.Is(cleanupErr, upstream.ErrDetachNotPrepared) {
+			cleanupErr = up.Close()
+		} else {
+			cleanupErr = errors.Join(cleanupErr, up.Close())
+		}
+		retErr := errors.Join(fmt.Errorf("owner: detach upstream: %w", err), cleanupErr)
+		proven := up.RetirementProven()
+		o.recordFailedHandoffTransition(up, retErr, proven)
+		if proven {
+			o.completeShutdown("owner handoff failed; upstream finalized")
+		}
+		o.logger.Printf("owner handoff failed: %v", retErr)
+		return HandoffPayload{}, retErr
+	}
+
+	payload := HandoffPayload{
+		ServerID:    o.serverID,
+		PID:         pid,
+		StdinFD:     stdinFD,
+		StdoutFD:    stdoutFD,
+		StderrFD:    stderrFD,
+		AuthorityFD: authorityFD,
+		Command:     o.command,
+		Args:        o.args,
+		Cwd:         o.cwd,
+		abort:       up.AbortDetach,
+		commit:      up.CommitDetach,
+	}
+	o.completeShutdown(fmt.Sprintf("owner handed off (pid=%d)", pid))
+	return payload, nil
 }

--- a/muxcore/owner/handoff.go
+++ b/muxcore/owner/handoff.go
@@ -128,23 +128,48 @@ func (o *Owner) recordFailedHandoffTransition(proc *upstream.Process, err error,
 	o.upstreamEventMu.Unlock()
 }
 
-// ShutdownForHandoff performs the same cleanup as Shutdown (closes listener,
-// sessions, control server) but instead of closing the upstream process it
-// detaches from it — returning the PID and file descriptors so the caller can
-// transfer ownership to a new daemon without restarting the upstream.
-//
-// After a successful ShutdownForHandoff the upstream process continues running
-// under a prepared lease. o.done is closed; the caller must later invoke the
-// payload's Commit or Abort operation exactly once (both are idempotent).
+func (o *Owner) commitPreparedHandoff(proc *upstream.Process, pid int) error {
+	o.removalMu.Lock()
+	defer o.removalMu.Unlock()
+	err := proc.CommitDetach()
+	if !proc.RetirementProven() {
+		o.recordFailedHandoffTransition(proc, err, false)
+		return errors.Join(errFinalizationUnproven, err)
+	}
+	if err != nil {
+		// The successor already owns duplicated stdio and tree authority once
+		// detach reaches committed. A local authority-handle close warning must
+		// not trigger cold fallback beside the accepted successor generation.
+		o.logger.Printf("owner handoff commit finalized with local release warning: %v", err)
+	}
+	o.recordFailedHandoffTransition(proc, nil, true)
+	o.completeShutdown(fmt.Sprintf("owner handed off (pid=%d)", pid))
+	return nil
+}
+
+func (o *Owner) abortPreparedHandoff(proc *upstream.Process, pid int) error {
+	o.removalMu.Lock()
+	defer o.removalMu.Unlock()
+	err := proc.AbortDetach()
+	proven := proc.RetirementProven()
+	o.recordFailedHandoffTransition(proc, err, proven)
+	if proven {
+		o.completeShutdown(fmt.Sprintf("owner handoff aborted and finalized (pid=%d)", pid))
+	}
+	return err
+}
+
+// ShutdownForHandoff performs the same admission and session teardown as
+// Shutdown, but prepares the upstream process for transactional transfer.
+// The returned payload retains the owner's removal lease logically: o.done
+// remains open until Commit proves transferred authority or Abort proves full
+// process-tree retirement. FinalizeForRemoval may retry a failed abort later.
 //
 // Error cases:
-//   - ErrAlreadyShutDown — Shutdown or ShutdownForHandoff was already called.
-//     o.done reflects how that earlier shutdown completed.
-//   - ErrNoUpstream — owner has no subprocess to hand off (nil upstream).
-//     The already-torn-down owner is completed and o.done is closed.
-//   - wrapped upstream.ErrAlreadyDetached / ErrDetachUnsupported — Detach failed.
-//     The upstream is aborted or closed, then o.done is closed. A failed handoff
-//     never leaves a torn-down owner or process tree in limbo.
+//   - ErrAlreadyShutDown — shutdown or a prior settled handoff completed.
+//   - ErrNoUpstream — no subprocess exists; teardown completes immediately.
+//   - wrapped detach errors — cleanup is attempted and completion occurs only
+//     when process-tree retirement is proven.
 func (o *Owner) ShutdownForHandoff() (HandoffPayload, error) {
 	o.removalMu.Lock()
 	defer o.removalMu.Unlock()
@@ -206,9 +231,12 @@ func (o *Owner) ShutdownForHandoff() (HandoffPayload, error) {
 		Command:     o.command,
 		Args:        o.args,
 		Cwd:         o.cwd,
-		abort:       up.AbortDetach,
-		commit:      up.CommitDetach,
+		abort: func() error {
+			return o.abortPreparedHandoff(up, pid)
+		},
+		commit: func() error {
+			return o.commitPreparedHandoff(up, pid)
+		},
 	}
-	o.completeShutdown(fmt.Sprintf("owner handed off (pid=%d)", pid))
 	return payload, nil
 }

--- a/muxcore/owner/handoff_from.go
+++ b/muxcore/owner/handoff_from.go
@@ -73,13 +73,16 @@ func newOwnerWithProcess(cfg OwnerConfig, payload HandoffPayload, proc *upstream
 		env:                    cfg.Env,
 		handlerFunc:            cfg.HandlerFunc,
 		sessionHandler:         cfg.SessionHandler,
+		upstreamWriter:         cfg.UpstreamWriter,
 		serverID:               srvID,
 		listener:               ln,
 		logger:                 logger,
 		onZeroSessions:         cfg.OnZeroSessions,
 		onUpstreamExit:         cfg.OnUpstreamExit,
 		onPersistentDetected:   cfg.OnPersistentDetected,
+		onPersistentResolved:   cfg.OnPersistentResolved,
 		onCacheReady:           cfg.OnCacheReady,
+		onCacheInvalidated:     cfg.OnCacheInvalidated,
 		authorizeSession:       cfg.AuthorizeSession,
 		onFrameReceived:        cfg.OnFrameReceived,
 		sessions:               make(map[int]*Session),
@@ -95,6 +98,12 @@ func newOwnerWithProcess(cfg OwnerConfig, payload HandoffPayload, proc *upstream
 		startTime:              time.Now(),
 		listenerDone:           make(chan struct{}),
 		done:                   make(chan struct{}),
+		materializationPolicy:  cfg.MaterializationPolicy,
+		materializationState:   MaterializationReady,
+		persistentRequired:     cfg.PersistentRequired,
+		materializationStop:    make(chan struct{}),
+		pendingDemands:         make(map[string]*localDemand),
+		persistentPending:      cfg.PersistentPending,
 	}
 	o.progressIntervalNs.Store(int64(5 * time.Second))
 
@@ -105,11 +114,27 @@ func newOwnerWithProcess(cfg OwnerConfig, payload HandoffPayload, proc *upstream
 	// Cache optional *WithSessionMeta interface upgrades for hot-path dispatch.
 	o.cacheHandlerInterfaces()
 
-	// Apply cached classification if provided — skip the classify round-trip.
-	if cfg.CachedClassification != "" {
+	// Adopt the predecessor's last coherent cache generation before any reader or
+	// session goroutine starts. A live handoff must not issue a second initialize
+	// transaction to an already-initialized upstream.
+	if cfg.AdoptedSnapshot != nil {
+		snap := *cfg.AdoptedSnapshot
+		o.hydrateSnapshotCache(snap)
+		for _, c := range snap.CwdSet {
+			o.cwdSet[serverid.CanonicalizePath(c)] = true
+		}
+		if len(snap.BoundTokens) > 0 {
+			o.sessionMgr.ImportBoundHistory(boundTokenSnapshotsToSession(snap.BoundTokens))
+		}
+		if o.initDone {
+			o.initReadyOnce.Do(func() { close(o.initReady) })
+		}
+	}
+	if o.classificationSource == "" && cfg.CachedClassification != "" {
 		o.autoClassification = cfg.CachedClassification
 		o.classificationSource = "handoff"
-		o.classificationReason = nil
+	}
+	if o.classificationSource != "" || o.autoClassification != "" {
 		o.classifiedOnce.Do(func() { close(o.classified) })
 	}
 
@@ -130,9 +155,10 @@ func newOwnerWithProcess(cfg OwnerConfig, payload HandoffPayload, proc *upstream
 		}
 	}
 
-	// Start goroutines — identical set to NewOwner.
+	// Start exactly one reader for the adopted initialized stream. Cache truth is
+	// staged above; no legacy proactive initialize/tools refresh is permitted.
 	go o.readUpstream(proc)
-	go o.sendProactiveInit(proc, nil)
+
 	go o.acceptLoop()
 	go o.runProgressReporter(doneContext(o.done))
 

--- a/muxcore/owner/handoff_from_test.go
+++ b/muxcore/owner/handoff_from_test.go
@@ -108,3 +108,41 @@ func TestNewOwnerFromHandoff_NoSpawn(t *testing.T) {
 		t.Errorf("o.upstream.PID() = %d, want 0 (handler process = no subprocess spawned)", pid)
 	}
 }
+
+func TestNewOwnerFromHandoff_ReappliesCachedRuntimeSettings(t *testing.T) {
+	hctx, hcancel := context.WithCancel(context.Background())
+	proc := upstream.NewProcessFromHandler(hctx, func(ctx context.Context, _ io.Reader, _ io.Writer) error {
+		<-ctx.Done()
+		return nil
+	})
+	initResponse := []byte(`{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"x-mux":{"drainTimeout":7,"toolTimeout":8,"idleTimeout":9,"progressInterval":10}},"serverInfo":{"name":"runtime-settings","version":"1"}}}`)
+	snap := OwnerSnapshot{
+		Classification: "shared",
+		CachedInit:     base64Encode(initResponse),
+	}
+	payload := HandoffPayload{ServerID: "test-runtime-settings", Command: "mock-handler"}
+	o, err := newOwnerWithProcess(OwnerConfig{
+		IPCPath:         testIPCPath(t),
+		ServerID:        payload.ServerID,
+		AdoptedSnapshot: &snap,
+		Logger:          testLogger(t),
+	}, payload, proc)
+	if err != nil {
+		t.Fatalf("newOwnerWithProcess: %v", err)
+	}
+	defer o.Shutdown()
+	defer hcancel()
+
+	if got := o.DrainTimeout(); got != 7*time.Second {
+		t.Fatalf("DrainTimeout()=%s, want 7s", got)
+	}
+	if got := time.Duration(o.toolTimeoutNs.Load()); got != 8*time.Second {
+		t.Fatalf("tool timeout=%s, want 8s", got)
+	}
+	if got := o.IdleTimeout(); got != 9*time.Second {
+		t.Fatalf("IdleTimeout()=%s, want 9s", got)
+	}
+	if got := o.loadProgressInterval(); got != 10*time.Second {
+		t.Fatalf("progress interval=%s, want 10s", got)
+	}
+}

--- a/muxcore/owner/handoff_test.go
+++ b/muxcore/owner/handoff_test.go
@@ -67,6 +67,16 @@ func TestShutdownForHandoff_HappyPath(t *testing.T) {
 	if _, err := o.ShutdownForHandoff(); !errors.Is(err, ErrHandoffAlreadyPrepared) {
 		t.Fatalf("duplicate ShutdownForHandoff error = %v, want ErrHandoffAlreadyPrepared", err)
 	}
+	if _, finalized, err := o.FinalizeForRemoval(false, 100*time.Millisecond); finalized || !errors.Is(err, ErrHandoffAlreadyPrepared) {
+		t.Fatalf("FinalizeForRemoval during prepared handoff = finalized=%v err=%v, want false/ErrHandoffAlreadyPrepared", finalized, err)
+	}
+	o.Shutdown()
+	select {
+	case <-o.Done():
+		t.Fatal("ordinary shutdown finalized a prepared handoff before Commit")
+	default:
+	}
+
 	if err := payload.Commit(); err != nil {
 		t.Fatalf("payload.Commit: %v", err)
 	}
@@ -87,6 +97,79 @@ func TestShutdownForHandoff_HappyPath(t *testing.T) {
 		// ok — Shutdown returned immediately because shutdownOnce already fired
 	case <-time.After(2 * time.Second):
 		t.Error("Shutdown() after ShutdownForHandoff blocked or panicked")
+	}
+}
+
+func TestShutdownForHandoff_ExplicitAbortRetriesUnprovenRetirement(t *testing.T) {
+	cmd, args := mockServerArgs()
+	o, err := NewOwner(OwnerConfig{
+		Command:  cmd,
+		Args:     args,
+		IPCPath:  testIPCPath(t),
+		ServerID: "test-handoff-abort-retry",
+		Logger:   testLogger(t),
+	})
+	if err != nil {
+		t.Fatalf("NewOwner: %v", err)
+	}
+	waitForCondition(t, 5*time.Second, func() bool { return o.MaterializationState() == MaterializationReady }, "owner did not finish initial materialization")
+	proc := o.currentUpstream()
+	if proc == nil {
+		t.Fatal("expected subprocess upstream")
+	}
+
+	payload, err := o.ShutdownForHandoff()
+	if err != nil {
+		t.Fatalf("ShutdownForHandoff: %v", err)
+	}
+	allowProof := false
+	defer func() {
+		allowProof = true
+		_ = payload.Abort()
+	}()
+	proofErr := errors.New("synthetic aborted-detach retirement remains unproven")
+	wrongProcessErr := errors.New("retirement probe received the wrong process")
+	proofCalls := 0
+	o.materializationFinalizationProbe = func(got *upstream.Process) error {
+		proofCalls++
+		if got != proc {
+			return wrongProcessErr
+		}
+		if !allowProof {
+			return proofErr
+		}
+		return nil
+	}
+
+	if err := payload.Abort(); !errors.Is(err, proofErr) {
+		t.Fatalf("first payload.Abort error = %v, want retirement proof failure", err)
+	}
+	select {
+	case <-o.Done():
+		t.Fatal("owner completed after unproven explicit abort")
+	default:
+	}
+	if state := o.MaterializationState(); state != MaterializationFinalizeBlocked {
+		t.Fatalf("state after unproven abort = %s, want %s", state, MaterializationFinalizeBlocked)
+	}
+	if err := payload.Commit(); !errors.Is(err, upstream.ErrDetachNotPrepared) {
+		t.Fatalf("payload.Commit after explicit abort = %v, want ErrDetachNotPrepared", err)
+	}
+	if _, finalized, err := o.FinalizeForRemoval(false, 100*time.Millisecond); finalized || !errors.Is(err, proofErr) {
+		t.Fatalf("FinalizeForRemoval retry before proof = finalized=%v err=%v, want false/proof failure", finalized, err)
+	}
+
+	allowProof = true
+	if err := payload.Abort(); err != nil {
+		t.Fatalf("payload.Abort retry after proof: %v", err)
+	}
+	select {
+	case <-o.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("owner did not complete after explicit abort retirement retry")
+	}
+	if proofCalls != 3 {
+		t.Fatalf("retirement proof calls = %d, want 3 (abort, finalizer retry, abort retry)", proofCalls)
 	}
 }
 

--- a/muxcore/owner/handoff_test.go
+++ b/muxcore/owner/handoff_test.go
@@ -1,7 +1,13 @@
 package owner
 
 import (
+	"bufio"
+	"context"
+	"encoding/json"
 	"errors"
+	"io"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -131,6 +137,7 @@ func TestShutdownForHandoff_DetachFailureAbortsTreeAndCompletesOwner(t *testing.
 	if err != nil {
 		t.Fatalf("NewOwner: %v", err)
 	}
+	waitForCondition(t, 5*time.Second, o.CacheReady, "owner did not finish initial materialization")
 
 	o.mu.RLock()
 	proc := o.upstream
@@ -155,5 +162,108 @@ func TestShutdownForHandoff_DetachFailureAbortsTreeAndCompletesOwner(t *testing.
 	case <-proc.Done:
 	case <-time.After(5 * time.Second):
 		t.Fatal("upstream tree survived detach failure cleanup")
+	}
+}
+
+func TestShutdownForHandoffWaitsForMaterializationQuiescence(t *testing.T) {
+	toolsSeen := make(chan struct{})
+	releaseTools := make(chan struct{})
+	var toolsOnce sync.Once
+	handler := func(_ context.Context, stdin io.Reader, stdout io.Writer) error {
+		scanner := bufio.NewScanner(stdin)
+		for scanner.Scan() {
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+				return err
+			}
+			switch req.Method {
+			case "initialize":
+				if err := writeControllerResponse(stdout, req.ID, `{"protocolVersion":"2025-11-25","capabilities":{},"serverInfo":{"name":"handoff","version":"1"}}`); err != nil {
+					return err
+				}
+			case "tools/list":
+				toolsOnce.Do(func() { close(toolsSeen) })
+				<-releaseTools
+				if err := writeControllerResponse(stdout, req.ID, `{"tools":[]}`); err != nil {
+					return err
+				}
+			}
+		}
+		return scanner.Err()
+	}
+	o, err := NewOwnerFromSnapshot(OwnerConfig{
+		HandlerFunc:           handler,
+		IPCPath:               testIPCPath(t),
+		MaterializationPolicy: MaterializationOnDemand,
+		Logger:                testLogger(t),
+	}, OwnerSnapshot{})
+	if err != nil {
+		t.Fatalf("NewOwnerFromSnapshot: %v", err)
+	}
+	o.SpawnUpstreamBackground()
+	select {
+	case <-toolsSeen:
+	case <-time.After(time.Second):
+		t.Fatal("materialization did not reach discovery")
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, handoffErr := o.ShutdownForHandoff()
+		errCh <- handoffErr
+	}()
+	select {
+	case err := <-errCh:
+		t.Fatalf("handoff returned before materialization quiesced: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(releaseTools)
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, upstream.ErrDetachUnsupported) {
+			t.Fatalf("ShutdownForHandoff error=%v, want ErrDetachUnsupported", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("handoff did not continue after materialization quiesced")
+	}
+	select {
+	case <-o.Done():
+	case <-time.After(time.Second):
+		t.Fatal("handoff failure left owner incomplete")
+	}
+}
+
+func TestHandoffAdoptsCacheWithoutProactiveInitialize(t *testing.T) {
+	received := make(chan string, 1)
+	proc := upstream.NewProcessFromHandler(context.Background(), func(_ context.Context, stdin io.Reader, _ io.Writer) error {
+		scanner := bufio.NewScanner(stdin)
+		for scanner.Scan() {
+			received <- scanner.Text()
+		}
+		return scanner.Err()
+	})
+	snap := controllerSnapshot()
+	snap.Classification = "session-aware"
+	o, err := newOwnerWithProcess(OwnerConfig{
+		IPCPath:              testIPCPath(t),
+		ServerID:             "handoff-cache-adoption",
+		CachedClassification: snap.Classification,
+		AdoptedSnapshot:      &snap,
+		Logger:               testLogger(t),
+	}, HandoffPayload{ServerID: "handoff-cache-adoption", Command: "adopted"}, proc)
+	if err != nil {
+		t.Fatalf("newOwnerWithProcess: %v", err)
+	}
+	defer o.Shutdown()
+	if !o.CacheReady() || !strings.Contains(string(o.getCachedResponse("tools/list")), "old-tool") {
+		t.Fatalf("handoff did not adopt coherent cache: %#v", o.Status())
+	}
+	select {
+	case line := <-received:
+		t.Fatalf("handoff sent duplicate proactive request: %s", line)
+	case <-time.After(100 * time.Millisecond):
 	}
 }

--- a/muxcore/owner/handoff_test.go
+++ b/muxcore/owner/handoff_test.go
@@ -64,6 +64,9 @@ func TestShutdownForHandoff_HappyPath(t *testing.T) {
 		t.Fatal("o.Done() closed before handoff settlement")
 	default:
 	}
+	if _, err := o.ShutdownForHandoff(); !errors.Is(err, ErrHandoffAlreadyPrepared) {
+		t.Fatalf("duplicate ShutdownForHandoff error = %v, want ErrHandoffAlreadyPrepared", err)
+	}
 	if err := payload.Commit(); err != nil {
 		t.Fatalf("payload.Commit: %v", err)
 	}

--- a/muxcore/owner/handoff_test.go
+++ b/muxcore/owner/handoff_test.go
@@ -16,8 +16,9 @@ import (
 
 // TestShutdownForHandoff_HappyPath verifies that ShutdownForHandoff:
 //   - returns a valid HandoffPayload with non-zero PID and FDs
-//   - closes o.Done() channel on success
-//   - makes a subsequent Shutdown() call a safe no-op (no panic, no block)
+//   - keeps o.Done open while the transfer is only prepared
+//   - closes o.Done only after Commit settles transferred authority
+//   - makes a subsequent Shutdown call a safe no-op
 func TestShutdownForHandoff_HappyPath(t *testing.T) {
 	ipcPath := testIPCPath(t)
 	cmd, args := mockServerArgs()
@@ -56,12 +57,20 @@ func TestShutdownForHandoff_HappyPath(t *testing.T) {
 		t.Errorf("payload.ServerID = %q, want %q", payload.ServerID, "test-handoff-happy")
 	}
 
-	// Done channel must be closed after a successful handoff.
+	// Preparation alone is not terminal: the predecessor retains the lease
+	// until the final adoption decision settles Commit or Abort.
 	select {
 	case <-o.Done():
-		// ok
+		t.Fatal("o.Done() closed before handoff settlement")
+	default:
+	}
+	if err := payload.Commit(); err != nil {
+		t.Fatalf("payload.Commit: %v", err)
+	}
+	select {
+	case <-o.Done():
 	case <-time.After(2 * time.Second):
-		t.Error("o.Done() not closed after ShutdownForHandoff")
+		t.Error("o.Done() not closed after handoff commit")
 	}
 
 	// Subsequent Shutdown() must be a safe no-op: no panic, no indefinite block.
@@ -137,7 +146,7 @@ func TestShutdownForHandoff_DetachFailureAbortsTreeAndCompletesOwner(t *testing.
 	if err != nil {
 		t.Fatalf("NewOwner: %v", err)
 	}
-	waitForCondition(t, 5*time.Second, o.CacheReady, "owner did not finish initial materialization")
+	waitForCondition(t, 5*time.Second, func() bool { return o.MaterializationState() == MaterializationReady }, "owner did not finish initial materialization")
 
 	o.mu.RLock()
 	proc := o.upstream

--- a/muxcore/owner/materialization.go
+++ b/muxcore/owner/materialization.go
@@ -1,0 +1,1759 @@
+package owner
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/thebtf/mcp-mux/muxcore/classify"
+	"github.com/thebtf/mcp-mux/muxcore/internal/envidentity"
+	"github.com/thebtf/mcp-mux/muxcore/jsonrpc"
+	"github.com/thebtf/mcp-mux/muxcore/listchanged"
+	"github.com/thebtf/mcp-mux/muxcore/remap"
+	"github.com/thebtf/mcp-mux/muxcore/serverid"
+	"github.com/thebtf/mcp-mux/muxcore/upstream"
+)
+
+const (
+	materializationFinalizeTimeout = 15 * time.Second
+	materializationRetryInitial    = 100 * time.Millisecond
+	materializationRetryMax        = 2 * time.Second
+)
+
+const restartMaterializationSettleGrace = 500 * time.Millisecond
+
+var (
+	materializationReadinessTimeout = 30 * time.Second
+	materializationDemandTimeout    = 30 * time.Second
+)
+
+// MaterializationPolicy controls when an owner without a live upstream creates
+// one. The zero value preserves the historical eager behavior.
+type MaterializationPolicy uint8
+
+const (
+	MaterializationEager MaterializationPolicy = iota
+	MaterializationOnDemand
+	MaterializationPersistent
+)
+
+func (p MaterializationPolicy) String() string {
+	switch p {
+	case MaterializationOnDemand:
+		return "on_demand"
+	case MaterializationPersistent:
+		return "persistent"
+	default:
+		return "eager"
+	}
+}
+
+// MaterializationState is the owner-local process authority state.
+type MaterializationState string
+
+const (
+	MaterializationCacheOnly       MaterializationState = "CACHE_ONLY"
+	MaterializationMaterializing   MaterializationState = "MATERIALIZING"
+	MaterializationReady           MaterializationState = "READY"
+	MaterializationFinalizing      MaterializationState = "FINALIZING"
+	MaterializationFinalizeBlocked MaterializationState = "FINALIZE_BLOCKED"
+)
+
+// MaterializationTrigger records why the current generation was requested.
+type MaterializationTrigger string
+
+const (
+	MaterializationTriggerEager        MaterializationTrigger = "eager"
+	MaterializationTriggerDemand       MaterializationTrigger = "demand"
+	MaterializationTriggerBackground   MaterializationTrigger = "background"
+	MaterializationTriggerUpstreamExit MaterializationTrigger = "upstream_exit"
+	MaterializationTriggerWriteError   MaterializationTrigger = "write_error"
+	MaterializationTriggerPersistent   MaterializationTrigger = "persistent"
+)
+
+var errFinalizationUnproven = errors.New("upstream process-tree finalization unproven")
+
+type materializationSignals struct {
+	initReady     chan struct{}
+	initReadyOnce sync.Once
+	initOK        bool
+
+	discoveryReady     chan struct{}
+	discoveryReadyOnce sync.Once
+
+	failed     chan struct{}
+	failedOnce sync.Once
+	failureErr error
+}
+
+func newMaterializationSignals() *materializationSignals {
+	return &materializationSignals{
+		initReady:      make(chan struct{}),
+		discoveryReady: make(chan struct{}),
+		failed:         make(chan struct{}),
+	}
+}
+
+type materializationAttempt struct {
+	generation   uint64
+	trigger      MaterializationTrigger
+	launch       LaunchContext
+	cancel       chan struct{}
+	cancelOnce   sync.Once
+	launchFrozen bool
+
+	started     chan struct{}
+	startedOnce sync.Once
+	startedErr  error
+
+	done     chan struct{}
+	doneOnce sync.Once
+	err      error
+
+	process *upstream.Process
+	signals *materializationSignals
+}
+
+func newMaterializationAttempt(generation uint64, trigger MaterializationTrigger) *materializationAttempt {
+	return &materializationAttempt{
+		generation: generation,
+		trigger:    trigger,
+		started:    make(chan struct{}),
+		cancel:     make(chan struct{}),
+		done:       make(chan struct{}),
+		signals:    newMaterializationSignals(),
+	}
+}
+
+func completedMaterializationAttempt(err error) *materializationAttempt {
+	a := newMaterializationAttempt(0, "")
+	a.startedErr = err
+	a.err = err
+	close(a.started)
+	close(a.done)
+	return a
+}
+
+func (a *materializationAttempt) signalStarted(err error) {
+	a.startedOnce.Do(func() {
+		a.startedErr = err
+		close(a.started)
+	})
+}
+
+func (s *materializationSignals) signalInit(ok bool) {
+	s.initReadyOnce.Do(func() {
+		s.initOK = ok
+		close(s.initReady)
+	})
+}
+
+func (s *materializationSignals) signalDiscoveryReady() {
+	s.discoveryReadyOnce.Do(func() { close(s.discoveryReady) })
+}
+
+func (s *materializationSignals) signalFailure(err error) {
+	if err == nil {
+		err = errors.New("upstream materialization failed")
+	}
+	s.failedOnce.Do(func() {
+		s.failureErr = err
+		close(s.failed)
+	})
+}
+
+func (a *materializationAttempt) finish(err error) {
+	a.doneOnce.Do(func() {
+		a.err = err
+		close(a.done)
+	})
+}
+
+func (a *materializationAttempt) cancelMaterialization() {
+	a.cancelOnce.Do(func() { close(a.cancel) })
+}
+
+func (a *materializationAttempt) cancelled() bool {
+	select {
+	case <-a.cancel:
+		return true
+	default:
+		return false
+	}
+}
+
+// LaunchContext is the immutable effective process context selected for one
+// materialization generation. Env is deep-copied when the context is elected.
+type LaunchContext struct {
+	SessionID int
+	Cwd       string
+	Env       map[string]string
+}
+
+type localDemandState string
+
+const (
+	localDemandWaiting    localDemandState = "WAITING"
+	localDemandCancelled  localDemandState = "CANCELLED"
+	localDemandTimedOut   localDemandState = "TIMED_OUT"
+	localDemandFailed     localDemandState = "FAILED"
+	localDemandRejected   localDemandState = "REJECTED"
+	localDemandForwarding localDemandState = "FORWARDING"
+)
+
+type localDemand struct {
+	key        string
+	session    *Session
+	message    *jsonrpc.Message
+	timer      *time.Timer
+	state      localDemandState
+	generation uint64
+}
+
+type cacheStage struct {
+	generation uint64
+	process    *upstream.Process
+	signals    *materializationSignals
+
+	initResp             []byte
+	toolList             []byte
+	promptList           []byte
+	resourceList         []byte
+	resourceTemplateList []byte
+	listChanged          bool
+}
+
+func (o *Owner) startMaterialization(trigger MaterializationTrigger) *materializationAttempt {
+	o.materializationMu.Lock()
+	a, start := o.startMaterializationLocked(trigger)
+	o.materializationMu.Unlock()
+	if start {
+		go o.runMaterialization(a)
+	}
+	return a
+}
+
+func (o *Owner) startMaterializationLocked(trigger MaterializationTrigger) (*materializationAttempt, bool) {
+	if o.upstreamWriter != nil || (o.sessionHandler != nil && o.handlerFunc == nil) {
+		return completedMaterializationAttempt(nil), false
+	}
+	if o.restartPins.Load() > 0 {
+		return completedMaterializationAttempt(errors.New("restart snapshot in progress")), false
+	}
+	select {
+	case <-o.materializationStop:
+		return completedMaterializationAttempt(errors.New("owner shutting down")), false
+	default:
+	}
+	if o.materializationState == MaterializationFinalizeBlocked {
+		err := o.materializationBlockedErr
+		if err == nil {
+			err = errFinalizationUnproven
+		}
+		return completedMaterializationAttempt(err), false
+	}
+	if o.materializationAttempt != nil {
+		return o.materializationAttempt, false
+	}
+	if o.materializationState == MaterializationReady && !o.upstreamDead.Load() {
+		return completedMaterializationAttempt(nil), false
+	}
+
+	o.materializationGeneration++
+	a := newMaterializationAttempt(o.materializationGeneration, trigger)
+	a.launch = o.electLaunchContextLocked()
+	o.materializationAttempt = a
+	o.materializationState = MaterializationMaterializing
+	o.materializationTrigger = trigger
+	return a, true
+}
+
+func (o *Owner) electLaunchContextLocked() LaunchContext {
+	for _, key := range o.pendingDemandOrder {
+		demand := o.pendingDemands[key]
+		if demand != nil && demand.state == localDemandWaiting && demand.session != nil {
+			return o.launchContextForSession(demand.session)
+		}
+	}
+	return o.launchContextForSession(nil)
+}
+
+func (o *Owner) launchContextForSession(session *Session) LaunchContext {
+	o.mu.RLock()
+	cwd := o.cwd
+	env := cloneLaunchEnv(o.env)
+	o.mu.RUnlock()
+	if session == nil {
+		return LaunchContext{Cwd: cwd, Env: env}
+	}
+	if session.Cwd != "" {
+		cwd = session.Cwd
+	}
+	if session.Env != nil {
+		env = cloneLaunchEnv(session.Env)
+	}
+	return LaunchContext{SessionID: session.ID, Cwd: cwd, Env: env}
+}
+
+func cloneLaunchEnv(src map[string]string) map[string]string {
+	if len(src) == 0 {
+		return nil
+	}
+	dst := make(map[string]string, len(src))
+	for key, value := range src {
+		dst[key] = value
+	}
+	return dst
+}
+
+func (o *Owner) launchContextCompatible(a, b LaunchContext) bool {
+	aIdentity, bIdentity := envidentity.Build(a.Env), envidentity.Build(b.Env)
+	if !envidentity.Equal(aIdentity, bIdentity, a.Env, b.Env) {
+		return false
+	}
+	o.mu.RLock()
+	mode := o.autoClassification
+	o.mu.RUnlock()
+	if mode == classify.ModeIsolated || mode == "" {
+		return serverid.CanonicalizePath(a.Cwd) == serverid.CanonicalizePath(b.Cwd)
+	}
+	return true
+}
+
+var (
+	errMaterializationCancelled     = errors.New("upstream materialization cancelled for restart")
+	errMaterializationInitiatorGone = errors.New("materialization initiator disconnected before isolated classification commit")
+)
+
+func (o *Owner) runMaterialization(a *materializationAttempt) {
+	wait := materializationRetryInitial
+	attemptNumber := 0
+
+	if current := o.currentUpstream(); current != nil {
+		if err := o.retireMaterializationProcess(a, current); err != nil {
+			a.signalStarted(err)
+			o.finishMaterializationFailure(a, err)
+			return
+		}
+	}
+
+	for {
+		attemptNumber++
+		select {
+		case <-o.materializationStop:
+			err := errors.New("owner shutting down")
+			a.signalStarted(err)
+			o.finishMaterializationFailure(a, err)
+			return
+		case <-a.cancel:
+			a.signalStarted(errMaterializationCancelled)
+			o.finishMaterializationFailure(a, errMaterializationCancelled)
+			return
+		default:
+		}
+
+		if !o.materializationStillNeeded(a.trigger) {
+			err := errors.New("upstream materialization no longer needed")
+			a.signalStarted(err)
+			o.finishMaterializationFailure(a, err)
+			return
+		}
+
+		o.materializationMu.Lock()
+		if !a.launchFrozen {
+			a.launch = o.electLaunchContextLocked()
+			a.launchFrozen = true
+		}
+		launch := LaunchContext{SessionID: a.launch.SessionID, Cwd: a.launch.Cwd, Env: cloneLaunchEnv(a.launch.Env)}
+		o.materializationMu.Unlock()
+
+		proc, err := o.spawnReplacementUpstream(launch)
+		if err != nil {
+			o.logger.Printf("upstream materialization start failed generation=%d attempt=%d trigger=%s err=%v", a.generation, attemptNumber, a.trigger, err)
+			if a.cancelled() || !o.shouldRetryMaterialization(a.trigger) {
+				a.signalStarted(err)
+				o.finishMaterializationFailure(a, err)
+				return
+			}
+			if !o.waitForMaterializationRetry(a, wait) {
+				err = errMaterializationCancelled
+				a.signalStarted(err)
+				o.finishMaterializationFailure(a, err)
+				return
+			}
+			wait = nextMaterializationRetry(wait)
+			continue
+		}
+
+		signals := o.installMaterializationProcess(a, proc)
+		a.signalStarted(nil)
+		o.logger.Printf("upstream materialization started generation=%d attempt=%d trigger=%s", a.generation, attemptNumber, a.trigger)
+		if a.cancelled() {
+			if retireErr := o.retireMaterializationProcess(a, proc); retireErr != nil {
+				o.finishMaterializationFailure(a, errors.Join(errMaterializationCancelled, retireErr))
+			} else {
+				o.finishMaterializationFailure(a, errMaterializationCancelled)
+			}
+			return
+		}
+
+		go o.readUpstream(proc)
+		go o.monitorUpstreamExit(proc)
+		if err := o.sendProactiveInitFor(a, signals); err != nil {
+			signals.signalFailure(err)
+		}
+
+		timer := time.NewTimer(materializationReadinessTimeout)
+		var readyErr error
+		select {
+		case <-signals.discoveryReady:
+			select {
+			case <-signals.failed:
+				readyErr = signals.failureErr
+			default:
+			}
+			if readyErr == nil && (o.upstreamDead.Load() || !o.isCurrentUpstream(proc)) {
+				readyErr = errors.New("upstream exited before materialization completed")
+			}
+		case <-signals.failed:
+			readyErr = signals.failureErr
+		case <-timer.C:
+			readyErr = fmt.Errorf("upstream materialization readiness timeout after %s", materializationReadinessTimeout)
+		case <-a.cancel:
+			readyErr = errMaterializationCancelled
+		case <-o.materializationStop:
+			readyErr = errors.New("owner shutting down")
+		}
+		if !timer.Stop() {
+			select {
+			case <-timer.C:
+			default:
+			}
+		}
+
+		if readyErr == nil {
+			o.finishMaterializationSuccess(a)
+			return
+		}
+
+		o.logger.Printf("upstream materialization failed generation=%d attempt=%d trigger=%s err=%v", a.generation, attemptNumber, a.trigger, readyErr)
+		if err := o.retireMaterializationProcess(a, proc); err != nil {
+			readyErr = errors.Join(readyErr, err)
+			o.finishMaterializationFailure(a, readyErr)
+			return
+		}
+		if errors.Is(readyErr, errMaterializationInitiatorGone) || a.cancelled() || !o.shouldRetryMaterialization(a.trigger) {
+			o.finishMaterializationFailure(a, readyErr)
+			return
+		}
+		if !o.waitForMaterializationRetry(a, wait) {
+			o.finishMaterializationFailure(a, errMaterializationCancelled)
+			return
+		}
+		wait = nextMaterializationRetry(wait)
+		o.materializationMu.Lock()
+		if o.materializationAttempt == a {
+			o.materializationState = MaterializationMaterializing
+		}
+		o.materializationMu.Unlock()
+	}
+}
+
+func nextMaterializationRetry(wait time.Duration) time.Duration {
+	wait *= 2
+	if wait > materializationRetryMax {
+		return materializationRetryMax
+	}
+	return wait
+}
+
+func (o *Owner) materializationStillNeeded(trigger MaterializationTrigger) bool {
+	if trigger == MaterializationTriggerEager || trigger == MaterializationTriggerBackground || trigger == MaterializationTriggerPersistent {
+		return true
+	}
+	o.materializationMu.Lock()
+	pending := len(o.pendingDemands)
+	persistenceObligation := o.materializationPolicy == MaterializationPersistent || o.persistentPending
+	o.materializationMu.Unlock()
+	return pending > 0 || persistenceObligation || o.SessionCount() > 0
+}
+
+func (o *Owner) shouldRetryMaterialization(trigger MaterializationTrigger) bool {
+	select {
+	case <-o.materializationStop:
+		return false
+	default:
+	}
+	o.materializationMu.Lock()
+	pending := len(o.pendingDemands)
+	persistenceObligation := o.materializationPolicy == MaterializationPersistent || o.persistentPending
+	o.materializationMu.Unlock()
+	if persistenceObligation || pending > 0 {
+		return true
+	}
+	return (trigger == MaterializationTriggerUpstreamExit || trigger == MaterializationTriggerWriteError) && o.SessionCount() > 0
+}
+
+func (o *Owner) waitForMaterializationRetry(a *materializationAttempt, wait time.Duration) bool {
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return true
+	case <-a.cancel:
+		return false
+	case <-o.materializationStop:
+		return false
+	}
+}
+
+func (o *Owner) installMaterializationProcess(a *materializationAttempt, proc *upstream.Process) *materializationSignals {
+	signals := newMaterializationSignals()
+	o.upstreamEventMu.Lock()
+	o.materializationMu.Lock()
+	a.process = proc
+	a.signals = signals
+	o.cacheStage = &cacheStage{generation: a.generation, process: proc, signals: signals}
+	o.mu.Lock()
+	o.upstream = proc
+	o.upstreamDead.Store(false)
+	o.mu.Unlock()
+	o.materializationMu.Unlock()
+	o.upstreamEventMu.Unlock()
+	return signals
+}
+
+func (o *Owner) retireMaterializationProcess(a *materializationAttempt, proc *upstream.Process) error {
+	if proc == nil {
+		return nil
+	}
+	o.upstreamEventMu.Lock()
+	o.materializationMu.Lock()
+	if o.materializationAttempt == a {
+		o.materializationState = MaterializationFinalizing
+		o.retiringProcess = proc
+	}
+	o.materializationMu.Unlock()
+	o.upstreamEventMu.Unlock()
+
+	closeErr := proc.Close()
+	if closeErr != nil {
+		o.logger.Printf("upstream finalizer failed generation=%d: %v", a.generation, closeErr)
+	}
+	var finalizationErr error
+	if o.materializationFinalizationProbe != nil {
+		finalizationErr = o.materializationFinalizationProbe(proc)
+	} else if !proc.RetirementProven() {
+		timer := time.NewTimer(materializationFinalizeTimeout)
+		defer timer.Stop()
+		select {
+		case <-proc.Done:
+		case <-timer.C:
+			finalizationErr = fmt.Errorf("%w after %s", errFinalizationUnproven, materializationFinalizeTimeout)
+		case <-o.materializationStop:
+			select {
+			case <-proc.Done:
+			case <-time.After(materializationFinalizeTimeout):
+				finalizationErr = fmt.Errorf("%w during shutdown", errFinalizationUnproven)
+			}
+		}
+		if finalizationErr == nil && !proc.RetirementProven() {
+			finalizationErr = errFinalizationUnproven
+		}
+	}
+	if finalizationErr != nil {
+		if closeErr != nil {
+			finalizationErr = errors.Join(finalizationErr, closeErr)
+		}
+		return o.blockMaterializationFinalization(a, finalizationErr)
+	}
+
+	o.upstreamEventMu.Lock()
+	o.materializationMu.Lock()
+	o.mu.Lock()
+	if o.upstream == proc {
+		o.upstream = nil
+	}
+	o.upstreamDead.Store(true)
+	o.mu.Unlock()
+	if o.retiringProcess == proc {
+		o.retiringProcess = nil
+	}
+	if o.cacheStage != nil && o.cacheStage.process == proc {
+		o.cacheStage = nil
+	}
+	if o.materializationAttempt == a && o.materializationState == MaterializationFinalizing {
+		o.materializationState = MaterializationMaterializing
+	}
+	o.materializationMu.Unlock()
+	o.upstreamEventMu.Unlock()
+	o.clearProactiveTracking()
+	return nil
+}
+
+func (o *Owner) blockMaterializationFinalization(a *materializationAttempt, err error) error {
+	o.upstreamEventMu.Lock()
+	o.materializationMu.Lock()
+	if o.materializationAttempt == a {
+		o.materializationState = MaterializationFinalizeBlocked
+		o.materializationBlockedErr = err
+	}
+	o.materializationMu.Unlock()
+	o.upstreamEventMu.Unlock()
+	return err
+}
+
+func (o *Owner) finishMaterializationSuccess(a *materializationAttempt) {
+	for {
+		o.materializationMu.Lock()
+		if o.materializationAttempt != a {
+			o.materializationMu.Unlock()
+			a.finish(errors.New("materialization attempt superseded"))
+			return
+		}
+		order := append([]string(nil), o.pendingDemandOrder...)
+		o.pendingDemandOrder = nil
+		if len(order) == 0 && len(o.pendingDemands) == 0 {
+			o.materializationAttempt = nil
+			o.materializationState = MaterializationReady
+			o.materializationTrigger = a.trigger
+			o.restartResumeTrigger = ""
+			o.materializationMu.Unlock()
+			a.finish(nil)
+			o.logger.Printf("upstream materialization ready generation=%d trigger=%s", a.generation, a.trigger)
+			return
+		}
+		o.materializationMu.Unlock()
+
+		for _, key := range order {
+			o.forwardQueuedDemand(key, a.generation, a.launch)
+		}
+	}
+}
+
+func (o *Owner) finishMaterializationFailure(a *materializationAttempt, err error) {
+	a.signalStarted(err)
+	o.clearProactiveTracking()
+	o.materializationMu.Lock()
+	demands := o.detachLocalDemandsForGenerationLocked(a.generation)
+	if o.materializationAttempt == a {
+		o.materializationAttempt = nil
+		if o.materializationState != MaterializationFinalizeBlocked {
+			o.materializationState = MaterializationCacheOnly
+		}
+		o.cacheStage = nil
+	}
+	o.materializationMu.Unlock()
+	a.finish(err)
+	o.writeFailedLocalDemands(demands, err)
+	o.resumeMaterializationAfterRestartPin()
+}
+
+func (o *Owner) clearProactiveTracking() {
+	o.methodTags.Range(func(key, _ any) bool {
+		id, ok := key.(string)
+		if !ok || !o.isProactiveID(json.RawMessage(id)) {
+			return true
+		}
+		if _, loaded := o.methodTags.LoadAndDelete(id); loaded {
+			o.decrementPending()
+		}
+		return true
+	})
+}
+
+func (o *Owner) currentUpstream() *upstream.Process {
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+	return o.upstream
+}
+
+func (o *Owner) acceptsProcessEvent(proc *upstream.Process) bool {
+	if proc == nil {
+		return true
+	}
+	o.materializationMu.Lock()
+	blocked := o.retiringProcess == proc || o.materializationState == MaterializationFinalizing || o.materializationState == MaterializationFinalizeBlocked
+	o.mu.RLock()
+	current := o.upstream
+	o.mu.RUnlock()
+	o.materializationMu.Unlock()
+	return !blocked && current == proc && !o.upstreamDead.Load()
+}
+
+func (o *Owner) sendProactiveInitFor(a *materializationAttempt, signals *materializationSignals) error {
+	proc := a.process
+	if proc == nil {
+		return errors.New("upstream process unavailable")
+	}
+	if a.cancelled() {
+		return errMaterializationCancelled
+	}
+	initKey := strconv.Quote(fmt.Sprintf("%s-%d-0", o.proactiveNamespace, a.generation))
+	initReq := []byte(fmt.Sprintf(`{"jsonrpc":"2.0","id":%s,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{"roots":{"listChanged":true}},"clientInfo":{"name":"mcp-mux","version":"1.0.0"}}}`, initKey))
+	o.methodTags.Store(initKey, "initialize")
+	o.pendingRequests.Add(1)
+	if err := proc.WriteLine(initReq); err != nil {
+		return fmt.Errorf("proactive initialize write: %w", err)
+	}
+	o.logger.Printf("proactive init: sent initialize request generation=%d", a.generation)
+
+	timer := time.NewTimer(materializationReadinessTimeout)
+	defer timer.Stop()
+	select {
+	case <-signals.initReady:
+		if !signals.initOK {
+			return errors.New("proactive initialize did not produce a usable response")
+		}
+	case <-signals.failed:
+		return signals.failureErr
+	case <-timer.C:
+		return fmt.Errorf("proactive initialize timeout after %s", materializationReadinessTimeout)
+	case <-a.cancel:
+		return errMaterializationCancelled
+	case <-o.materializationStop:
+		return errors.New("owner shutting down")
+	}
+
+	if a.cancelled() {
+		return errMaterializationCancelled
+	}
+	if err := proc.WriteLine([]byte(`{"jsonrpc":"2.0","method":"notifications/initialized"}`)); err != nil {
+		return fmt.Errorf("proactive initialized notification: %w", err)
+	}
+	toolsKey := strconv.Quote(fmt.Sprintf("%s-%d-1", o.proactiveNamespace, a.generation))
+	toolsReq := []byte(fmt.Sprintf(`{"jsonrpc":"2.0","id":%s,"method":"tools/list","params":{}}`, toolsKey))
+	o.methodTags.Store(toolsKey, "tools/list")
+	o.pendingRequests.Add(1)
+	if err := proc.WriteLine(toolsReq); err != nil {
+		return fmt.Errorf("proactive tools/list write: %w", err)
+	}
+	return nil
+}
+
+func (o *Owner) cacheResponseFrom(proc *upstream.Process, method string, raw []byte) {
+	if proc == nil {
+		o.cacheResponse(method, raw)
+		return
+	}
+	o.upstreamEventMu.RLock()
+	defer o.upstreamEventMu.RUnlock()
+	if !o.acceptsProcessEvent(proc) {
+		return
+	}
+	o.cacheResponseFromLocked(proc, method, raw)
+}
+
+// cacheResponseFromLocked is called only with the exact generation's read
+// lease held. It avoids recursively acquiring RWMutex.RLock from the message
+// handler, which would deadlock behind a queued writer.
+func (o *Owner) cacheResponseFromLocked(proc *upstream.Process, method string, raw []byte) {
+	// Active materialization stages are generation-fenced by attempt/process CAS.
+	if proc != nil && o.stageMaterializationCacheResponse(proc, method, raw) {
+		return
+	}
+	if o.cacheResponseState(method, raw) {
+		o.broadcastListChanged()
+	}
+}
+
+func (o *Owner) stageMaterializationListChanged(proc *upstream.Process, method string) bool {
+	switch method {
+	case "notifications/tools/list_changed", "notifications/prompts/list_changed", "notifications/resources/list_changed":
+	default:
+		return false
+	}
+	o.materializationMu.Lock()
+	defer o.materializationMu.Unlock()
+	a := o.materializationAttempt
+	stage := o.cacheStage
+	if a == nil || stage == nil || stage.process != proc || a.process != proc {
+		return false
+	}
+	stage.listChanged = true
+	return true
+}
+
+func (o *Owner) stageMaterializationCacheResponse(proc *upstream.Process, method string, raw []byte) bool {
+	cached := append([]byte(nil), raw...)
+	if method == "initialize" {
+		if injected, ok := listchanged.InjectInitializeCapability(cached); ok {
+			cached = injected
+		}
+	}
+
+	o.materializationMu.Lock()
+	a := o.materializationAttempt
+	stage := o.cacheStage
+	if a == nil || stage == nil || stage.process != proc || a.process != proc {
+		o.materializationMu.Unlock()
+		return false
+	}
+	persistentDetected := false
+	switch method {
+	case "initialize":
+		stage.initResp = cached
+		if classify.ParsePersistent(cached) && !o.persistentPending {
+			o.persistentPending = true
+			o.materializationPolicy = MaterializationPersistent
+			persistentDetected = true
+		}
+	case "tools/list":
+		stage.toolList = cached
+	case "prompts/list":
+		stage.promptList = cached
+	case "resources/list":
+		stage.resourceList = cached
+	case "resources/templates/list":
+		stage.resourceTemplateList = cached
+	default:
+		o.materializationMu.Unlock()
+		return false
+	}
+	readyToCommit := stage.initResp != nil && stage.toolList != nil
+	if method == "initialize" {
+		stage.signals.signalInit(true)
+	}
+	o.materializationMu.Unlock()
+
+	if persistentDetected && o.onPersistentDetected != nil {
+		o.onPersistentDetected(o)
+	}
+	if readyToCommit {
+		o.commitMaterializationCache(a)
+	}
+	return true
+}
+
+func (o *Owner) commitMaterializationCache(a *materializationAttempt) {
+	o.materializationMu.Lock()
+	if o.materializationAttempt != a || o.cacheStage == nil || o.cacheStage.generation != a.generation {
+		o.materializationMu.Unlock()
+		return
+	}
+	o.admissionMu.Lock()
+	stage := o.cacheStage
+	freshMode, freshSource, freshReason := stagedClassification(stage.initResp, stage.toolList)
+	persistent := classify.ParsePersistent(stage.initResp)
+
+	o.mu.Lock()
+	if freshMode == classify.ModeIsolated && a.launch.SessionID != 0 {
+		if _, initiatorPresent := o.sessions[a.launch.SessionID]; !initiatorPresent {
+			o.mu.Unlock()
+			o.admissionMu.Unlock()
+			o.materializationMu.Unlock()
+			stage.signals.signalFailure(errMaterializationInitiatorGone)
+			return
+		}
+	}
+	hadCachedLists := o.toolList != nil || o.promptList != nil || o.resourceList != nil || o.resourceTemplateList != nil
+	stagedSnapshot := o.stagedSnapshotLocked(a, stage, freshMode, freshSource, freshReason, persistent)
+	liveMode, liveSource := freshMode, freshSource
+	liveReason := append([]string(nil), freshReason...)
+	if o.autoClassification == classify.ModeIsolated && freshMode != classify.ModeIsolated {
+		liveMode = classify.ModeIsolated
+		liveSource = o.classificationSource
+		liveReason = append([]string(nil), o.classificationReason...)
+	}
+	o.admissionFrozen.Store(true)
+	o.mu.Unlock()
+
+	// The daemon's compare-and-publish is the generation commit point. The
+	// staged snapshot intentionally carries fresh classification for future
+	// templates, while local liveMode may remain conservatively isolated.
+	if o.onCacheReady != nil && !o.onCacheReady(o, stagedSnapshot) {
+		o.admissionFrozen.Store(false)
+		o.admissionMu.Unlock()
+		o.materializationMu.Unlock()
+		stage.signals.signalFailure(errors.New("stale owner generation rejected cache commit"))
+		return
+	}
+
+	o.mu.Lock()
+	o.initResp = append([]byte(nil), stage.initResp...)
+	o.toolList = append([]byte(nil), stage.toolList...)
+	o.promptList = append([]byte(nil), stage.promptList...)
+	o.resourceList = append([]byte(nil), stage.resourceList...)
+	o.resourceTemplateList = append([]byte(nil), stage.resourceTemplateList...)
+	o.initDone = true
+	o.autoClassification = liveMode
+	o.classificationSource = liveSource
+	o.classificationReason = liveReason
+	o.cwd = a.launch.Cwd
+	o.env = cloneLaunchEnv(a.launch.Env)
+	evictees := o.isolatedEvicteesLocked(liveMode, a.launch.SessionID)
+	o.mu.Unlock()
+
+	o.persistentPending = false
+	if persistent || o.persistentRequired {
+		o.materializationPolicy = MaterializationPersistent
+	} else if o.materializationPolicy == MaterializationPersistent {
+		o.materializationPolicy = MaterializationOnDemand
+	}
+
+	var rejected []*localDemand
+	if len(evictees) > 0 {
+		evictedIDs := make(map[int]struct{}, len(evictees))
+		for _, s := range evictees {
+			evictedIDs[s.ID] = struct{}{}
+		}
+		for key, demand := range o.pendingDemands {
+			if _, evicted := evictedIDs[demand.session.ID]; evicted && demand.state == localDemandWaiting {
+				demand.state = localDemandRejected
+				delete(o.pendingDemands, key)
+				rejected = append(rejected, demand)
+			}
+		}
+		if len(rejected) > 0 {
+			order := o.pendingDemandOrder[:0]
+			for _, key := range o.pendingDemandOrder {
+				if _, exists := o.pendingDemands[key]; exists {
+					order = append(order, key)
+				}
+			}
+			o.pendingDemandOrder = order
+		}
+	}
+	shouldBroadcast := hadCachedLists || stage.listChanged
+	o.cacheStage = nil
+	o.admissionFrozen.Store(false)
+	o.admissionMu.Unlock()
+	o.materializationMu.Unlock()
+
+	o.initReadyOnce.Do(func() {
+		if o.initReady != nil {
+			close(o.initReady)
+		}
+	})
+	for _, demand := range rejected {
+		if demand.timer != nil {
+			demand.timer.Stop()
+		}
+	}
+	for _, s := range evictees {
+		s.Close()
+	}
+	o.classifiedOnce.Do(func() {
+		if o.classified != nil {
+			close(o.classified)
+		}
+	})
+	if o.onPersistentResolved != nil {
+		o.onPersistentResolved(o, persistent)
+	}
+	o.parseDrainTimeout(stage.initResp)
+	o.parseToolTimeout(stage.initResp)
+	o.parseIdleTimeout(stage.initResp)
+	if sec := classify.ParseProgressInterval(stage.initResp); sec > 0 {
+		o.progressIntervalNs.Store(int64(time.Duration(sec) * time.Second))
+	}
+	if shouldBroadcast {
+		o.broadcastListChanged()
+	}
+	stage.signals.signalDiscoveryReady()
+}
+
+func (o *Owner) stagedSnapshotLocked(a *materializationAttempt, stage *cacheStage, mode classify.SharingMode, source string, reason []string, persistent bool) OwnerSnapshot {
+	snap := o.exportSnapshotLocked()
+	snap.Cwd = a.launch.Cwd
+	snap.Env = cloneSnapshotEnv(a.launch.Env)
+	snap.Classification = mode
+	snap.ClassificationSource = source
+	snap.ClassificationReason = append([]string(nil), reason...)
+	snap.CachedInit = base64Encode(stage.initResp)
+	snap.CachedTools = base64Encode(stage.toolList)
+	snap.CachedPrompts = base64Encode(stage.promptList)
+	snap.CachedResources = base64Encode(stage.resourceList)
+	snap.CachedResourceTemplates = base64Encode(stage.resourceTemplateList)
+	snap.Persistent = persistent || o.persistentRequired
+	primary := serverid.CanonicalizePath(a.launch.Cwd)
+	if mode == classify.ModeIsolated {
+		snap.CwdSet = []string{primary}
+	} else if primary != "" {
+		seen := false
+		for _, cwd := range snap.CwdSet {
+			if serverid.CanonicalizePath(cwd) == primary {
+				seen = true
+				break
+			}
+		}
+		if !seen {
+			snap.CwdSet = append(snap.CwdSet, primary)
+		}
+	}
+	return snap
+}
+
+func stagedClassification(initJSON, toolsJSON []byte) (classify.SharingMode, string, []string) {
+	if mode, ok := classify.ClassifyCapabilities(initJSON); ok {
+		return mode, "capability", nil
+	}
+	mode, matched := classify.ClassifyTools(toolsJSON)
+	return mode, "tools", matched
+}
+
+func (o *Owner) isolatedEvicteesLocked(mode classify.SharingMode, keepID int) []*Session {
+	if mode != classify.ModeIsolated {
+		return nil
+	}
+	primaryCwd := serverid.CanonicalizePath(o.cwd)
+	o.cwdSet = map[string]bool{primaryCwd: true}
+	o.sessionMgr.RemovePendingForOwnerExcept(o.serverID, o.initialAdmissionToken)
+	if len(o.sessions) <= 1 {
+		return nil
+	}
+	if _, ok := o.sessions[keepID]; !ok {
+		keepID = -1
+		for id := range o.sessions {
+			if keepID == -1 || id < keepID {
+				keepID = id
+			}
+		}
+	}
+	evictees := make([]*Session, 0, len(o.sessions)-1)
+	for id, s := range o.sessions {
+		if id != keepID {
+			evictees = append(evictees, s)
+		}
+	}
+	return evictees
+}
+
+func (o *Owner) enqueueLocalDemand(s *Session, msg *jsonrpc.Message) (bool, error) {
+	raw := append([]byte(nil), msg.Raw...)
+	copyMsg, err := jsonrpc.Parse(raw)
+	if err != nil {
+		return false, err
+	}
+	key := string(remap.Remap(s.ID, msg.ID))
+	candidate := o.launchContextForSession(s)
+
+	o.materializationMu.Lock()
+	if o.materializationState == MaterializationReady && !o.upstreamDead.Load() {
+		o.materializationMu.Unlock()
+		return false, nil
+	}
+	if o.restartPins.Load() > 0 {
+		o.materializationMu.Unlock()
+		return true, o.writeDemandError(s, msg.ID, "restart snapshot in progress")
+	}
+	if o.materializationState == MaterializationFinalizeBlocked {
+		err := o.materializationBlockedErr
+		if err == nil {
+			err = errFinalizationUnproven
+		}
+		o.materializationMu.Unlock()
+		return true, o.writeDemandError(s, msg.ID, err.Error())
+	}
+	if _, exists := o.pendingDemands[key]; exists {
+		o.materializationMu.Unlock()
+		return true, o.writeDemandError(s, msg.ID, "duplicate request id while upstream materializes")
+	}
+	if active := o.materializationAttempt; active != nil && !o.launchContextCompatible(active.launch, candidate) {
+		o.materializationMu.Unlock()
+		return true, o.writeDemandError(s, msg.ID, "request context incompatible with active upstream materialization")
+	}
+
+	demand := &localDemand{key: key, session: s, message: copyMsg, state: localDemandWaiting}
+	o.pendingDemands[key] = demand
+	o.pendingDemandOrder = append(o.pendingDemandOrder, key)
+	demand.timer = time.AfterFunc(materializationDemandTimeout, func() {
+		o.expireLocalDemand(key)
+	})
+	a, start := o.startMaterializationLocked(MaterializationTriggerDemand)
+	if a.generation == 0 {
+		delete(o.pendingDemands, key)
+		demand.state = localDemandFailed
+		if demand.timer != nil {
+			demand.timer.Stop()
+		}
+		o.materializationMu.Unlock()
+		if a.err != nil {
+			return true, o.writeDemandError(s, msg.ID, a.err.Error())
+		}
+		return false, nil
+	}
+	demand.generation = a.generation
+	o.materializationMu.Unlock()
+	if start {
+		go o.runMaterialization(a)
+	}
+	return true, nil
+}
+
+func (o *Owner) expireLocalDemand(key string) {
+	o.materializationMu.Lock()
+	demand, ok := o.transitionLocalDemandLocked(key, localDemandTimedOut)
+	o.materializationMu.Unlock()
+	if ok {
+		_ = o.writeDemandError(demand.session, demand.message.ID, "upstream materialization timed out")
+	}
+}
+
+func (o *Owner) cancelLocalDemand(s *Session, requestID json.RawMessage) bool {
+	key := string(remap.Remap(s.ID, requestID))
+	if o.beforeLocalDemandCancel != nil {
+		o.beforeLocalDemandCancel()
+	}
+	o.materializationMu.Lock()
+	demand, ok := o.transitionLocalDemandLocked(key, localDemandCancelled)
+	if ok && o.materializationAttempt != nil && !o.materializationAttempt.launchFrozen && demand.session.ID == o.materializationAttempt.launch.SessionID {
+		o.materializationAttempt.launch = o.electLaunchContextLocked()
+	}
+	o.materializationMu.Unlock()
+	return ok
+}
+
+func (o *Owner) cancelLocalDemandsForSession(sessionID int) {
+	o.materializationMu.Lock()
+	launchRemoved := false
+	for key, demand := range o.pendingDemands {
+		if demand.session.ID != sessionID || demand.state != localDemandWaiting {
+			continue
+		}
+		demand.state = localDemandCancelled
+		delete(o.pendingDemands, key)
+		if demand.timer != nil {
+			demand.timer.Stop()
+		}
+		if o.materializationAttempt != nil && demand.session.ID == o.materializationAttempt.launch.SessionID {
+			launchRemoved = true
+		}
+	}
+	if launchRemoved && o.materializationAttempt != nil && !o.materializationAttempt.launchFrozen {
+		o.materializationAttempt.launch = o.electLaunchContextLocked()
+	}
+	o.materializationMu.Unlock()
+}
+
+func (o *Owner) cancelDisposableMaterializationForZeroSessions() {
+	o.materializationMu.Lock()
+	a := o.materializationAttempt
+	if a == nil || o.materializationPolicy == MaterializationPersistent || o.persistentPending || o.restartPins.Load() > 0 || a.trigger == MaterializationTriggerBackground || a.trigger == MaterializationTriggerPersistent {
+		o.materializationMu.Unlock()
+		return
+	}
+	a.cancelMaterialization()
+	o.materializationMu.Unlock()
+}
+
+func (o *Owner) detachLocalDemandsForGenerationLocked(generation uint64) []*localDemand {
+	demands := make([]*localDemand, 0, len(o.pendingDemands))
+	for key, demand := range o.pendingDemands {
+		if demand.state != localDemandWaiting || generation != 0 && demand.generation != generation {
+			continue
+		}
+		demand.state = localDemandFailed
+		delete(o.pendingDemands, key)
+		if demand.timer != nil {
+			demand.timer.Stop()
+		}
+		demands = append(demands, demand)
+	}
+	kept := o.pendingDemandOrder[:0]
+	for _, key := range o.pendingDemandOrder {
+		if demand := o.pendingDemands[key]; demand != nil && demand.state == localDemandWaiting {
+			kept = append(kept, key)
+		}
+	}
+	o.pendingDemandOrder = kept
+	return demands
+}
+
+func (o *Owner) detachAllLocalDemands() []*localDemand {
+	o.materializationMu.Lock()
+	demands := o.detachLocalDemandsForGenerationLocked(0)
+	o.materializationMu.Unlock()
+	return demands
+}
+
+func (o *Owner) writeFailedLocalDemands(demands []*localDemand, err error) {
+	if err == nil {
+		err = errors.New("upstream materialization failed")
+	}
+	for _, demand := range demands {
+		_ = o.writeDemandError(demand.session, demand.message.ID, err.Error())
+	}
+}
+
+func (o *Owner) failAllLocalDemands(err error) {
+	o.writeFailedLocalDemands(o.detachAllLocalDemands(), err)
+}
+
+func (o *Owner) forwardQueuedDemand(key string, generation uint64, launch LaunchContext) {
+	o.materializationMu.Lock()
+	demand := o.pendingDemands[key]
+	if demand == nil || demand.state != localDemandWaiting || demand.generation != generation {
+		o.materializationMu.Unlock()
+		return
+	}
+
+	o.mu.RLock()
+	attached := o.sessions[demand.session.ID] == demand.session
+	o.mu.RUnlock()
+	authorized := o.authorizeSession == nil || demand.session.Meta().IsAuthorized()
+	compatible := o.launchContextCompatible(launch, o.launchContextForSession(demand.session))
+	if !attached || !authorized || !compatible {
+		demand.state = localDemandRejected
+		delete(o.pendingDemands, key)
+		if demand.timer != nil {
+			demand.timer.Stop()
+		}
+		o.materializationMu.Unlock()
+		_ = o.writeDemandError(demand.session, demand.message.ID, "request no longer admitted after upstream materialization")
+		return
+	}
+
+	demand.state = localDemandForwarding
+	delete(o.pendingDemands, key)
+	if demand.timer != nil {
+		demand.timer.Stop()
+	}
+	if cached := o.getCachedResponse(demand.message.Method); cached != nil &&
+		(demand.message.Method != "initialize" || o.initFingerprintMatches(demand.message.Raw)) {
+		err := o.replayFromCache(demand.session, demand.message, cached)
+		o.materializationMu.Unlock()
+		if err != nil {
+			_ = o.writeDemandError(demand.session, demand.message.ID, err.Error())
+		}
+		return
+	}
+
+	if o.beforeQueuedDemandWrite != nil {
+		o.beforeQueuedDemandWrite()
+	}
+	writeFailed, err := o.forwardRequestPrepared(demand.session, demand.message)
+	o.materializationMu.Unlock()
+	if err != nil {
+		o.logger.Printf("session %d: queued demand forwarding failed: %v", demand.session.ID, err)
+	}
+	if writeFailed {
+		o.startMaterialization(MaterializationTriggerWriteError)
+	}
+}
+
+func (o *Owner) transitionLocalDemandLocked(key string, terminal localDemandState) (*localDemand, bool) {
+	demand := o.pendingDemands[key]
+	if demand == nil || demand.state != localDemandWaiting {
+		return nil, false
+	}
+	demand.state = terminal
+	delete(o.pendingDemands, key)
+	if demand.timer != nil {
+		demand.timer.Stop()
+	}
+	return demand, true
+}
+
+func (o *Owner) writeDemandError(s *Session, id json.RawMessage, message string) error {
+	payload, err := buildJSONRPCErrorBytes(id, -32603, message)
+	if err != nil {
+		return err
+	}
+	return s.WriteRaw(payload)
+}
+
+func (o *Owner) forwardRequestNow(s *Session, msg *jsonrpc.Message) error {
+	writeFailed, err := o.forwardRequestPrepared(s, msg)
+	if writeFailed {
+		o.startMaterialization(MaterializationTriggerWriteError)
+	}
+	return err
+}
+
+func (o *Owner) forwardRequestPrepared(s *Session, msg *jsonrpc.Message) (bool, error) {
+	o.pendingRequests.Add(1)
+	newID := remap.Remap(s.ID, msg.ID)
+	remapped, err := jsonrpc.ReplaceID(msg.Raw, newID)
+	if err != nil {
+		o.decrementPending()
+		return false, fmt.Errorf("remap request: %w", err)
+	}
+
+	o.inflightTracker.Store(string(newID), &InflightRequest{
+		Method:    msg.Method,
+		Tool:      extractToolName(msg.Raw),
+		SessionID: s.ID,
+		StartTime: time.Now(),
+	})
+	if msg.Method == "initialize" || msg.Method == "tools/list" ||
+		msg.Method == "prompts/list" || msg.Method == "resources/list" ||
+		msg.Method == "resources/templates/list" {
+		o.methodTags.Store(string(newID), msg.Method)
+	}
+	if msg.Method == "initialize" {
+		o.captureInitFingerprint(msg.Raw)
+	}
+
+	o.mu.RLock()
+	needsMeta := o.autoClassification == classify.ModeSessionAware || o.handlerFunc != nil
+	o.mu.RUnlock()
+	if needsMeta {
+		if injected, injectErr := jsonrpc.InjectMeta(remapped, "muxSessionId", s.MuxSessionID); injectErr == nil {
+			remapped = injected
+		} else {
+			o.logger.Printf("session %d: failed to inject muxSessionId: %v", s.ID, injectErr)
+		}
+		if s.Cwd != "" {
+			if injected, injectErr := jsonrpc.InjectMeta(remapped, "muxCwd", s.Cwd); injectErr == nil {
+				remapped = injected
+			} else {
+				o.logger.Printf("session %d: failed to inject muxCwd: %v", s.ID, injectErr)
+			}
+		}
+		if len(s.Env) > 0 {
+			if injected, injectErr := jsonrpc.InjectMeta(remapped, "muxEnv", s.Env); injectErr == nil {
+				remapped = injected
+			} else {
+				o.logger.Printf("session %d: failed to inject muxEnv: %v", s.ID, injectErr)
+			}
+		}
+	}
+
+	o.trackProgressToken(s.ID, string(newID), msg.Raw)
+	o.sessionMgr.TrackRequest(string(newID), s.ID)
+	if msg.Method == "tools/call" && o.toolTimeoutNs.Load() > 0 {
+		o.startToolWatchdog(string(newID), msg.ID, s, msg.Method)
+	}
+	if err := o.writeUpstream(remapped); err != nil {
+		o.logger.Printf("session %d: upstream write failed for request id=%s: %v", s.ID, string(newID), err)
+		o.upstreamDead.Store(true)
+		o.drainInflightRequests()
+		return true, nil
+	}
+	return false, nil
+}
+
+func (o *Owner) ensureUpstreamReadyForRequest() error {
+	if o.materializationReadyForRequests() {
+		return nil
+	}
+	a := o.startMaterialization(MaterializationTriggerDemand)
+	timer := time.NewTimer(materializationReadinessTimeout)
+	defer timer.Stop()
+	select {
+	case <-a.done:
+		return a.err
+	case <-timer.C:
+		return fmt.Errorf("upstream materialization still pending after %s", materializationReadinessTimeout)
+	case <-o.materializationStop:
+		return errors.New("owner shutting down")
+	}
+}
+
+func (o *Owner) materializationReadyForRequests() bool {
+	if o.upstreamWriter != nil || (o.sessionHandler != nil && o.handlerFunc == nil) {
+		return true
+	}
+	o.materializationMu.Lock()
+	ready := o.materializationState == MaterializationReady && !o.upstreamDead.Load()
+	o.materializationMu.Unlock()
+	return ready && o.hasWritableUpstream()
+}
+
+func (o *Owner) forwardNotificationIfReady(data []byte) error {
+	if !o.materializationReadyForRequests() {
+		return nil
+	}
+	return o.writeUpstream(data)
+}
+
+// StartInitialMaterialization starts the daemon-deferred initial generation and
+// waits until process start succeeds or fails. Discovery continues through the
+// normal controller after this method returns.
+func (o *Owner) StartInitialMaterialization() error {
+	trigger := MaterializationTriggerEager
+	o.materializationMu.Lock()
+	if o.materializationPolicy == MaterializationPersistent || o.persistentPending {
+		trigger = MaterializationTriggerPersistent
+	}
+	o.materializationMu.Unlock()
+	a := o.startMaterialization(trigger)
+	<-a.started
+	return a.startedErr
+}
+
+// SpawnUpstreamBackground retains the existing call surface while routing the
+// work through the single owner-owned materialization controller.
+func (o *Owner) SpawnUpstreamBackground() {
+	o.startMaterialization(MaterializationTriggerBackground)
+}
+
+func (o *Owner) monitorMaterializedProcessExit(proc *upstream.Process) {
+	if proc == nil {
+		return
+	}
+	o.upstreamEventMu.Lock()
+	o.materializationMu.Lock()
+	if o.retiringProcess == proc {
+		o.materializationMu.Unlock()
+		o.upstreamEventMu.Unlock()
+		o.handleRetiringProcessExit(proc)
+		return
+	}
+	o.mu.Lock()
+	if o.upstream != proc {
+		o.mu.Unlock()
+		o.materializationMu.Unlock()
+		o.upstreamEventMu.Unlock()
+		return
+	}
+	o.upstreamDead.Store(true)
+	if a := o.materializationAttempt; a != nil && a.process == proc {
+		signals := a.signals
+		o.mu.Unlock()
+		responses := o.claimInflightRequests()
+		o.materializationMu.Unlock()
+		o.upstreamEventMu.Unlock()
+		o.deliverInflightResponses(responses)
+		signals.signalFailure(fmt.Errorf("upstream exited before materialization completed: %v", proc.ExitErr))
+		return
+	}
+	o.upstream = nil
+	o.mu.Unlock()
+	o.materializationState = MaterializationCacheOnly
+	responses := o.claimInflightRequests()
+	o.materializationMu.Unlock()
+	o.upstreamEventMu.Unlock()
+	o.deliverInflightResponses(responses)
+
+	if o.shouldRetryMaterialization(MaterializationTriggerUpstreamExit) {
+		o.startMaterialization(MaterializationTriggerUpstreamExit)
+		return
+	}
+	if !o.hasUsableCache() {
+		o.notifyUpstreamExit()
+	}
+}
+
+func (o *Owner) handleRetiringProcessExit(proc *upstream.Process) bool {
+	o.upstreamEventMu.Lock()
+	o.materializationMu.Lock()
+	if o.retiringProcess != proc {
+		o.materializationMu.Unlock()
+		o.upstreamEventMu.Unlock()
+		return false
+	}
+	if o.materializationState != MaterializationFinalizeBlocked || !errors.Is(o.materializationBlockedErr, errFinalizationUnproven) {
+		o.materializationMu.Unlock()
+		o.upstreamEventMu.Unlock()
+		return true
+	}
+	o.materializationMu.Unlock()
+	o.upstreamEventMu.Unlock()
+
+	// Process finalization may block; generation writers already see this proc
+	// as retiring, so no lease is held across Close.
+	closeErr := proc.Close()
+	proofErr := error(nil)
+	proven := proc.RetirementProven()
+	if o.materializationFinalizationProbe != nil {
+		proofErr = o.materializationFinalizationProbe(proc)
+		proven = proofErr == nil
+	}
+	if !proven {
+		if proofErr == nil {
+			proofErr = errFinalizationUnproven
+		}
+		if closeErr != nil {
+			proofErr = errors.Join(proofErr, closeErr)
+		}
+		o.upstreamEventMu.Lock()
+		o.materializationMu.Lock()
+		if o.retiringProcess == proc {
+			o.materializationBlockedErr = proofErr
+		}
+		o.materializationMu.Unlock()
+		o.upstreamEventMu.Unlock()
+		return true
+	}
+	if closeErr != nil {
+		o.logger.Printf("retiring process finalized after warning: %v", closeErr)
+	}
+
+	o.upstreamEventMu.Lock()
+	o.materializationMu.Lock()
+	if o.retiringProcess != proc {
+		o.materializationMu.Unlock()
+		o.upstreamEventMu.Unlock()
+		return true
+	}
+	o.mu.Lock()
+	if o.upstream == proc {
+		o.upstream = nil
+	}
+	o.upstreamDead.Store(true)
+	o.mu.Unlock()
+	o.retiringProcess = nil
+	o.materializationBlockedErr = nil
+	o.materializationState = MaterializationCacheOnly
+	if o.cacheStage != nil && o.cacheStage.process == proc {
+		o.cacheStage = nil
+	}
+	responses := o.claimInflightRequests()
+	o.materializationMu.Unlock()
+	o.upstreamEventMu.Unlock()
+	o.deliverInflightResponses(responses)
+	o.clearProactiveTracking()
+	if o.shouldRetryMaterialization(MaterializationTriggerUpstreamExit) {
+		o.startMaterialization(MaterializationTriggerUpstreamExit)
+	} else if !o.hasUsableCache() {
+		o.notifyUpstreamExit()
+	}
+	return true
+}
+
+// RestartPin freezes new materialization generations while restart state is
+// serialized. Release must be called after the daemon has committed or aborted
+// the snapshot operation.
+type RestartPin struct {
+	owner    *Owner
+	Snapshot OwnerSnapshot
+	Sessions []SessionSnapshot
+	release  sync.Once
+}
+
+func (p *RestartPin) Release() {
+	if p == nil || p.owner == nil {
+		return
+	}
+	p.release.Do(p.owner.releaseRestartPin)
+}
+
+func (o *Owner) releaseRestartPin() {
+	if o.restartPins.Add(-1) == 0 {
+		o.resumeMaterializationAfterRestartPin()
+	}
+}
+
+func (o *Owner) resumeMaterializationAfterRestartPin() {
+	if o.restartPins.Load() != 0 {
+		return
+	}
+	select {
+	case <-o.materializationStop:
+		o.materializationMu.Lock()
+		o.restartResumeTrigger = ""
+		o.materializationMu.Unlock()
+		return
+	default:
+	}
+
+	o.materializationMu.Lock()
+	if o.restartPins.Load() != 0 {
+		o.materializationMu.Unlock()
+		return
+	}
+	if o.materializationAttempt != nil {
+		o.materializationMu.Unlock()
+		return
+	}
+	if o.materializationState == MaterializationReady || o.materializationState == MaterializationFinalizeBlocked {
+		o.restartResumeTrigger = ""
+		o.materializationMu.Unlock()
+		return
+	}
+	trigger := o.restartResumeTrigger
+	if o.materializationPolicy == MaterializationPersistent || o.persistentPending {
+		trigger = MaterializationTriggerPersistent
+	} else if trigger == "" && len(o.pendingDemands) > 0 {
+		trigger = MaterializationTriggerDemand
+	}
+	o.restartResumeTrigger = ""
+	if trigger == "" {
+		o.materializationMu.Unlock()
+		return
+	}
+	a, start := o.startMaterializationLocked(trigger)
+	o.materializationMu.Unlock()
+	if start {
+		go o.runMaterialization(a)
+	}
+}
+
+func (o *Owner) AcquireRestartPin(ctx context.Context) (*RestartPin, error) {
+	o.restartPins.Add(1)
+	releaseOnError := true
+	defer func() {
+		if releaseOnError {
+			o.releaseRestartPin()
+		}
+	}()
+
+	o.materializationMu.Lock()
+	a := o.materializationAttempt
+	var launch *LaunchContext
+	if a != nil {
+		if !a.launchFrozen {
+			a.launch = o.electLaunchContextLocked()
+			a.launchFrozen = true
+		}
+		selected := LaunchContext{SessionID: a.launch.SessionID, Cwd: a.launch.Cwd, Env: cloneLaunchEnv(a.launch.Env)}
+		launch = &selected
+		if o.restartResumeTrigger == "" {
+			o.restartResumeTrigger = a.trigger
+		}
+	} else if o.materializationPolicy == MaterializationPersistent || o.persistentPending {
+		o.restartResumeTrigger = MaterializationTriggerPersistent
+	}
+	o.materializationMu.Unlock()
+	if a != nil {
+		settled := false
+		timer := time.NewTimer(restartMaterializationSettleGrace)
+		select {
+		case <-a.done:
+			settled = true
+		case <-timer.C:
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, fmt.Errorf("restart materialization barrier: %w", ctx.Err())
+		case <-o.materializationStop:
+			timer.Stop()
+			return nil, errors.New("restart materialization barrier: owner shutting down")
+		}
+		if !timer.Stop() {
+			select {
+			case <-timer.C:
+			default:
+			}
+		}
+		if !settled {
+			a.cancelMaterialization()
+			select {
+			case <-a.done:
+			case <-ctx.Done():
+				return nil, fmt.Errorf("restart materialization cancellation: %w", ctx.Err())
+			case <-o.materializationStop:
+				return nil, errors.New("restart materialization cancellation: owner shutting down")
+			}
+		}
+	}
+
+	o.materializationMu.Lock()
+	state := o.materializationState
+	blockedErr := o.materializationBlockedErr
+	o.materializationMu.Unlock()
+	if state == MaterializationFinalizeBlocked {
+		if blockedErr == nil {
+			blockedErr = errFinalizationUnproven
+		}
+		return nil, fmt.Errorf("restart materialization barrier: %w", blockedErr)
+	}
+	snapshot, sessions := o.ExportSnapshotState()
+	if launch != nil {
+		snapshot.Cwd = launch.Cwd
+		snapshot.Env = cloneSnapshotEnv(launch.Env)
+	}
+	pin := &RestartPin{owner: o, Snapshot: snapshot, Sessions: sessions}
+	releaseOnError = false
+	return pin, nil
+}
+
+func (o *Owner) quiesceMaterializationForHandoff() error {
+	o.materializationMu.Lock()
+	a := o.materializationAttempt
+	o.materializationMu.Unlock()
+	if a != nil {
+		timer := time.NewTimer(materializationFinalizeTimeout)
+		select {
+		case <-a.done:
+			timer.Stop()
+		case <-timer.C:
+			o.stopMaterialization()
+			return fmt.Errorf("materialization quiesce timeout after %s", materializationFinalizeTimeout)
+		}
+	}
+	o.stopMaterialization()
+	o.materializationMu.Lock()
+	state := o.materializationState
+	blockedErr := o.materializationBlockedErr
+	o.materializationMu.Unlock()
+	if state == MaterializationFinalizeBlocked {
+		if blockedErr == nil {
+			blockedErr = errFinalizationUnproven
+		}
+		return blockedErr
+	}
+	return nil
+}
+
+func (o *Owner) hasUsableCache() bool {
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+	return o.initResp != nil
+}
+
+func (o *Owner) CacheReady() bool {
+	o.mu.RLock()
+	ready := o.initResp != nil && o.toolList != nil
+	o.mu.RUnlock()
+	return ready
+}
+
+func (o *Owner) stopMaterialization() {
+	if o.materializationStop != nil {
+		select {
+		case <-o.materializationStop:
+			return
+		default:
+			close(o.materializationStop)
+		}
+	}
+	o.materializationMu.Lock()
+	if a := o.materializationAttempt; a != nil {
+		a.signals.signalFailure(errors.New("owner shutting down"))
+	}
+	o.materializationMu.Unlock()
+	o.failAllLocalDemands(errors.New("owner shutting down"))
+}
+
+func (o *Owner) MaterializationState() MaterializationState {
+	o.materializationMu.Lock()
+	state := o.materializationState
+	o.materializationMu.Unlock()
+	return state
+}
+
+func (o *Owner) PersistentPending() bool {
+	o.materializationMu.Lock()
+	pending := o.persistentPending
+	o.materializationMu.Unlock()
+	return pending
+}
+
+func (o *Owner) ResolvePersistent(persistent bool) {
+	o.materializationMu.Lock()
+	o.persistentPending = false
+	if persistent || o.persistentRequired {
+		o.materializationPolicy = MaterializationPersistent
+	} else if o.materializationPolicy == MaterializationPersistent {
+		o.materializationPolicy = MaterializationOnDemand
+	}
+	o.materializationMu.Unlock()
+}
+
+func (o *Owner) MaterializationBlocksEviction() bool {
+	if o.restartPins.Load() > 0 {
+		return true
+	}
+	o.materializationMu.Lock()
+	state := o.materializationState
+	pendingPersistent := o.persistentPending
+	o.materializationMu.Unlock()
+	return pendingPersistent || state == MaterializationMaterializing || state == MaterializationFinalizing || state == MaterializationFinalizeBlocked
+}
+
+func (o *Owner) materializationStatus() (MaterializationState, MaterializationTrigger, MaterializationPolicy, uint64, int, bool, string) {
+	o.materializationMu.Lock()
+	defer o.materializationMu.Unlock()
+	blocked := ""
+	if o.materializationBlockedErr != nil {
+		blocked = o.materializationBlockedErr.Error()
+	}
+	return o.materializationState, o.materializationTrigger, o.materializationPolicy,
+		o.materializationGeneration, len(o.pendingDemands), o.persistentPending, blocked
+}

--- a/muxcore/owner/materialization.go
+++ b/muxcore/owner/materialization.go
@@ -99,12 +99,13 @@ func newMaterializationSignals() *materializationSignals {
 }
 
 type materializationAttempt struct {
-	generation   uint64
-	trigger      MaterializationTrigger
-	launch       LaunchContext
-	cancel       chan struct{}
-	cancelOnce   sync.Once
-	launchFrozen bool
+	generation            uint64
+	trigger               MaterializationTrigger
+	launch                LaunchContext
+	launchFrozen          bool
+	launchRequiresSession bool
+	cancel                chan struct{}
+	cancelOnce            sync.Once
 
 	started     chan struct{}
 	startedOnce sync.Once
@@ -206,12 +207,15 @@ const (
 )
 
 type localDemand struct {
-	key        string
-	session    *Session
-	message    *jsonrpc.Message
-	timer      *time.Timer
-	state      localDemandState
-	generation uint64
+	key                 string
+	session             *Session
+	message             *jsonrpc.Message
+	timer               *time.Timer
+	state               localDemandState
+	generation          uint64
+	forwardDone         chan struct{}
+	materializationDone <-chan struct{}
+	upstreamForwarded   bool
 }
 
 type cacheStage struct {
@@ -275,18 +279,42 @@ func (o *Owner) startMaterializationLocked(trigger MaterializationTrigger) (*mat
 func (o *Owner) electLaunchContextLocked() LaunchContext {
 	for _, key := range o.pendingDemandOrder {
 		demand := o.pendingDemands[key]
-		if demand != nil && demand.state == localDemandWaiting && demand.session != nil {
+		if demand != nil && demand.state == localDemandWaiting && o.sessionEligibleForDemand(demand.session) {
 			return o.launchContextForSession(demand.session)
 		}
 	}
 	return o.launchContextForSession(nil)
 }
 
+func (o *Owner) launchSessionEligible(launch LaunchContext) bool {
+	if launch.SessionID == 0 {
+		return true
+	}
+	o.mu.RLock()
+	session := o.sessions[launch.SessionID]
+	o.mu.RUnlock()
+	return o.sessionEligibleForDemand(session)
+}
+
+func (o *Owner) oldestEligibleLaunchContext() (LaunchContext, bool) {
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+	session := o.oldestEligibleSessionLocked()
+	if session == nil {
+		return LaunchContext{}, false
+	}
+	return o.launchContextForSessionLocked(session), true
+}
+
 func (o *Owner) launchContextForSession(session *Session) LaunchContext {
 	o.mu.RLock()
+	defer o.mu.RUnlock()
+	return o.launchContextForSessionLocked(session)
+}
+
+func (o *Owner) launchContextForSessionLocked(session *Session) LaunchContext {
 	cwd := o.cwd
 	env := cloneLaunchEnv(o.env)
-	o.mu.RUnlock()
 	if session == nil {
 		return LaunchContext{Cwd: cwd, Env: env}
 	}
@@ -299,6 +327,24 @@ func (o *Owner) launchContextForSession(session *Session) LaunchContext {
 	return LaunchContext{SessionID: session.ID, Cwd: cwd, Env: env}
 }
 
+func (o *Owner) oldestEligibleSessionLocked() *Session {
+	var selected *Session
+	selectedID := 0
+	for id, session := range o.sessions {
+		if session == nil || session.IsClosed() {
+			continue
+		}
+		if o.authorizeSession != nil && !session.Meta().IsAuthorized() {
+			continue
+		}
+		if selected == nil || id < selectedID {
+			selected = session
+			selectedID = id
+		}
+	}
+	return selected
+}
+
 func cloneLaunchEnv(src map[string]string) map[string]string {
 	if len(src) == 0 {
 		return nil
@@ -308,6 +354,19 @@ func cloneLaunchEnv(src map[string]string) map[string]string {
 		dst[key] = value
 	}
 	return dst
+}
+
+func launchContextsEqual(a, b LaunchContext) bool {
+	if serverid.CanonicalizePath(a.Cwd) != serverid.CanonicalizePath(b.Cwd) || len(a.Env) != len(b.Env) {
+		return false
+	}
+	for key, value := range a.Env {
+		other, ok := b.Env[key]
+		if !ok || other != value {
+			return false
+		}
+	}
+	return true
 }
 
 func (o *Owner) launchContextCompatible(a, b LaunchContext) bool {
@@ -325,8 +384,9 @@ func (o *Owner) launchContextCompatible(a, b LaunchContext) bool {
 }
 
 var (
-	errMaterializationCancelled     = errors.New("upstream materialization cancelled for restart")
-	errMaterializationInitiatorGone = errors.New("materialization initiator disconnected before isolated classification commit")
+	errMaterializationCancelled        = errors.New("upstream materialization cancelled for restart")
+	errMaterializationInitiatorGone    = errors.New("materialization initiator disconnected before isolated classification commit")
+	errMaterializationContextReelected = errors.New("fresh isolated classification requires retained-session rematerialization")
 )
 
 func (o *Owner) runMaterialization(a *materializationAttempt) {
@@ -363,17 +423,32 @@ func (o *Owner) runMaterialization(a *materializationAttempt) {
 			return
 		}
 
+		o.launchContextMu.Lock()
 		o.materializationMu.Lock()
 		if !a.launchFrozen {
-			a.launch = o.electLaunchContextLocked()
+			if !o.launchSessionEligible(a.launch) {
+				if a.launchRequiresSession {
+					if replacement, ok := o.oldestEligibleLaunchContext(); ok {
+						a.launch = replacement
+					}
+				} else {
+					a.launch = o.electLaunchContextLocked()
+				}
+			}
 			a.launchFrozen = true
 		}
 		launch := LaunchContext{SessionID: a.launch.SessionID, Cwd: a.launch.Cwd, Env: cloneLaunchEnv(a.launch.Env)}
 		o.materializationMu.Unlock()
 
 		proc, err := o.spawnReplacementUpstream(launch)
+		o.launchContextMu.Unlock()
 		if err != nil {
 			o.logger.Printf("upstream materialization start failed generation=%d attempt=%d trigger=%s err=%v", a.generation, attemptNumber, a.trigger, err)
+			o.materializationMu.Lock()
+			if o.materializationAttempt == a {
+				a.launchFrozen = false
+			}
+			o.materializationMu.Unlock()
 			if a.cancelled() || !o.shouldRetryMaterialization(a.trigger) {
 				a.signalStarted(err)
 				o.finishMaterializationFailure(a, err)
@@ -446,7 +521,14 @@ func (o *Owner) runMaterialization(a *materializationAttempt) {
 			o.finishMaterializationFailure(a, readyErr)
 			return
 		}
-		if errors.Is(readyErr, errMaterializationInitiatorGone) || a.cancelled() || !o.shouldRetryMaterialization(a.trigger) {
+		o.materializationMu.Lock()
+		if o.materializationAttempt == a {
+			a.launchFrozen = false
+		}
+		o.materializationMu.Unlock()
+		initiatorGoneTerminal := errors.Is(readyErr, errMaterializationInitiatorGone) &&
+			a.trigger != MaterializationTriggerUpstreamExit && a.trigger != MaterializationTriggerWriteError
+		if initiatorGoneTerminal || a.cancelled() || !o.shouldRetryMaterialization(a.trigger) {
 			o.finishMaterializationFailure(a, readyErr)
 			return
 		}
@@ -598,12 +680,16 @@ func (o *Owner) retireMaterializationProcess(a *materializationAttempt, proc *up
 func (o *Owner) blockMaterializationFinalization(a *materializationAttempt, err error) error {
 	o.upstreamEventMu.Lock()
 	o.materializationMu.Lock()
-	if o.materializationAttempt == a {
+	blocked := o.materializationAttempt == a
+	if blocked {
 		o.materializationState = MaterializationFinalizeBlocked
 		o.materializationBlockedErr = err
 	}
 	o.materializationMu.Unlock()
 	o.upstreamEventMu.Unlock()
+	if blocked && a.process != nil {
+		o.startRetiringProcessRetry(a.process, a.trigger)
+	}
 	return err
 }
 
@@ -779,11 +865,10 @@ func (o *Owner) stageMaterializationListChanged(proc *upstream.Process, method s
 }
 
 func (o *Owner) stageMaterializationCacheResponse(proc *upstream.Process, method string, raw []byte) bool {
-	cached := append([]byte(nil), raw...)
-	if method == "initialize" {
-		if injected, ok := listchanged.InjectInitializeCapability(cached); ok {
-			cached = injected
-		}
+	switch method {
+	case "initialize", "tools/list", "prompts/list", "resources/list", "resources/templates/list":
+	default:
+		return false
 	}
 
 	o.materializationMu.Lock()
@@ -793,6 +878,22 @@ func (o *Owner) stageMaterializationCacheResponse(proc *upstream.Process, method
 		o.materializationMu.Unlock()
 		return false
 	}
+	if !successfulJSONRPCResponse(raw) {
+		if method == "initialize" {
+			stage.signals.signalInit(false)
+		}
+		stage.signals.signalFailure(fmt.Errorf("%s did not return a successful JSON-RPC result", method))
+		o.materializationMu.Unlock()
+		return true
+	}
+
+	cached := append([]byte(nil), raw...)
+	if method == "initialize" {
+		if injected, ok := listchanged.InjectInitializeCapability(cached); ok {
+			cached = injected
+		}
+	}
+
 	persistentDetected := false
 	switch method {
 	case "initialize":
@@ -810,9 +911,6 @@ func (o *Owner) stageMaterializationCacheResponse(proc *upstream.Process, method
 		stage.resourceList = cached
 	case "resources/templates/list":
 		stage.resourceTemplateList = cached
-	default:
-		o.materializationMu.Unlock()
-		return false
 	}
 	readyToCommit := stage.initResp != nil && stage.toolList != nil
 	if method == "initialize" {
@@ -839,10 +937,32 @@ func (o *Owner) commitMaterializationCache(a *materializationAttempt) {
 	stage := o.cacheStage
 	freshMode, freshSource, freshReason := stagedClassification(stage.initResp, stage.toolList)
 	persistent := classify.ParsePersistent(stage.initResp)
+	// Persistence is monotonic safety state. A failed generation's declaration,
+	// a configured requirement, or a prior committed generation cannot be
+	// downgraded by a later initialize response that omits the capability.
+	effectivePersistent := persistent || o.persistentPending || o.persistentRequired || o.materializationPolicy == MaterializationPersistent
 
 	o.mu.Lock()
+	if freshMode == classify.ModeIsolated && a.launch.SessionID == 0 {
+		if retained := o.oldestEligibleSessionLocked(); retained != nil {
+			retainedLaunch := o.launchContextForSessionLocked(retained)
+			a.launchRequiresSession = true
+			if launchContextsEqual(a.launch, retainedLaunch) {
+				a.launch = retainedLaunch
+			} else {
+				a.launch = retainedLaunch
+				a.launchFrozen = false
+				o.mu.Unlock()
+				o.admissionMu.Unlock()
+				o.materializationMu.Unlock()
+				stage.signals.signalFailure(errMaterializationContextReelected)
+				return
+			}
+		}
+	}
 	if freshMode == classify.ModeIsolated && a.launch.SessionID != 0 {
-		if _, initiatorPresent := o.sessions[a.launch.SessionID]; !initiatorPresent {
+		initiator, initiatorPresent := o.sessions[a.launch.SessionID]
+		if !initiatorPresent || initiator.IsClosed() {
 			o.mu.Unlock()
 			o.admissionMu.Unlock()
 			o.materializationMu.Unlock()
@@ -851,7 +971,7 @@ func (o *Owner) commitMaterializationCache(a *materializationAttempt) {
 		}
 	}
 	hadCachedLists := o.toolList != nil || o.promptList != nil || o.resourceList != nil || o.resourceTemplateList != nil
-	stagedSnapshot := o.stagedSnapshotLocked(a, stage, freshMode, freshSource, freshReason, persistent)
+	stagedSnapshot := o.stagedSnapshotLocked(a, stage, freshMode, freshSource, freshReason, effectivePersistent)
 	liveMode, liveSource := freshMode, freshSource
 	liveReason := append([]string(nil), freshReason...)
 	if o.autoClassification == classify.ModeIsolated && freshMode != classify.ModeIsolated {
@@ -889,10 +1009,8 @@ func (o *Owner) commitMaterializationCache(a *materializationAttempt) {
 	o.mu.Unlock()
 
 	o.persistentPending = false
-	if persistent || o.persistentRequired {
+	if effectivePersistent {
 		o.materializationPolicy = MaterializationPersistent
-	} else if o.materializationPolicy == MaterializationPersistent {
-		o.materializationPolicy = MaterializationOnDemand
 	}
 
 	var rejected []*localDemand
@@ -943,7 +1061,7 @@ func (o *Owner) commitMaterializationCache(a *materializationAttempt) {
 		}
 	})
 	if o.onPersistentResolved != nil {
-		o.onPersistentResolved(o, persistent)
+		o.onPersistentResolved(o, effectivePersistent)
 	}
 	o.parseDrainTimeout(stage.initResp)
 	o.parseToolTimeout(stage.initResp)
@@ -1002,25 +1120,49 @@ func (o *Owner) isolatedEvicteesLocked(mode classify.SharingMode, keepID int) []
 	}
 	primaryCwd := serverid.CanonicalizePath(o.cwd)
 	o.cwdSet = map[string]bool{primaryCwd: true}
-	o.sessionMgr.RemovePendingForOwnerExcept(o.serverID, o.initialAdmissionToken)
-	if len(o.sessions) <= 1 {
-		return nil
-	}
-	if _, ok := o.sessions[keepID]; !ok {
+
+	var keep *Session
+	if candidate, ok := o.sessions[keepID]; ok {
+		keep = candidate
+	} else {
 		keepID = -1
-		for id := range o.sessions {
-			if keepID == -1 || id < keepID {
+		for id, session := range o.sessions {
+			if keep == nil || id < keepID {
 				keepID = id
+				keep = session
 			}
 		}
 	}
+	if keep == nil {
+		o.sessionMgr.RemovePendingForOwnerExcept(o.serverID, o.initialAdmissionToken)
+	} else {
+		o.sessionMgr.RemovePendingForOwnerExceptSession(o.serverID, keep)
+		o.sessionMgr.RemoveBoundForOwnerExceptSession(o.serverID, keep)
+	}
+	if len(o.sessions) <= 1 {
+		return nil
+	}
+
 	evictees := make([]*Session, 0, len(o.sessions)-1)
-	for id, s := range o.sessions {
+	for id, session := range o.sessions {
 		if id != keepID {
-			evictees = append(evictees, s)
+			evictees = append(evictees, session)
 		}
 	}
 	return evictees
+}
+
+func (o *Owner) sessionEligibleForDemand(s *Session) bool {
+	if s == nil || s.IsClosed() {
+		return false
+	}
+	if o.authorizeSession != nil && !s.Meta().IsAuthorized() {
+		return false
+	}
+	o.mu.RLock()
+	attached := o.sessions[s.ID] == s
+	o.mu.RUnlock()
+	return attached
 }
 
 func (o *Owner) enqueueLocalDemand(s *Session, msg *jsonrpc.Message) (bool, error) {
@@ -1033,6 +1175,10 @@ func (o *Owner) enqueueLocalDemand(s *Session, msg *jsonrpc.Message) (bool, erro
 	candidate := o.launchContextForSession(s)
 
 	o.materializationMu.Lock()
+	if !o.sessionEligibleForDemand(s) {
+		o.materializationMu.Unlock()
+		return true, o.writeDemandError(s, msg.ID, "request no longer admitted before upstream materialization")
+	}
 	if o.materializationState == MaterializationReady && !o.upstreamDead.Load() {
 		o.materializationMu.Unlock()
 		return false, nil
@@ -1100,6 +1246,29 @@ func (o *Owner) cancelLocalDemand(s *Session, requestID json.RawMessage) bool {
 		o.beforeLocalDemandCancel()
 	}
 	o.materializationMu.Lock()
+	if demand := o.pendingDemands[key]; demand != nil && demand.state == localDemandForwarding {
+		forwardDone := demand.forwardDone
+		materializationDone := demand.materializationDone
+		o.materializationMu.Unlock()
+		if forwardDone != nil {
+			select {
+			case <-forwardDone:
+			case <-o.materializationStop:
+				return true
+			}
+		}
+		if !demand.upstreamForwarded {
+			return true
+		}
+		if materializationDone != nil {
+			select {
+			case <-materializationDone:
+			case <-o.materializationStop:
+				return true
+			}
+		}
+		return false
+	}
 	demand, ok := o.transitionLocalDemandLocked(key, localDemandCancelled)
 	if ok && o.materializationAttempt != nil && !o.materializationAttempt.launchFrozen && demand.session.ID == o.materializationAttempt.launch.SessionID {
 		o.materializationAttempt.launch = o.electLaunchContextLocked()
@@ -1192,12 +1361,9 @@ func (o *Owner) forwardQueuedDemand(key string, generation uint64, launch Launch
 		return
 	}
 
-	o.mu.RLock()
-	attached := o.sessions[demand.session.ID] == demand.session
-	o.mu.RUnlock()
-	authorized := o.authorizeSession == nil || demand.session.Meta().IsAuthorized()
+	eligible := o.sessionEligibleForDemand(demand.session)
 	compatible := o.launchContextCompatible(launch, o.launchContextForSession(demand.session))
-	if !attached || !authorized || !compatible {
+	if !eligible || !compatible {
 		demand.state = localDemandRejected
 		delete(o.pendingDemands, key)
 		if demand.timer != nil {
@@ -1209,14 +1375,22 @@ func (o *Owner) forwardQueuedDemand(key string, generation uint64, launch Launch
 	}
 
 	demand.state = localDemandForwarding
-	delete(o.pendingDemands, key)
+	demand.forwardDone = make(chan struct{})
+	if a := o.materializationAttempt; a != nil && a.generation == generation {
+		demand.materializationDone = a.done
+	}
 	if demand.timer != nil {
 		demand.timer.Stop()
 	}
-	if cached := o.getCachedResponse(demand.message.Method); cached != nil &&
-		(demand.message.Method != "initialize" || o.initFingerprintMatches(demand.message.Raw)) {
+	cached := o.getCachedResponse(demand.message.Method)
+	if demand.message.Method == "initialize" && !o.initFingerprintMatches(demand.message.Raw) {
+		cached = nil
+	}
+	o.materializationMu.Unlock()
+
+	if cached != nil {
 		err := o.replayFromCache(demand.session, demand.message, cached)
-		o.materializationMu.Unlock()
+		o.completeForwardingLocalDemand(key, demand, false)
 		if err != nil {
 			_ = o.writeDemandError(demand.session, demand.message.ID, err.Error())
 		}
@@ -1226,14 +1400,30 @@ func (o *Owner) forwardQueuedDemand(key string, generation uint64, launch Launch
 	if o.beforeQueuedDemandWrite != nil {
 		o.beforeQueuedDemandWrite()
 	}
-	writeFailed, err := o.forwardRequestPrepared(demand.session, demand.message)
-	o.materializationMu.Unlock()
+	usedProc, writeFailed, err := o.forwardRequestPrepared(demand.session, demand.message)
+	o.completeForwardingLocalDemand(key, demand, err == nil && !writeFailed)
 	if err != nil {
 		o.logger.Printf("session %d: queued demand forwarding failed: %v", demand.session.ID, err)
 	}
 	if writeFailed {
-		o.startMaterialization(MaterializationTriggerWriteError)
+		if usedProc != nil {
+			o.retireReadyProcess(usedProc, MaterializationTriggerWriteError)
+		} else {
+			o.startMaterialization(MaterializationTriggerWriteError)
+		}
 	}
+}
+
+func (o *Owner) completeForwardingLocalDemand(key string, demand *localDemand, upstreamForwarded bool) {
+	o.materializationMu.Lock()
+	if current := o.pendingDemands[key]; current == demand && demand.state == localDemandForwarding {
+		demand.upstreamForwarded = upstreamForwarded
+		delete(o.pendingDemands, key)
+		if demand.forwardDone != nil {
+			close(demand.forwardDone)
+		}
+	}
+	o.materializationMu.Unlock()
 }
 
 func (o *Owner) transitionLocalDemandLocked(key string, terminal localDemandState) (*localDemand, bool) {
@@ -1258,20 +1448,24 @@ func (o *Owner) writeDemandError(s *Session, id json.RawMessage, message string)
 }
 
 func (o *Owner) forwardRequestNow(s *Session, msg *jsonrpc.Message) error {
-	writeFailed, err := o.forwardRequestPrepared(s, msg)
+	failedProc, writeFailed, err := o.forwardRequestPrepared(s, msg)
 	if writeFailed {
-		o.startMaterialization(MaterializationTriggerWriteError)
+		if failedProc != nil {
+			o.retireReadyProcess(failedProc, MaterializationTriggerWriteError)
+		} else {
+			o.startMaterialization(MaterializationTriggerWriteError)
+		}
 	}
 	return err
 }
 
-func (o *Owner) forwardRequestPrepared(s *Session, msg *jsonrpc.Message) (bool, error) {
+func (o *Owner) forwardRequestPrepared(s *Session, msg *jsonrpc.Message) (*upstream.Process, bool, error) {
 	o.pendingRequests.Add(1)
 	newID := remap.Remap(s.ID, msg.ID)
 	remapped, err := jsonrpc.ReplaceID(msg.Raw, newID)
 	if err != nil {
 		o.decrementPending()
-		return false, fmt.Errorf("remap request: %w", err)
+		return nil, false, fmt.Errorf("remap request: %w", err)
 	}
 
 	o.inflightTracker.Store(string(newID), &InflightRequest{
@@ -1319,13 +1513,19 @@ func (o *Owner) forwardRequestPrepared(s *Session, msg *jsonrpc.Message) (bool, 
 	if msg.Method == "tools/call" && o.toolTimeoutNs.Load() > 0 {
 		o.startToolWatchdog(string(newID), msg.ID, s, msg.Method)
 	}
-	if err := o.writeUpstream(remapped); err != nil {
-		o.logger.Printf("session %d: upstream write failed for request id=%s: %v", s.ID, string(newID), err)
-		o.upstreamDead.Store(true)
-		o.drainInflightRequests()
-		return true, nil
+	usedProc, writeErr := o.writeUpstreamFromCurrent(remapped)
+	if writeErr != nil {
+		o.logger.Printf("session %d: upstream write failed for request id=%s: %v", s.ID, string(newID), writeErr)
+		if _, loaded := o.inflightTracker.LoadAndDelete(string(newID)); loaded {
+			o.methodTags.Delete(string(newID))
+			o.sessionMgr.CompleteRequest(string(newID))
+			o.clearProgressTokensForRequest(string(newID))
+			o.decrementPending()
+		}
+		_ = o.writeDemandError(s, msg.ID, "upstream write failed")
+		return usedProc, true, nil
 	}
-	return false, nil
+	return usedProc, false, nil
 }
 
 func (o *Owner) ensureUpstreamReadyForRequest() error {
@@ -1390,9 +1590,54 @@ func (o *Owner) monitorMaterializedProcessExit(proc *upstream.Process) {
 	o.upstreamEventMu.Lock()
 	o.materializationMu.Lock()
 	if o.retiringProcess == proc {
+		blocked := o.materializationState == MaterializationFinalizeBlocked
+		managedByAttempt := o.materializationAttempt != nil && o.materializationAttempt.process == proc
+		trigger := o.materializationTrigger
 		o.materializationMu.Unlock()
 		o.upstreamEventMu.Unlock()
-		o.handleRetiringProcessExit(proc)
+		if blocked && !managedByAttempt && !o.completeRetiringProcess(proc, trigger) {
+			o.startRetiringProcessRetry(proc, trigger)
+		}
+		return
+	}
+	o.mu.Lock()
+	if o.upstream != proc {
+		o.mu.Unlock()
+		o.materializationMu.Unlock()
+		o.upstreamEventMu.Unlock()
+		return
+	}
+	if a := o.materializationAttempt; a != nil && a.process == proc {
+		o.upstreamDead.Store(true)
+		signals := a.signals
+		o.mu.Unlock()
+		responses := o.claimInflightRequests()
+		o.materializationMu.Unlock()
+		o.upstreamEventMu.Unlock()
+		o.deliverInflightResponses(responses)
+		signals.signalFailure(fmt.Errorf("upstream exited before materialization completed: %v", proc.ExitErr))
+		return
+	}
+	o.mu.Unlock()
+	o.materializationMu.Unlock()
+	o.upstreamEventMu.Unlock()
+
+	o.retireReadyProcess(proc, MaterializationTriggerUpstreamExit)
+}
+
+// retireReadyProcess moves one exact installed generation through FINALIZING.
+// The generation remains authoritative until both process exit and process-tree
+// authority retirement are proven; only then may the controller materialize a
+// replacement generation.
+func (o *Owner) retireReadyProcess(proc *upstream.Process, trigger MaterializationTrigger) {
+	if proc == nil {
+		return
+	}
+	o.upstreamEventMu.Lock()
+	o.materializationMu.Lock()
+	if o.retiringProcess == proc {
+		o.materializationMu.Unlock()
+		o.upstreamEventMu.Unlock()
 		return
 	}
 	o.mu.Lock()
@@ -1403,51 +1648,21 @@ func (o *Owner) monitorMaterializedProcessExit(proc *upstream.Process) {
 		return
 	}
 	o.upstreamDead.Store(true)
-	if a := o.materializationAttempt; a != nil && a.process == proc {
-		signals := a.signals
-		o.mu.Unlock()
-		responses := o.claimInflightRequests()
-		o.materializationMu.Unlock()
-		o.upstreamEventMu.Unlock()
-		o.deliverInflightResponses(responses)
-		signals.signalFailure(fmt.Errorf("upstream exited before materialization completed: %v", proc.ExitErr))
-		return
-	}
-	o.upstream = nil
 	o.mu.Unlock()
-	o.materializationState = MaterializationCacheOnly
+	o.retiringProcess = proc
+	o.materializationState = MaterializationFinalizing
+	o.materializationTrigger = trigger
 	responses := o.claimInflightRequests()
 	o.materializationMu.Unlock()
 	o.upstreamEventMu.Unlock()
 	o.deliverInflightResponses(responses)
 
-	if o.shouldRetryMaterialization(MaterializationTriggerUpstreamExit) {
-		o.startMaterialization(MaterializationTriggerUpstreamExit)
-		return
-	}
-	if !o.hasUsableCache() {
-		o.notifyUpstreamExit()
+	if !o.completeRetiringProcess(proc, trigger) {
+		o.startRetiringProcessRetry(proc, trigger)
 	}
 }
 
-func (o *Owner) handleRetiringProcessExit(proc *upstream.Process) bool {
-	o.upstreamEventMu.Lock()
-	o.materializationMu.Lock()
-	if o.retiringProcess != proc {
-		o.materializationMu.Unlock()
-		o.upstreamEventMu.Unlock()
-		return false
-	}
-	if o.materializationState != MaterializationFinalizeBlocked || !errors.Is(o.materializationBlockedErr, errFinalizationUnproven) {
-		o.materializationMu.Unlock()
-		o.upstreamEventMu.Unlock()
-		return true
-	}
-	o.materializationMu.Unlock()
-	o.upstreamEventMu.Unlock()
-
-	// Process finalization may block; generation writers already see this proc
-	// as retiring, so no lease is held across Close.
+func (o *Owner) completeRetiringProcess(proc *upstream.Process, trigger MaterializationTrigger) bool {
 	closeErr := proc.Close()
 	proofErr := error(nil)
 	proven := proc.RetirementProven()
@@ -1465,11 +1680,12 @@ func (o *Owner) handleRetiringProcessExit(proc *upstream.Process) bool {
 		o.upstreamEventMu.Lock()
 		o.materializationMu.Lock()
 		if o.retiringProcess == proc {
+			o.materializationState = MaterializationFinalizeBlocked
 			o.materializationBlockedErr = proofErr
 		}
 		o.materializationMu.Unlock()
 		o.upstreamEventMu.Unlock()
-		return true
+		return false
 	}
 	if closeErr != nil {
 		o.logger.Printf("retiring process finalized after warning: %v", closeErr)
@@ -1499,12 +1715,41 @@ func (o *Owner) handleRetiringProcessExit(proc *upstream.Process) bool {
 	o.upstreamEventMu.Unlock()
 	o.deliverInflightResponses(responses)
 	o.clearProactiveTracking()
-	if o.shouldRetryMaterialization(MaterializationTriggerUpstreamExit) {
-		o.startMaterialization(MaterializationTriggerUpstreamExit)
+	o.retirementRetryProcess.CompareAndSwap(proc, nil)
+	if o.shouldRetryMaterialization(trigger) {
+		o.startMaterialization(trigger)
 	} else if !o.hasUsableCache() {
 		o.notifyUpstreamExit()
 	}
 	return true
+}
+
+func (o *Owner) startRetiringProcessRetry(proc *upstream.Process, trigger MaterializationTrigger) {
+	if !o.retirementRetryProcess.CompareAndSwap(nil, proc) {
+		return
+	}
+	go func() {
+		defer o.retirementRetryProcess.CompareAndSwap(proc, nil)
+		wait := materializationRetryInitial
+		for {
+			timer := time.NewTimer(wait)
+			select {
+			case <-timer.C:
+			case <-o.materializationStop:
+				if !timer.Stop() {
+					select {
+					case <-timer.C:
+					default:
+					}
+				}
+				return
+			}
+			if o.completeRetiringProcess(proc, trigger) {
+				return
+			}
+			wait = nextMaterializationRetry(wait)
+		}
+	}()
 }
 
 // RestartPin freezes new materialization generations while restart state is
@@ -1728,10 +1973,8 @@ func (o *Owner) PersistentPending() bool {
 func (o *Owner) ResolvePersistent(persistent bool) {
 	o.materializationMu.Lock()
 	o.persistentPending = false
-	if persistent || o.persistentRequired {
+	if persistent || o.persistentRequired || o.materializationPolicy == MaterializationPersistent {
 		o.materializationPolicy = MaterializationPersistent
-	} else if o.materializationPolicy == MaterializationPersistent {
-		o.materializationPolicy = MaterializationOnDemand
 	}
 	o.materializationMu.Unlock()
 }

--- a/muxcore/owner/materialization.go
+++ b/muxcore/owner/materialization.go
@@ -587,16 +587,19 @@ func (o *Owner) materializationStillNeeded(trigger MaterializationTrigger) bool 
 }
 
 func (o *Owner) shouldRetryMaterialization(trigger MaterializationTrigger) bool {
+	o.materializationMu.Lock()
+	retry := o.shouldRetryMaterializationLocked(trigger)
+	o.materializationMu.Unlock()
+	return retry
+}
+
+func (o *Owner) shouldRetryMaterializationLocked(trigger MaterializationTrigger) bool {
 	select {
 	case <-o.materializationStop:
 		return false
 	default:
 	}
-	o.materializationMu.Lock()
-	pending := len(o.pendingDemands)
-	persistenceObligation := o.materializationPolicy == MaterializationPersistent || o.persistentPending
-	o.materializationMu.Unlock()
-	if persistenceObligation || pending > 0 {
+	if o.materializationPolicy == MaterializationPersistent || o.persistentPending || len(o.pendingDemands) > 0 {
 		return true
 	}
 	return (trigger == MaterializationTriggerUpstreamExit || trigger == MaterializationTriggerWriteError) && o.SessionCount() > 0
@@ -1255,7 +1258,9 @@ func (o *Owner) enqueueLocalDemand(s *Session, msg *jsonrpc.Message) (bool, erro
 		o.materializationMu.Unlock()
 		return true, o.writeDemandError(s, msg.ID, "duplicate request id while upstream materializes")
 	}
-	if active := o.materializationAttempt; active != nil && !o.launchContextCompatible(active.launch, candidate) {
+	active := o.materializationAttempt
+	postAttemptRecovery := o.materializationState == MaterializationCacheOnly && active != nil
+	if active != nil && !postAttemptRecovery && !o.launchContextCompatible(active.launch, candidate) {
 		o.materializationMu.Unlock()
 		return true, o.writeDemandError(s, msg.ID, "request context incompatible with active upstream materialization")
 	}
@@ -1266,7 +1271,7 @@ func (o *Owner) enqueueLocalDemand(s *Session, msg *jsonrpc.Message) (bool, erro
 	demand.timer = time.AfterFunc(materializationDemandTimeout, func() {
 		o.expireLocalDemand(key)
 	})
-	if o.materializationState == MaterializationFinalizing || o.retiringProcess != nil || o.upstreamDead.Load() && o.currentUpstream() != nil {
+	if postAttemptRecovery || o.materializationState == MaterializationFinalizing || o.retiringProcess != nil || o.upstreamDead.Load() && o.currentUpstream() != nil {
 		o.materializationMu.Unlock()
 		return true, nil
 	}
@@ -1764,6 +1769,11 @@ func (o *Owner) completeRetiringProcess(proc *upstream.Process, trigger Material
 	o.mu.Unlock()
 	o.retiringProcess = nil
 	o.materializationBlockedErr = nil
+	retry := o.shouldRetryMaterializationLocked(trigger)
+	settlingAttempt := retry && o.materializationAttempt != nil
+	if settlingAttempt && o.restartResumeTrigger == "" {
+		o.restartResumeTrigger = trigger
+	}
 	o.materializationState = MaterializationCacheOnly
 	if o.cacheStage != nil && o.cacheStage.process == proc {
 		o.cacheStage = nil
@@ -1774,9 +1784,9 @@ func (o *Owner) completeRetiringProcess(proc *upstream.Process, trigger Material
 	o.deliverInflightResponses(responses)
 	o.clearProactiveTracking()
 	o.retirementRetryProcess.CompareAndSwap(proc, nil)
-	if o.shouldRetryMaterialization(trigger) {
+	if retry && !settlingAttempt {
 		o.startMaterialization(trigger)
-	} else if !o.hasUsableCache() {
+	} else if !retry && !o.hasUsableCache() {
 		o.notifyUpstreamExit()
 	}
 	return true

--- a/muxcore/owner/materialization.go
+++ b/muxcore/owner/materialization.go
@@ -207,15 +207,14 @@ const (
 )
 
 type localDemand struct {
-	key                 string
-	session             *Session
-	message             *jsonrpc.Message
-	timer               *time.Timer
-	state               localDemandState
-	generation          uint64
-	forwardDone         chan struct{}
-	materializationDone <-chan struct{}
-	upstreamForwarded   bool
+	key               string
+	session           *Session
+	message           *jsonrpc.Message
+	timer             *time.Timer
+	state             localDemandState
+	generation        uint64
+	forwardDone       chan struct{}
+	upstreamForwarded bool
 }
 
 type cacheStage struct {
@@ -258,7 +257,9 @@ func (o *Owner) startMaterializationLocked(trigger MaterializationTrigger) (*mat
 		return completedMaterializationAttempt(errors.New("owner shutting down")), false
 	default:
 	}
-	if o.materializationState == MaterializationFinalizeBlocked {
+	if o.materializationState == MaterializationFinalizing ||
+		o.materializationState == MaterializationFinalizeBlocked ||
+		o.retiringProcess != nil {
 		err := o.materializationBlockedErr
 		if err == nil {
 			err = errFinalizationUnproven
@@ -271,10 +272,18 @@ func (o *Owner) startMaterializationLocked(trigger MaterializationTrigger) (*mat
 	if o.materializationState == MaterializationReady && !o.upstreamDead.Load() {
 		return completedMaterializationAttempt(nil), false
 	}
+	if o.upstreamDead.Load() && o.currentUpstream() != nil {
+		return completedMaterializationAttempt(errFinalizationUnproven), false
+	}
 
 	o.materializationGeneration++
 	a := newMaterializationAttempt(o.materializationGeneration, trigger)
 	a.launch = o.electLaunchContextLocked()
+	for _, demand := range o.pendingDemands {
+		if demand.state == localDemandWaiting && demand.generation == 0 {
+			demand.generation = a.generation
+		}
+	}
 	o.materializationAttempt = a
 	o.materializationState = MaterializationMaterializing
 	o.materializationTrigger = trigger
@@ -669,7 +678,7 @@ func (o *Owner) retireMaterializationProcess(a *materializationAttempt, proc *up
 		if closeErr != nil {
 			finalizationErr = errors.Join(finalizationErr, closeErr)
 		}
-		return o.blockMaterializationFinalization(a, finalizationErr)
+		return o.blockMaterializationFinalization(a, proc, finalizationErr)
 	}
 
 	o.upstreamEventMu.Lock()
@@ -695,7 +704,7 @@ func (o *Owner) retireMaterializationProcess(a *materializationAttempt, proc *up
 	return nil
 }
 
-func (o *Owner) blockMaterializationFinalization(a *materializationAttempt, err error) error {
+func (o *Owner) blockMaterializationFinalization(a *materializationAttempt, proc *upstream.Process, err error) error {
 	o.upstreamEventMu.Lock()
 	o.materializationMu.Lock()
 	blocked := o.materializationAttempt == a
@@ -705,8 +714,8 @@ func (o *Owner) blockMaterializationFinalization(a *materializationAttempt, err 
 	}
 	o.materializationMu.Unlock()
 	o.upstreamEventMu.Unlock()
-	if blocked && a.process != nil {
-		o.startRetiringProcessRetry(a.process, a.trigger)
+	if blocked && proc != nil {
+		o.startRetiringProcessRetry(proc, a.trigger)
 	}
 	return err
 }
@@ -722,6 +731,31 @@ func (o *Owner) finishMaterializationSuccess(a *materializationAttempt) {
 		order := append([]string(nil), o.pendingDemandOrder...)
 		o.pendingDemandOrder = nil
 		if len(order) == 0 && len(o.pendingDemands) == 0 {
+			state := o.materializationState
+			retiring := o.retiringProcess
+			readyErr := o.materializationBlockedErr
+			retryTrigger := o.materializationTrigger
+			o.mu.RLock()
+			current := o.upstream
+			o.mu.RUnlock()
+			live := state == MaterializationMaterializing && retiring == nil && current == a.process && !o.upstreamDead.Load()
+			if !live {
+				if readyErr == nil {
+					readyErr = errors.New("materialization generation lost process authority before ready")
+				}
+				if retryTrigger == "" {
+					retryTrigger = MaterializationTriggerUpstreamExit
+				}
+				o.materializationMu.Unlock()
+				if a.process != nil {
+					o.retireReadyProcess(a.process, retryTrigger)
+				}
+				o.finishMaterializationFailure(a, readyErr)
+				if o.shouldRetryMaterialization(retryTrigger) {
+					o.startMaterialization(retryTrigger)
+				}
+				return
+			}
 			o.materializationAttempt = nil
 			o.materializationState = MaterializationReady
 			o.materializationTrigger = a.trigger
@@ -747,7 +781,11 @@ func (o *Owner) finishMaterializationFailure(a *materializationAttempt, err erro
 	if o.materializationAttempt == a {
 		o.materializationAttempt = nil
 		if o.materializationState != MaterializationFinalizeBlocked {
-			o.materializationState = MaterializationCacheOnly
+			if o.retiringProcess != nil || o.materializationState == MaterializationFinalizing {
+				o.materializationState = MaterializationFinalizing
+			} else {
+				o.materializationState = MaterializationCacheOnly
+			}
 		}
 		o.cacheStage = nil
 	}
@@ -1228,6 +1266,10 @@ func (o *Owner) enqueueLocalDemand(s *Session, msg *jsonrpc.Message) (bool, erro
 	demand.timer = time.AfterFunc(materializationDemandTimeout, func() {
 		o.expireLocalDemand(key)
 	})
+	if o.materializationState == MaterializationFinalizing || o.retiringProcess != nil || o.upstreamDead.Load() && o.currentUpstream() != nil {
+		o.materializationMu.Unlock()
+		return true, nil
+	}
 	a, start := o.startMaterializationLocked(MaterializationTriggerDemand)
 	if a.generation == 0 {
 		delete(o.pendingDemands, key)
@@ -1266,7 +1308,6 @@ func (o *Owner) cancelLocalDemand(s *Session, requestID json.RawMessage) bool {
 	o.materializationMu.Lock()
 	if demand := o.pendingDemands[key]; demand != nil && demand.state == localDemandForwarding {
 		forwardDone := demand.forwardDone
-		materializationDone := demand.materializationDone
 		o.materializationMu.Unlock()
 		if forwardDone != nil {
 			select {
@@ -1275,17 +1316,7 @@ func (o *Owner) cancelLocalDemand(s *Session, requestID json.RawMessage) bool {
 				return true
 			}
 		}
-		if !demand.upstreamForwarded {
-			return true
-		}
-		if materializationDone != nil {
-			select {
-			case <-materializationDone:
-			case <-o.materializationStop:
-				return true
-			}
-		}
-		return false
+		return !demand.upstreamForwarded
 	}
 	demand, ok := o.transitionLocalDemandLocked(key, localDemandCancelled)
 	if ok && o.materializationAttempt != nil && !o.materializationAttempt.launchFrozen && demand.session.ID == o.materializationAttempt.launch.SessionID {
@@ -1394,9 +1425,6 @@ func (o *Owner) forwardQueuedDemand(key string, generation uint64, launch Launch
 
 	demand.state = localDemandForwarding
 	demand.forwardDone = make(chan struct{})
-	if a := o.materializationAttempt; a != nil && a.generation == generation {
-		demand.materializationDone = a.done
-	}
 	if demand.timer != nil {
 		demand.timer.Stop()
 	}
@@ -1628,12 +1656,21 @@ func (o *Owner) monitorMaterializedProcessExit(proc *upstream.Process) {
 	if a := o.materializationAttempt; a != nil && a.process == proc {
 		o.upstreamDead.Store(true)
 		signals := a.signals
+		discoveryCommitted := false
+		select {
+		case <-signals.discoveryReady:
+			discoveryCommitted = true
+		default:
+		}
 		o.mu.Unlock()
 		responses := o.claimInflightRequests()
 		o.materializationMu.Unlock()
 		o.upstreamEventMu.Unlock()
 		o.deliverInflightResponses(responses)
 		signals.signalFailure(fmt.Errorf("upstream exited before materialization completed: %v", proc.ExitErr))
+		if discoveryCommitted {
+			o.retireReadyProcess(proc, MaterializationTriggerUpstreamExit)
+		}
 		return
 	}
 	o.mu.Unlock()
@@ -1689,6 +1726,7 @@ func (o *Owner) completeRetiringProcess(proc *upstream.Process, trigger Material
 		proven = proofErr == nil
 	}
 	if !proven {
+		var demands []*localDemand
 		if proofErr == nil {
 			proofErr = errFinalizationUnproven
 		}
@@ -1700,9 +1738,11 @@ func (o *Owner) completeRetiringProcess(proc *upstream.Process, trigger Material
 		if o.retiringProcess == proc {
 			o.materializationState = MaterializationFinalizeBlocked
 			o.materializationBlockedErr = proofErr
+			demands = o.detachLocalDemandsForGenerationLocked(0)
 		}
 		o.materializationMu.Unlock()
 		o.upstreamEventMu.Unlock()
+		o.writeFailedLocalDemands(demands, proofErr)
 		return false
 	}
 	if closeErr != nil {
@@ -1901,9 +1941,10 @@ func (o *Owner) AcquireRestartPin(ctx context.Context) (*RestartPin, error) {
 
 	o.materializationMu.Lock()
 	state := o.materializationState
+	retiring := o.retiringProcess != nil
 	blockedErr := o.materializationBlockedErr
 	o.materializationMu.Unlock()
-	if state == MaterializationFinalizeBlocked {
+	if state == MaterializationFinalizing || state == MaterializationFinalizeBlocked || retiring {
 		if blockedErr == nil {
 			blockedErr = errFinalizationUnproven
 		}
@@ -1936,9 +1977,10 @@ func (o *Owner) quiesceMaterializationForHandoff() error {
 	o.stopMaterialization()
 	o.materializationMu.Lock()
 	state := o.materializationState
+	retiring := o.retiringProcess != nil
 	blockedErr := o.materializationBlockedErr
 	o.materializationMu.Unlock()
-	if state == MaterializationFinalizeBlocked {
+	if state == MaterializationFinalizing || state == MaterializationFinalizeBlocked || retiring {
 		if blockedErr == nil {
 			blockedErr = errFinalizationUnproven
 		}

--- a/muxcore/owner/materialization.go
+++ b/muxcore/owner/materialization.go
@@ -1453,6 +1453,9 @@ func (o *Owner) forwardQueuedDemand(key string, generation uint64, launch Launch
 	}
 	usedProc, writeFailed, err := o.forwardRequestPrepared(demand.session, demand.message)
 	o.completeForwardingLocalDemand(key, demand, err == nil && !writeFailed)
+	if o.afterQueuedDemandWrite != nil {
+		o.afterQueuedDemandWrite()
+	}
 	if err != nil {
 		o.logger.Printf("session %d: queued demand forwarding failed: %v", demand.session.ID, err)
 	}
@@ -1519,12 +1522,13 @@ func (o *Owner) forwardRequestPrepared(s *Session, msg *jsonrpc.Message) (*upstr
 		return nil, false, fmt.Errorf("remap request: %w", err)
 	}
 
-	o.inflightTracker.Store(string(newID), &InflightRequest{
+	inflight := &InflightRequest{
 		Method:    msg.Method,
 		Tool:      extractToolName(msg.Raw),
 		SessionID: s.ID,
 		StartTime: time.Now(),
-	})
+	}
+	o.inflightTracker.Store(string(newID), inflight)
 	if msg.Method == "initialize" || msg.Method == "tools/list" ||
 		msg.Method == "prompts/list" || msg.Method == "resources/list" ||
 		msg.Method == "resources/templates/list" {
@@ -1564,7 +1568,7 @@ func (o *Owner) forwardRequestPrepared(s *Session, msg *jsonrpc.Message) (*upstr
 	if msg.Method == "tools/call" && o.toolTimeoutNs.Load() > 0 {
 		o.startToolWatchdog(string(newID), msg.ID, s, msg.Method)
 	}
-	usedProc, writeErr := o.writeUpstreamFromCurrent(remapped)
+	usedProc, writeErr := o.writeUpstreamFromCurrent(remapped, inflight.process.Store)
 	if writeErr != nil {
 		o.logger.Printf("session %d: upstream write failed for request id=%s: %v", s.ID, string(newID), writeErr)
 		if _, loaded := o.inflightTracker.LoadAndDelete(string(newID)); loaded {

--- a/muxcore/owner/materialization.go
+++ b/muxcore/owner/materialization.go
@@ -246,6 +246,11 @@ func (o *Owner) startMaterializationLocked(trigger MaterializationTrigger) (*mat
 		return completedMaterializationAttempt(nil), false
 	}
 	if o.restartPins.Load() > 0 {
+		if o.restartResumeTrigger == "" &&
+			(trigger == MaterializationTriggerUpstreamExit || trigger == MaterializationTriggerWriteError) &&
+			o.SessionCount() > 0 {
+			o.restartResumeTrigger = trigger
+		}
 		return completedMaterializationAttempt(errors.New("restart snapshot in progress")), false
 	}
 	select {
@@ -444,6 +449,14 @@ func (o *Owner) runMaterialization(a *materializationAttempt) {
 		o.launchContextMu.Unlock()
 		if err != nil {
 			o.logger.Printf("upstream materialization start failed generation=%d attempt=%d trigger=%s err=%v", a.generation, attemptNumber, a.trigger, err)
+			if proc != nil {
+				if retireErr := o.retireFailedMaterializationStart(a, proc); retireErr != nil {
+					err = errors.Join(err, retireErr)
+					a.signalStarted(err)
+					o.finishMaterializationFailure(a, err)
+					return
+				}
+			}
 			o.materializationMu.Lock()
 			if o.materializationAttempt == a {
 				a.launchFrozen = false
@@ -607,6 +620,11 @@ func (o *Owner) installMaterializationProcess(a *materializationAttempt, proc *u
 	o.materializationMu.Unlock()
 	o.upstreamEventMu.Unlock()
 	return signals
+}
+
+func (o *Owner) retireFailedMaterializationStart(a *materializationAttempt, proc *upstream.Process) error {
+	o.installMaterializationProcess(a, proc)
+	return o.retireMaterializationProcess(a, proc)
 }
 
 func (o *Owner) retireMaterializationProcess(a *materializationAttempt, proc *upstream.Process) error {
@@ -1876,6 +1894,9 @@ func (o *Owner) AcquireRestartPin(ctx context.Context) (*RestartPin, error) {
 				return nil, errors.New("restart materialization cancellation: owner shutting down")
 			}
 		}
+	}
+	if a != nil && a.err == nil {
+		launch = nil
 	}
 
 	o.materializationMu.Lock()

--- a/muxcore/owner/materialization_controller_test.go
+++ b/muxcore/owner/materialization_controller_test.go
@@ -194,9 +194,9 @@ func TestConcurrentUncachedDemandsShareOneMaterialization(t *testing.T) {
 	if got := starts.Load(); got != 1 {
 		t.Fatalf("upstream starts = %d, want exactly 1", got)
 	}
-	if state := o.MaterializationState(); state != MaterializationReady {
-		t.Fatalf("materialization state = %s, want ready", state)
-	}
+	waitForCondition(t, time.Second, func() bool {
+		return o.MaterializationState() == MaterializationReady
+	}, "shared materialization did not reach ready state")
 }
 
 func TestCancellationRacingForwardingWritesRequestBeforeUpstreamCancel(t *testing.T) {
@@ -294,6 +294,72 @@ func TestCancellationRacingForwardingWritesRequestBeforeUpstreamCancel(t *testin
 		t.Fatalf("upstream order=%v, want request then cancellation", gotOrder)
 	}
 	waitForCondition(t, time.Second, func() bool { return o.Status()["pending_requests"] == int64(0) }, "forwarded request left pending residue")
+}
+
+func TestCancellationAfterForwardingDoesNotWaitForGeneration(t *testing.T) {
+	o := newMinimalOwner()
+	var upstream bytes.Buffer
+	o.upstreamWriter = &upstream
+	s := NewSession(strings.NewReader(""), io.Discard)
+	o.admissionMu.Lock()
+	o.addSessionLocked(s)
+	o.admissionMu.Unlock()
+	defer s.Close()
+
+	msg, err := jsonrpc.Parse([]byte(`{"jsonrpc":"2.0","id":41,"method":"custom/forwarded","params":{}}`))
+	if err != nil {
+		t.Fatalf("parse request: %v", err)
+	}
+	key := string(remap.Remap(s.ID, msg.ID))
+	launch := o.launchContextForSession(s)
+	a := newMaterializationAttempt(1, MaterializationTriggerDemand)
+	a.launch = launch
+	o.materializationMu.Lock()
+	o.materializationAttempt = a
+	o.materializationState = MaterializationMaterializing
+	o.pendingDemands[key] = &localDemand{key: key, session: s, message: msg, state: localDemandWaiting, generation: a.generation}
+	o.materializationMu.Unlock()
+
+	writeEntered := make(chan struct{})
+	releaseWrite := make(chan struct{})
+	var writeOnce sync.Once
+	o.beforeQueuedDemandWrite = func() {
+		writeOnce.Do(func() { close(writeEntered) })
+		<-releaseWrite
+	}
+	forwardDone := make(chan struct{})
+	go func() {
+		o.forwardQueuedDemand(key, a.generation, launch)
+		close(forwardDone)
+	}()
+	select {
+	case <-writeEntered:
+	case <-time.After(time.Second):
+		t.Fatal("queued demand did not reach forwarding boundary")
+	}
+
+	cancelResult := make(chan bool, 1)
+	go func() { cancelResult <- o.cancelLocalDemand(s, msg.ID) }()
+	close(releaseWrite)
+	select {
+	case local := <-cancelResult:
+		if local {
+			t.Fatal("forwarded request cancellation was consumed locally")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("forwarded request cancellation waited for generation completion")
+	}
+	select {
+	case <-a.done:
+		t.Fatal("test generation completed before cancellation result")
+	default:
+	}
+	a.finish(nil)
+	select {
+	case <-forwardDone:
+	case <-time.After(time.Second):
+		t.Fatal("queued demand forwarding did not complete")
+	}
 }
 
 func TestUnauthorizedWaiterRejectedAfterMaterialization(t *testing.T) {
@@ -527,9 +593,9 @@ func TestTimedOutDemandNeverForwardsWhileLaterWaiterContinues(t *testing.T) {
 	if got := forwardedTwo.Load(); got != 1 {
 		t.Fatalf("later demand forwarded %d times, want 1", got)
 	}
-	if status := o.Status(); status["pending_demand_count"] != 0 {
-		t.Fatalf("pending demand residue: %#v", status)
-	}
+	waitForCondition(t, time.Second, func() bool {
+		return o.Status()["pending_demand_count"] == 0
+	}, "forwarded demand remained pending after response delivery")
 }
 
 func TestMaterializationDiagnosticsDoNotExposeRawEnvValues(t *testing.T) {
@@ -1012,6 +1078,139 @@ func TestRestartPinDefersLiveRecoveryUntilFinalRelease(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 	if got := starts.Load(); got != 1 {
 		t.Fatalf("deferred recovery started %d generations, want exactly 1", got)
+	}
+}
+
+func TestRestartAndHandoffRejectActiveFinalization(t *testing.T) {
+	newFinalizingOwner := func() *Owner {
+		o := newMinimalOwner()
+		proc := &upstream.Process{Done: make(chan struct{})}
+		o.mu.Lock()
+		o.upstream = proc
+		o.mu.Unlock()
+		o.materializationMu.Lock()
+		o.materializationState = MaterializationFinalizing
+		o.retiringProcess = proc
+		o.materializationMu.Unlock()
+		return o
+	}
+
+	t.Run("restart pin", func(t *testing.T) {
+		o := newFinalizingOwner()
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		if pin, err := o.AcquireRestartPin(ctx); err == nil || pin != nil || !errors.Is(err, errFinalizationUnproven) {
+			t.Fatalf("restart pin during finalization = pin=%v err=%v", pin, err)
+		}
+		if pins := o.restartPins.Load(); pins != 0 {
+			t.Fatalf("failed restart pin leaked %d pins", pins)
+		}
+	})
+
+	t.Run("handoff quiesce", func(t *testing.T) {
+		o := newFinalizingOwner()
+		if err := o.quiesceMaterializationForHandoff(); !errors.Is(err, errFinalizationUnproven) {
+			t.Fatalf("handoff quiesce during finalization = %v", err)
+		}
+	})
+}
+
+func TestMaterializationAdmissionRejectsUnretiredGeneration(t *testing.T) {
+	tests := []struct {
+		name     string
+		state    MaterializationState
+		dead     bool
+		retiring bool
+	}{
+		{name: "finalizing state", state: MaterializationFinalizing},
+		{name: "retiring process", state: MaterializationCacheOnly, retiring: true},
+		{name: "ready dead before retirement claim", state: MaterializationReady, dead: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := newMinimalOwner()
+			proc := &upstream.Process{Done: make(chan struct{})}
+			o.mu.Lock()
+			o.upstream = proc
+			o.mu.Unlock()
+			o.upstreamDead.Store(tt.dead)
+			o.materializationMu.Lock()
+			o.materializationState = tt.state
+			if tt.retiring {
+				o.retiringProcess = proc
+			}
+			a, start := o.startMaterializationLocked(MaterializationTriggerDemand)
+			state := o.materializationState
+			generation := o.materializationGeneration
+			o.materializationMu.Unlock()
+			if start || a.err == nil {
+				t.Fatalf("unretired generation admitted replacement: start=%v err=%v", start, a.err)
+			}
+			if state != tt.state || generation != 0 {
+				t.Fatalf("rejected admission mutated controller: state=%s generation=%d", state, generation)
+			}
+		})
+	}
+}
+
+func TestPostDiscoveryExitRetiresBeforeReadyPublication(t *testing.T) {
+	done := make(chan struct{})
+	close(done)
+	proc := &upstream.Process{Done: done}
+	o := newMinimalOwner()
+	a := newMaterializationAttempt(1, MaterializationTriggerDemand)
+	a.process = proc
+	a.signals.signalDiscoveryReady()
+	o.mu.Lock()
+	o.upstream = proc
+	o.mu.Unlock()
+	o.materializationMu.Lock()
+	o.materializationAttempt = a
+	o.materializationState = MaterializationMaterializing
+	o.materializationMu.Unlock()
+
+	o.monitorMaterializedProcessExit(proc)
+	if state := o.MaterializationState(); state != MaterializationCacheOnly {
+		t.Fatalf("post-discovery exit state = %s, want cache_only after retirement", state)
+	}
+	if current := o.currentUpstream(); current != nil {
+		t.Fatalf("post-discovery exit retained upstream %p", current)
+	}
+
+	o.finishMaterializationSuccess(a)
+	select {
+	case <-a.done:
+	default:
+		t.Fatal("failed post-discovery generation did not settle")
+	}
+	if a.err == nil || o.MaterializationState() == MaterializationReady {
+		t.Fatalf("dead post-discovery generation published ready: err=%v state=%s", a.err, o.MaterializationState())
+	}
+}
+
+func TestFinishMaterializationSuccessPreservesFinalizeBlocked(t *testing.T) {
+	o := newMinimalOwner()
+	proc := &upstream.Process{Done: make(chan struct{})}
+	blockErr := errors.New("synthetic authority remains")
+	a := newMaterializationAttempt(1, MaterializationTriggerDemand)
+	a.process = proc
+	o.mu.Lock()
+	o.upstream = proc
+	o.mu.Unlock()
+	o.upstreamDead.Store(true)
+	o.materializationMu.Lock()
+	o.materializationAttempt = a
+	o.materializationState = MaterializationFinalizeBlocked
+	o.materializationBlockedErr = blockErr
+	o.retiringProcess = proc
+	o.materializationMu.Unlock()
+
+	o.finishMaterializationSuccess(a)
+	if state := o.MaterializationState(); state != MaterializationFinalizeBlocked {
+		t.Fatalf("finish success overwrote blocked state with %s", state)
+	}
+	if !errors.Is(a.err, blockErr) || o.currentUpstream() != proc {
+		t.Fatalf("blocked authority was not retained: err=%v current=%p", a.err, o.currentUpstream())
 	}
 }
 
@@ -2239,6 +2438,16 @@ func TestResolvePersistentCannotDowngradeCommittedPersistence(t *testing.T) {
 	}
 }
 
+func TestExportSnapshotPreservesCommittedPersistentPolicy(t *testing.T) {
+	o := newMinimalOwner()
+	o.materializationPolicy = MaterializationPersistent
+
+	snapshot := o.ExportSnapshot()
+	if !snapshot.Persistent {
+		t.Fatal("committed persistent policy was not preserved in snapshot")
+	}
+}
+
 func TestMaterializationStatusReportsCacheOnlyAndLiveGeneration(t *testing.T) {
 	handler := func(_ context.Context, stdin io.Reader, stdout io.Writer) error {
 		scanner := bufio.NewScanner(stdin)
@@ -2289,10 +2498,10 @@ func TestMaterializationStatusReportsCacheOnlyAndLiveGeneration(t *testing.T) {
 	defer s.close()
 	sendReq(t, s.write, 21, "custom/status", `{}`)
 	assertResponseID(t, readRespWithID(t, s.read, 21), 21)
-	status = o.Status()
-	if status["materialization_state"] != string(MaterializationReady) || status["upstream_live"] != true {
-		t.Fatalf("ready status = %#v", status)
-	}
+	waitForCondition(t, time.Second, func() bool {
+		status = o.Status()
+		return status["materialization_state"] == string(MaterializationReady) && status["upstream_live"] == true
+	}, "ready status was not published")
 	if generation, ok := status["materialization_generation"].(uint64); !ok || generation != 1 {
 		t.Fatalf("materialization generation = %#v, want uint64(1)", status["materialization_generation"])
 	}
@@ -2651,6 +2860,35 @@ func TestCacheResponseStateRejectsJSONRPCError(t *testing.T) {
 	}
 }
 
+func TestLiveCachePublicationRejectionDoesNotCommitLocalTools(t *testing.T) {
+	o := newMinimalOwner()
+	o.initResp = []byte(`{"jsonrpc":"2.0","id":1,"result":{"capabilities":{}}}`)
+	o.initDone = true
+	var staged OwnerSnapshot
+	o.onCacheReady = func(got *Owner, snap OwnerSnapshot) bool {
+		if got != o {
+			t.Fatalf("cache callback owner = %p, want %p", got, o)
+		}
+		staged = snap
+		return false
+	}
+
+	raw := []byte(`{"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"fresh"}]}}`)
+	o.cacheResponseState("tools/list", raw)
+	if o.getCachedResponse("tools/list") != nil {
+		t.Fatal("rejected live cache publication committed tools locally")
+	}
+	if staged.CachedTools == "" || staged.ClassificationSource != "tools" {
+		t.Fatalf("cache callback did not receive staged tools/classification: %+v", staged)
+	}
+	o.mu.RLock()
+	classificationSource := o.classificationSource
+	o.mu.RUnlock()
+	if classificationSource != "" {
+		t.Fatalf("rejected live cache publication committed classification source %q", classificationSource)
+	}
+}
+
 func TestBlockedMaterializationFinalizationReprovesAutomatically(t *testing.T) {
 	done := make(chan struct{})
 	close(done)
@@ -2658,7 +2896,6 @@ func TestBlockedMaterializationFinalizationReprovesAutomatically(t *testing.T) {
 	o := newMinimalOwner()
 	o.initResp = []byte(`{"jsonrpc":"2.0","id":1,"result":{}}`)
 	a := newMaterializationAttempt(1, MaterializationTriggerDemand)
-	a.process = proc
 	o.materializationAttempt = a
 	o.materializationState = MaterializationFinalizing
 	o.retiringProcess = proc
@@ -2671,7 +2908,7 @@ func TestBlockedMaterializationFinalizationReprovesAutomatically(t *testing.T) {
 		}
 		return errors.New("synthetic authority still live")
 	}
-	blockErr := o.blockMaterializationFinalization(a, errors.New("synthetic authority still live"))
+	blockErr := o.blockMaterializationFinalization(a, proc, errors.New("synthetic authority still live"))
 	o.finishMaterializationFailure(a, blockErr)
 	allowProof.Store(true)
 

--- a/muxcore/owner/materialization_controller_test.go
+++ b/muxcore/owner/materialization_controller_test.go
@@ -19,6 +19,7 @@ import (
 	muxcore "github.com/thebtf/mcp-mux/muxcore"
 	"github.com/thebtf/mcp-mux/muxcore/jsonrpc"
 	"github.com/thebtf/mcp-mux/muxcore/remap"
+	muxsession "github.com/thebtf/mcp-mux/muxcore/session"
 	"github.com/thebtf/mcp-mux/muxcore/upstream"
 )
 
@@ -918,6 +919,399 @@ func TestLaterProcessExitClearsRecoverableFinalizationBlock(t *testing.T) {
 	}
 }
 
+func TestReadyGenerationRemainsAuthoritativeUntilRetirementProof(t *testing.T) {
+	o, err := NewOwnerFromSnapshot(OwnerConfig{
+		IPCPath:               testIPCPath(t),
+		MaterializationPolicy: MaterializationOnDemand,
+		Logger:                testLogger(t),
+	}, controllerSnapshot())
+	if err != nil {
+		t.Fatalf("NewOwnerFromSnapshot: %v", err)
+	}
+	defer o.Shutdown()
+
+	proc := upstream.NewProcessFromHandler(context.Background(), func(context.Context, io.Reader, io.Writer) error {
+		return errors.New("synthetic ready-generation exit")
+	})
+	select {
+	case <-proc.Done:
+	case <-time.After(time.Second):
+		t.Fatal("fixture process did not exit")
+	}
+	o.upstreamEventMu.Lock()
+	o.materializationMu.Lock()
+	o.mu.Lock()
+	o.upstream = proc
+	o.upstreamDead.Store(false)
+	o.mu.Unlock()
+	o.materializationState = MaterializationReady
+	o.materializationMu.Unlock()
+	o.upstreamEventMu.Unlock()
+
+	var allowProof atomic.Bool
+	o.materializationFinalizationProbe = func(*upstream.Process) error {
+		if allowProof.Load() {
+			return nil
+		}
+		return errors.New("synthetic process-tree authority remains")
+	}
+	o.monitorMaterializedProcessExit(proc)
+	waitForCondition(t, time.Second, func() bool {
+		return o.MaterializationState() == MaterializationFinalizeBlocked
+	}, "ready generation did not enter finalize_blocked")
+	if got := o.currentUpstream(); got != proc {
+		t.Fatalf("authoritative process changed before retirement proof: got=%p want=%p", got, proc)
+	}
+	if attempt := o.startMaterialization(MaterializationTriggerUpstreamExit); attempt.err == nil {
+		t.Fatal("replacement materialization was accepted before retirement proof")
+	}
+
+	allowProof.Store(true)
+	waitForCondition(t, 2*time.Second, func() bool {
+		return o.MaterializationState() == MaterializationCacheOnly && o.currentUpstream() == nil && o.retirementRetryProcess.Load() == nil
+	}, "retirement retry did not release generation after proof")
+}
+
+func TestStaleWriteFailureDoesNotRetireReplacementGeneration(t *testing.T) {
+	o, err := NewOwnerFromSnapshot(OwnerConfig{
+		IPCPath:               testIPCPath(t),
+		MaterializationPolicy: MaterializationOnDemand,
+		Logger:                testLogger(t),
+	}, controllerSnapshot())
+	if err != nil {
+		t.Fatalf("NewOwnerFromSnapshot: %v", err)
+	}
+	defer o.Shutdown()
+
+	stale := upstream.NewProcessFromHandler(context.Background(), func(context.Context, io.Reader, io.Writer) error {
+		return nil
+	})
+	select {
+	case <-stale.Done:
+	case <-time.After(time.Second):
+		t.Fatal("stale process did not exit")
+	}
+	replacement := upstream.NewProcessFromHandler(context.Background(), func(_ context.Context, stdin io.Reader, _ io.Writer) error {
+		_, err := io.Copy(io.Discard, stdin)
+		return err
+	})
+
+	sessionOutput := &bytes.Buffer{}
+	s := NewSessionWithRawWriter(7001, sessionOutput)
+	defer s.Close()
+	o.mu.Lock()
+	o.sessions[s.ID] = s
+	o.mu.Unlock()
+	o.sessionMgr.RegisterSession(s, "")
+	o.upstreamEventMu.Lock()
+	o.materializationMu.Lock()
+	o.mu.Lock()
+	o.upstream = stale
+	o.upstreamDead.Store(false)
+	o.mu.Unlock()
+	o.materializationState = MaterializationReady
+	o.materializationMu.Unlock()
+	o.upstreamEventMu.Unlock()
+
+	writeCaptured := make(chan *upstream.Process, 1)
+	releaseWrite := make(chan struct{})
+	o.beforeCurrentUpstreamWrite = func(proc *upstream.Process) {
+		writeCaptured <- proc
+		<-releaseWrite
+	}
+	msg, err := jsonrpc.Parse([]byte(`{"jsonrpc":"2.0","id":73,"method":"custom/stale-write","params":{}}`))
+	if err != nil {
+		t.Fatalf("parse request: %v", err)
+	}
+	forwardDone := make(chan error, 1)
+	go func() { forwardDone <- o.forwardRequestNow(s, msg) }()
+	select {
+	case got := <-writeCaptured:
+		if got != stale {
+			t.Fatalf("captured write process=%p, want stale=%p", got, stale)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("write did not reach generation capture seam")
+	}
+	o.upstreamEventMu.Lock()
+	o.materializationMu.Lock()
+	o.mu.Lock()
+	o.upstream = replacement
+	o.upstreamDead.Store(false)
+	o.mu.Unlock()
+	o.materializationState = MaterializationReady
+	o.materializationMu.Unlock()
+	o.upstreamEventMu.Unlock()
+	close(releaseWrite)
+	select {
+	case err := <-forwardDone:
+		if err != nil {
+			t.Fatalf("forwardRequestNow: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("stale write did not return after release")
+	}
+
+	if got := o.currentUpstream(); got != replacement {
+		t.Fatalf("stale write failure replaced current process: got=%p want=%p", got, replacement)
+	}
+	if o.upstreamDead.Load() || o.MaterializationState() != MaterializationReady {
+		t.Fatalf("replacement generation was marked failed: %#v", o.Status())
+	}
+	if o.PendingRequests() != 0 {
+		t.Fatalf("failed stale write left pending requests: %d", o.PendingRequests())
+	}
+	if !strings.Contains(sessionOutput.String(), `"id":73`) || !strings.Contains(sessionOutput.String(), "upstream write failed") {
+		t.Fatalf("failed request did not receive its own error: %s", sessionOutput.String())
+	}
+}
+
+func TestClosedAttachedSessionCannotSeedMaterialization(t *testing.T) {
+	o, err := NewOwnerFromSnapshot(OwnerConfig{
+		IPCPath:               testIPCPath(t),
+		MaterializationPolicy: MaterializationOnDemand,
+		Logger:                testLogger(t),
+	}, controllerSnapshot())
+	if err != nil {
+		t.Fatalf("NewOwnerFromSnapshot: %v", err)
+	}
+	defer o.Shutdown()
+
+	s := NewSession(strings.NewReader(""), io.Discard)
+	s.Cwd = "/closed/waiter"
+	o.mu.Lock()
+	o.sessions[s.ID] = s
+	o.mu.Unlock()
+	s.Close()
+
+	o.materializationMu.Lock()
+	o.pendingDemands["closed"] = &localDemand{session: s, state: localDemandWaiting}
+	o.pendingDemandOrder = []string{"closed"}
+	launch := o.electLaunchContextLocked()
+	o.materializationMu.Unlock()
+	o.materializationMu.Lock()
+	delete(o.pendingDemands, "closed")
+	o.pendingDemandOrder = nil
+	o.materializationMu.Unlock()
+	if launch.SessionID == s.ID || launch.Cwd == s.Cwd {
+		t.Fatalf("closed attached session seeded launch context: %+v", launch)
+	}
+}
+
+func TestProactiveIsolatedRecoveryRematerializesInOldestAttachedContext(t *testing.T) {
+	firstInit := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	var firstOnce sync.Once
+	var starts atomic.Int32
+	defer firstOnce.Do(func() { close(releaseFirst) })
+	handler := func(_ context.Context, stdin io.Reader, stdout io.Writer) error {
+		generation := starts.Add(1)
+		scanner := bufio.NewScanner(stdin)
+		for scanner.Scan() {
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+				return err
+			}
+			switch req.Method {
+			case "initialize":
+				if generation == 1 {
+					close(firstInit)
+					<-releaseFirst
+				}
+				if err := writeControllerResponse(stdout, req.ID, `{"protocolVersion":"2025-11-25","capabilities":{"x-mux":{"sharing":"isolated"}},"serverInfo":{"name":"recovery","version":"1"}}`); err != nil {
+					return err
+				}
+			case "tools/list":
+				if err := writeControllerResponse(stdout, req.ID, `{"tools":[]}`); err != nil {
+					return err
+				}
+			}
+		}
+		return scanner.Err()
+	}
+
+	o, err := NewOwnerFromSnapshot(OwnerConfig{
+		Cwd:                   "/project/departed",
+		Env:                   map[string]string{"CONFIG_PATH": "departed"},
+		HandlerFunc:           handler,
+		IPCPath:               testIPCPath(t),
+		ServerID:              "proactive-isolated-context",
+		MaterializationPolicy: MaterializationOnDemand,
+		Logger:                testLogger(t),
+	}, controllerSnapshot())
+	if err != nil {
+		t.Fatalf("NewOwnerFromSnapshot: %v", err)
+	}
+	defer o.Shutdown()
+
+	oldest := newControllerTestSession(o)
+	defer oldest.close()
+	oldest.session.Cwd = "/project/retained"
+	oldest.session.Env = map[string]string{"CONFIG_PATH": "retained"}
+	newer := newControllerTestSession(o)
+	defer newer.close()
+	newer.session.Cwd = "/project/newer"
+	newer.session.Env = map[string]string{"CONFIG_PATH": "newer"}
+
+	attempt := o.startMaterialization(MaterializationTriggerUpstreamExit)
+	select {
+	case <-firstInit:
+	case <-time.After(time.Second):
+		t.Fatal("proactive recovery did not reach its first initialize")
+	}
+	o.materializationMu.Lock()
+	firstLaunch := attempt.launch
+	o.materializationMu.Unlock()
+	if firstLaunch.SessionID != 0 || firstLaunch.Cwd != "/project/departed" {
+		t.Fatalf("initial proactive launch = %+v, want stored owner context", firstLaunch)
+	}
+	firstOnce.Do(func() { close(releaseFirst) })
+	waitForCondition(t, 3*time.Second, func() bool { return starts.Load() >= 2 }, "isolated verdict did not rematerialize")
+	o.materializationMu.Lock()
+	secondLaunch := attempt.launch
+	o.materializationMu.Unlock()
+	if secondLaunch.SessionID != oldest.session.ID || secondLaunch.Cwd != oldest.session.Cwd || secondLaunch.Env["CONFIG_PATH"] != "retained" {
+		t.Fatalf("second launch context = %+v, want oldest attached session", secondLaunch)
+	}
+	select {
+	case <-attempt.done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("rematerialized isolated recovery did not finish")
+	}
+	if attempt.err != nil {
+		t.Fatalf("rematerialized isolated recovery failed: %v", attempt.err)
+	}
+	if got := starts.Load(); got != 2 {
+		t.Fatalf("upstream starts = %d, want owner-context probe plus retained-context generation", got)
+	}
+	snapshot := o.ExportSnapshot()
+	if snapshot.Cwd != oldest.session.Cwd || snapshot.Env["CONFIG_PATH"] != "retained" || snapshot.Classification != "isolated" {
+		t.Fatalf("committed recovery context = %+v", snapshot)
+	}
+	select {
+	case <-oldest.session.Done():
+		t.Fatal("retained oldest session was evicted")
+	default:
+	}
+	waitForCondition(t, time.Second, func() bool {
+		select {
+		case <-newer.session.Done():
+			return true
+		default:
+			return false
+		}
+	}, "newer session was not evicted after isolated rematerialization")
+}
+
+func TestProactiveIsolatedRecoveryReelectsWhenOldestLeavesBeforeRestart(t *testing.T) {
+	firstInit := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	var firstOnce sync.Once
+	var starts atomic.Int32
+	defer firstOnce.Do(func() { close(releaseFirst) })
+	handler := func(_ context.Context, stdin io.Reader, stdout io.Writer) error {
+		generation := starts.Add(1)
+		scanner := bufio.NewScanner(stdin)
+		for scanner.Scan() {
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+				return err
+			}
+			switch req.Method {
+			case "initialize":
+				if generation == 1 {
+					close(firstInit)
+					<-releaseFirst
+				}
+				if err := writeControllerResponse(stdout, req.ID, `{"protocolVersion":"2025-11-25","capabilities":{"x-mux":{"sharing":"isolated"}},"serverInfo":{"name":"recovery","version":"1"}}`); err != nil {
+					return err
+				}
+			case "tools/list":
+				if err := writeControllerResponse(stdout, req.ID, `{"tools":[]}`); err != nil {
+					return err
+				}
+			}
+		}
+		return scanner.Err()
+	}
+
+	o, err := NewOwnerFromSnapshot(OwnerConfig{
+		Cwd:                   "/project/departed",
+		Env:                   map[string]string{"CONFIG_PATH": "departed"},
+		HandlerFunc:           handler,
+		IPCPath:               testIPCPath(t),
+		ServerID:              "proactive-isolated-reelection",
+		MaterializationPolicy: MaterializationOnDemand,
+		Logger:                testLogger(t),
+	}, controllerSnapshot())
+	if err != nil {
+		t.Fatalf("NewOwnerFromSnapshot: %v", err)
+	}
+	defer o.Shutdown()
+
+	oldest := newControllerTestSession(o)
+	oldest.session.Cwd = "/project/oldest"
+	oldest.session.Env = map[string]string{"CONFIG_PATH": "oldest"}
+	newer := newControllerTestSession(o)
+	defer newer.close()
+	newer.session.Cwd = "/project/newer"
+	newer.session.Env = map[string]string{"CONFIG_PATH": "newer"}
+
+	attempt := o.startMaterialization(MaterializationTriggerUpstreamExit)
+	select {
+	case <-firstInit:
+	case <-time.After(time.Second):
+		t.Fatal("proactive recovery did not reach its first initialize")
+	}
+	o.materializationMu.Lock()
+	firstSignals := attempt.signals
+	o.materializationMu.Unlock()
+	firstOnce.Do(func() { close(releaseFirst) })
+	select {
+	case <-firstSignals.failed:
+	case <-time.After(time.Second):
+		t.Fatal("first isolated verdict did not request retained-context rematerialization")
+	}
+	oldest.close()
+	waitForCondition(t, time.Second, func() bool {
+		return !o.sessionEligibleForDemand(oldest.session)
+	}, "oldest session remained eligible before replacement start")
+
+	waitForCondition(t, 3*time.Second, func() bool { return starts.Load() >= 2 }, "replacement generation did not start")
+	o.materializationMu.Lock()
+	secondLaunch := attempt.launch
+	o.materializationMu.Unlock()
+	if secondLaunch.SessionID != newer.session.ID || secondLaunch.Cwd != newer.session.Cwd || secondLaunch.Env["CONFIG_PATH"] != "newer" {
+		t.Fatalf("replacement launch context = %+v, want next-oldest attached session", secondLaunch)
+	}
+	select {
+	case <-attempt.done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("re-elected isolated recovery did not finish")
+	}
+	if attempt.err != nil {
+		t.Fatalf("re-elected isolated recovery failed: %v", attempt.err)
+	}
+	if got := starts.Load(); got != 2 {
+		t.Fatalf("upstream starts = %d, want owner-context probe plus one re-elected generation", got)
+	}
+	snapshot := o.ExportSnapshot()
+	if snapshot.Cwd != newer.session.Cwd || snapshot.Env["CONFIG_PATH"] != "newer" || snapshot.Classification != "isolated" {
+		t.Fatalf("committed re-elected recovery context = %+v", snapshot)
+	}
+	select {
+	case <-newer.session.Done():
+		t.Fatal("re-elected session was evicted")
+	default:
+	}
+}
+
 func TestFreshIsolatedClassificationRetainsInitiatingSession(t *testing.T) {
 	initSeen := make(chan struct{})
 	releaseInit := make(chan struct{})
@@ -965,6 +1359,7 @@ func TestFreshIsolatedClassificationRetainsInitiatingSession(t *testing.T) {
 		IPCPath:               testIPCPath(t),
 		MaterializationPolicy: MaterializationOnDemand,
 		Logger:                testLogger(t),
+		ServerID:              "fresh-isolated-reconnect",
 	}, controllerSnapshot())
 	if err != nil {
 		t.Fatalf("NewOwnerFromSnapshot: %v", err)
@@ -978,6 +1373,12 @@ func TestFreshIsolatedClassificationRetainsInitiatingSession(t *testing.T) {
 	defer high.close()
 	high.session.Cwd = "/project/high"
 	high.session.Env = map[string]string{"GITHUB_TOKEN": "same"}
+	for token, session := range map[string]*Session{"low-bound": low.session, "high-bound": high.session} {
+		o.SessionMgr().PreRegisterForOwner(token, o.ServerID(), session.Cwd, session.Env)
+		if !o.SessionMgr().Bind(token, o.ServerID(), session) {
+			t.Fatalf("Bind(%q) returned false", token)
+		}
+	}
 
 	sendReq(t, high.write, 9, "custom/high", `{}`)
 	select {
@@ -1013,6 +1414,12 @@ func TestFreshIsolatedClassificationRetainsInitiatingSession(t *testing.T) {
 	snapshot := o.ExportSnapshot()
 	if snapshot.Cwd != "/project/high" || snapshot.Classification != "isolated" {
 		t.Fatalf("committed initiating context/classification = %+v", snapshot)
+	}
+	if _, err := o.SessionMgr().RegisterReconnect("low-bound", func(string) bool { return true }); !errors.Is(err, muxsession.ErrUnknownToken) {
+		t.Fatalf("evicted reconnect error = %v, want ErrUnknownToken", err)
+	}
+	if _, err := o.SessionMgr().RegisterReconnect("high-bound", func(string) bool { return true }); err != nil {
+		t.Fatalf("retained reconnect authority was revoked: %v", err)
 	}
 }
 
@@ -1081,6 +1488,7 @@ func TestMaterializationIsolatedCommitRevokesTokenDuringAuthorization(t *testing
 	initiator := newControllerTestSession(o)
 	defer initiator.close()
 	initiator.session.Cwd = "/project/initiator"
+	initiator.session.SetMeta(muxcore.SessionMeta{AuthorizedAt: time.Now()})
 
 	const token = "deadbeef"
 	if !o.PreRegister(token, "/project/extra", map[string]string{"PROJECT": "extra"}) {
@@ -1540,7 +1948,11 @@ func TestPendingPersistenceRetriesAfterDiscoveryFailureWithoutSessions(t *testin
 			}
 			switch req.Method {
 			case "initialize":
-				if err := writeControllerResponse(stdout, req.ID, `{"protocolVersion":"2025-11-25","capabilities":{"x-mux":{"persistent":true}},"serverInfo":{"name":"persistent-retry","version":"1"}}`); err != nil {
+				result := `{"protocolVersion":"2025-11-25","capabilities":{},"serverInfo":{"name":"persistent-retry","version":"1"}}`
+				if generation == 1 {
+					result = `{"protocolVersion":"2025-11-25","capabilities":{"x-mux":{"persistent":true}},"serverInfo":{"name":"persistent-retry","version":"1"}}`
+				}
+				if err := writeControllerResponse(stdout, req.ID, result); err != nil {
 					return err
 				}
 			case "tools/list":
@@ -1583,7 +1995,26 @@ func TestPendingPersistenceRetriesAfterDiscoveryFailureWithoutSessions(t *testin
 		return starts.Load() >= 2 && o.MaterializationState() == MaterializationReady
 	}, "pending persistence did not retain one retry obligation")
 	if o.PersistentPending() {
-		t.Fatal("successful persistent commit did not promote the pending obligation")
+		t.Fatal("successful commit did not promote the pending obligation")
+	}
+	o.materializationMu.Lock()
+	policy := o.materializationPolicy
+	o.materializationMu.Unlock()
+	if policy != MaterializationPersistent {
+		t.Fatalf("second generation downgraded latched persistence: policy=%s", policy)
+	}
+}
+
+func TestResolvePersistentCannotDowngradeCommittedPersistence(t *testing.T) {
+	o := &Owner{materializationPolicy: MaterializationPersistent}
+
+	o.ResolvePersistent(false)
+
+	o.materializationMu.Lock()
+	policy := o.materializationPolicy
+	o.materializationMu.Unlock()
+	if policy != MaterializationPersistent {
+		t.Fatalf("later persistent=false resolution downgraded committed persistence: policy=%s", policy)
 	}
 }
 
@@ -1629,6 +2060,9 @@ func TestMaterializationStatusReportsCacheOnlyAndLiveGeneration(t *testing.T) {
 	status := o.Status()
 	if status["materialization_state"] != string(MaterializationCacheOnly) || status["cache_ready"] != true || status["upstream_live"] != false {
 		t.Fatalf("cache-only status = %#v", status)
+	}
+	if status["materialization_policy"] != "on_demand" {
+		t.Fatalf("materialization policy = %#v, want on_demand", status["materialization_policy"])
 	}
 	s := newControllerTestSession(o)
 	defer s.close()
@@ -1946,5 +2380,137 @@ func TestMaterializationListChangedSuccessBroadcastsFromColdCommit(t *testing.T)
 	}, "cold staged list_changed was not broadcast after commit")
 	if got := string(o.getCachedResponse("tools/list")); !strings.Contains(got, "fresh") {
 		t.Fatalf("successful staged cache not committed: %s", got)
+	}
+}
+
+func TestMaterializationDiscoveryErrorsFailWithoutStaging(t *testing.T) {
+	for _, method := range []string{"initialize", "tools/list"} {
+		t.Run(method, func(t *testing.T) {
+			o := newMinimalOwner()
+			proc := &upstream.Process{Done: make(chan struct{})}
+			a := newMaterializationAttempt(1, MaterializationTriggerDemand)
+			a.process = proc
+			a.signals = newMaterializationSignals()
+			o.materializationAttempt = a
+			o.cacheStage = &cacheStage{generation: a.generation, process: proc, signals: a.signals}
+
+			raw := []byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"discovery failed"}}`)
+			if !o.stageMaterializationCacheResponse(proc, method, raw) {
+				t.Fatal("materialization response was not claimed")
+			}
+			select {
+			case <-a.signals.failed:
+			default:
+				t.Fatal("JSON-RPC discovery error did not fail materialization")
+			}
+			if method == "initialize" {
+				select {
+				case <-a.signals.initReady:
+				default:
+					t.Fatal("initialize error did not settle the init usability gate")
+				}
+				if a.signals.initOK {
+					t.Fatal("initialize error marked the response usable")
+				}
+			}
+			if o.cacheStage.initResp != nil || o.cacheStage.toolList != nil {
+				t.Fatalf("discovery error entered staged cache: %#v", o.cacheStage)
+			}
+		})
+	}
+}
+
+func TestCacheResponseStateRejectsJSONRPCError(t *testing.T) {
+	o := newMinimalOwner()
+	raw := []byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"not cacheable"}}`)
+	o.cacheResponseState("initialize", raw)
+	o.cacheResponseState("tools/list", raw)
+	if o.getCachedResponse("initialize") != nil || o.getCachedResponse("tools/list") != nil {
+		t.Fatal("JSON-RPC error response entered the reusable cache")
+	}
+}
+
+func TestBlockedMaterializationFinalizationReprovesAutomatically(t *testing.T) {
+	done := make(chan struct{})
+	close(done)
+	proc := &upstream.Process{Done: done}
+	o := newMinimalOwner()
+	o.initResp = []byte(`{"jsonrpc":"2.0","id":1,"result":{}}`)
+	a := newMaterializationAttempt(1, MaterializationTriggerDemand)
+	a.process = proc
+	o.materializationAttempt = a
+	o.materializationState = MaterializationFinalizing
+	o.retiringProcess = proc
+	o.upstream = proc
+
+	var allowProof atomic.Bool
+	o.materializationFinalizationProbe = func(*upstream.Process) error {
+		if allowProof.Load() {
+			return nil
+		}
+		return errors.New("synthetic authority still live")
+	}
+	blockErr := o.blockMaterializationFinalization(a, errors.New("synthetic authority still live"))
+	o.finishMaterializationFailure(a, blockErr)
+	allowProof.Store(true)
+
+	waitForCondition(t, time.Second, func() bool {
+		return o.MaterializationState() == MaterializationCacheOnly && o.currentUpstream() == nil
+	}, "blocked materialization finalization was not automatically re-proven")
+}
+
+func TestBlockedQueuedWriteDoesNotHoldMaterializationMutex(t *testing.T) {
+	o := newMinimalOwner()
+	var upstream bytes.Buffer
+	o.upstreamWriter = &upstream
+	s := NewSession(strings.NewReader(""), io.Discard)
+	o.admissionMu.Lock()
+	o.addSessionLocked(s)
+	o.admissionMu.Unlock()
+	defer s.Close()
+
+	msg, err := jsonrpc.Parse([]byte(`{"jsonrpc":"2.0","id":41,"method":"custom/blocked","params":{}}`))
+	if err != nil {
+		t.Fatalf("parse request: %v", err)
+	}
+	key := string(remap.Remap(s.ID, msg.ID))
+	o.pendingDemands[key] = &localDemand{key: key, session: s, message: msg, state: localDemandWaiting, generation: 1}
+	o.materializationState = MaterializationReady
+
+	writeEntered := make(chan struct{})
+	releaseWrite := make(chan struct{})
+	o.beforeQueuedDemandWrite = func() {
+		close(writeEntered)
+		<-releaseWrite
+	}
+	forwardDone := make(chan struct{})
+	go func() {
+		o.forwardQueuedDemand(key, 1, o.launchContextForSession(s))
+		close(forwardDone)
+	}()
+	select {
+	case <-writeEntered:
+	case <-time.After(time.Second):
+		t.Fatal("queued write did not reach the blocking boundary")
+	}
+
+	lockAcquired := make(chan struct{})
+	go func() {
+		o.materializationMu.Lock()
+		o.materializationMu.Unlock()
+		close(lockAcquired)
+	}()
+	select {
+	case <-lockAcquired:
+	case <-time.After(150 * time.Millisecond):
+		close(releaseWrite)
+		<-forwardDone
+		t.Fatal("blocked upstream write held materializationMu")
+	}
+	close(releaseWrite)
+	select {
+	case <-forwardDone:
+	case <-time.After(time.Second):
+		t.Fatal("queued write did not complete")
 	}
 }

--- a/muxcore/owner/materialization_controller_test.go
+++ b/muxcore/owner/materialization_controller_test.go
@@ -832,6 +832,227 @@ func TestAcquireRestartPinCancelsMaterializationAndFreezesSnapshot(t *testing.T)
 	}
 }
 
+func TestAcquireRestartPinPreservesSettledReelectedLaunchContext(t *testing.T) {
+	firstInit := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	var firstOnce sync.Once
+	var releaseOnce sync.Once
+	var starts atomic.Int32
+	release := func() { releaseOnce.Do(func() { close(releaseFirst) }) }
+	defer release()
+
+	handler := func(_ context.Context, stdin io.Reader, stdout io.Writer) error {
+		generation := starts.Add(1)
+		scanner := bufio.NewScanner(stdin)
+		for scanner.Scan() {
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+				return err
+			}
+			switch req.Method {
+			case "initialize":
+				if generation == 1 {
+					firstOnce.Do(func() { close(firstInit) })
+					<-releaseFirst
+				}
+				if err := writeControllerResponse(stdout, req.ID, `{"protocolVersion":"2025-11-25","capabilities":{"x-mux":{"sharing":"isolated"}},"serverInfo":{"name":"restart-pin","version":"1"}}`); err != nil {
+					return err
+				}
+			case "tools/list":
+				if err := writeControllerResponse(stdout, req.ID, `{"tools":[]}`); err != nil {
+					return err
+				}
+			}
+		}
+		return scanner.Err()
+	}
+
+	o, err := NewOwnerFromSnapshot(OwnerConfig{
+		Cwd:                   "/project/pre-wait",
+		Env:                   map[string]string{"CONFIG_PATH": "pre-wait"},
+		HandlerFunc:           handler,
+		IPCPath:               testIPCPath(t),
+		MaterializationPolicy: MaterializationOnDemand,
+		Logger:                testLogger(t),
+	}, controllerSnapshot())
+	if err != nil {
+		t.Fatalf("NewOwnerFromSnapshot: %v", err)
+	}
+	defer o.Shutdown()
+	retained := newControllerTestSession(o)
+	defer retained.close()
+	retained.session.Cwd = "/project/reelected"
+	retained.session.Env = map[string]string{"CONFIG_PATH": "reelected"}
+
+	attempt := o.startMaterialization(MaterializationTriggerUpstreamExit)
+	select {
+	case <-firstInit:
+	case <-time.After(time.Second):
+		t.Fatal("materialization did not reach the pre-wait generation")
+	}
+
+	type pinResult struct {
+		pin *RestartPin
+		err error
+	}
+	resultCh := make(chan pinResult, 1)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	go func() {
+		pin, acquireErr := o.AcquireRestartPin(ctx)
+		resultCh <- pinResult{pin: pin, err: acquireErr}
+	}()
+	waitForCondition(t, time.Second, func() bool {
+		o.materializationMu.Lock()
+		defer o.materializationMu.Unlock()
+		return o.restartPins.Load() == 1 && attempt.launchFrozen && o.restartResumeTrigger == MaterializationTriggerUpstreamExit
+	}, "restart pin did not freeze the pre-wait launch")
+	release()
+
+	var result pinResult
+	select {
+	case result = <-resultCh:
+	case <-time.After(3 * time.Second):
+		t.Fatal("AcquireRestartPin did not settle")
+	}
+	if result.err != nil {
+		t.Fatalf("AcquireRestartPin: %v", result.err)
+	}
+	defer result.pin.Release()
+	if attempt.err != nil {
+		t.Fatalf("re-elected materialization failed: %v", attempt.err)
+	}
+	if result.pin.Snapshot.Cwd != retained.session.Cwd || result.pin.Snapshot.Env["CONFIG_PATH"] != "reelected" {
+		t.Fatalf("restart snapshot context = %+v, want settled re-elected context", result.pin.Snapshot)
+	}
+	if got := starts.Load(); got != 2 {
+		t.Fatalf("upstream starts = %d, want pre-wait plus one re-elected generation", got)
+	}
+	result.pin.Release()
+	time.Sleep(50 * time.Millisecond)
+	if got := starts.Load(); got != 2 {
+		t.Fatalf("pin release started duplicate generation: got %d starts, want 2", got)
+	}
+}
+
+func TestRestartPinDefersLiveRecoveryUntilFinalRelease(t *testing.T) {
+	var starts atomic.Int32
+	handler := func(_ context.Context, stdin io.Reader, stdout io.Writer) error {
+		starts.Add(1)
+		scanner := bufio.NewScanner(stdin)
+		for scanner.Scan() {
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+				return err
+			}
+			switch req.Method {
+			case "initialize":
+				if err := writeControllerResponse(stdout, req.ID, `{"protocolVersion":"2025-11-25","capabilities":{},"serverInfo":{"name":"restart-resume","version":"1"}}`); err != nil {
+					return err
+				}
+			case "tools/list":
+				if err := writeControllerResponse(stdout, req.ID, `{"tools":[]}`); err != nil {
+					return err
+				}
+			}
+		}
+		return scanner.Err()
+	}
+
+	o, err := NewOwnerFromSnapshot(OwnerConfig{
+		HandlerFunc:           handler,
+		IPCPath:               testIPCPath(t),
+		MaterializationPolicy: MaterializationOnDemand,
+		Logger:                testLogger(t),
+	}, controllerSnapshot())
+	if err != nil {
+		t.Fatalf("NewOwnerFromSnapshot: %v", err)
+	}
+	defer o.Shutdown()
+	s := newControllerTestSession(o)
+	defer s.close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	firstPin, err := o.AcquireRestartPin(ctx)
+	if err != nil {
+		t.Fatalf("first AcquireRestartPin: %v", err)
+	}
+	defer firstPin.Release()
+	finalPin, err := o.AcquireRestartPin(ctx)
+	if err != nil {
+		t.Fatalf("second AcquireRestartPin: %v", err)
+	}
+	defer finalPin.Release()
+
+	for _, trigger := range []MaterializationTrigger{MaterializationTriggerUpstreamExit, MaterializationTriggerWriteError} {
+		blocked := o.startMaterialization(trigger)
+		if blocked.err == nil || !strings.Contains(blocked.err.Error(), "restart snapshot in progress") {
+			t.Fatalf("%s start while pinned = %v, want restart barrier", trigger, blocked.err)
+		}
+	}
+	if got := starts.Load(); got != 0 {
+		t.Fatalf("pinned recovery started %d generations, want 0", got)
+	}
+	firstPin.Release()
+	time.Sleep(50 * time.Millisecond)
+	if got := starts.Load(); got != 0 {
+		t.Fatalf("non-final pin release started %d generations, want 0", got)
+	}
+	finalPin.Release()
+	waitForCondition(t, 2*time.Second, func() bool {
+		return starts.Load() == 1 && o.MaterializationState() == MaterializationReady
+	}, "final pin release did not restore live-session recovery")
+	time.Sleep(50 * time.Millisecond)
+	if got := starts.Load(); got != 1 {
+		t.Fatalf("deferred recovery started %d generations, want exactly 1", got)
+	}
+}
+
+func TestFailedStartAuthorityEntersFinalizeBlockedWithoutReplacement(t *testing.T) {
+	o := newMinimalOwner()
+	defer close(o.materializationStop)
+	proc := upstream.NewProcessFromHandler(context.Background(), func(_ context.Context, stdin io.Reader, _ io.Writer) error {
+		_, err := io.Copy(io.Discard, stdin)
+		return err
+	})
+	a := newMaterializationAttempt(1, MaterializationTriggerUpstreamExit)
+	o.materializationAttempt = a
+	o.materializationState = MaterializationMaterializing
+
+	var sawExactAuthority atomic.Bool
+	o.materializationFinalizationProbe = func(got *upstream.Process) error {
+		sawExactAuthority.Store(got == proc)
+		return errors.New("synthetic failed-start authority remains")
+	}
+	retireErr := o.retireFailedMaterializationStart(a, proc)
+	if retireErr == nil || !strings.Contains(retireErr.Error(), "authority remains") {
+		t.Fatalf("failed-start retirement = %v, want unproven authority", retireErr)
+	}
+	startErr := errors.New("synthetic start failed after authority install")
+	o.finishMaterializationFailure(a, errors.Join(startErr, retireErr))
+
+	if !sawExactAuthority.Load() {
+		t.Fatal("failed-start finalization did not receive the installed process authority")
+	}
+	if got := o.currentUpstream(); got != proc {
+		t.Fatalf("authoritative failed-start process = %p, want %p", got, proc)
+	}
+	if a.process != proc || o.retiringProcess != proc || o.MaterializationState() != MaterializationFinalizeBlocked {
+		t.Fatalf("failed-start authority was not retained: attempt=%p retiring=%p status=%#v", a.process, o.retiringProcess, o.Status())
+	}
+	blocked := o.startMaterialization(MaterializationTriggerUpstreamExit)
+	if blocked.err == nil || !strings.Contains(blocked.err.Error(), "authority remains") {
+		t.Fatalf("replacement start while failed-start authority remained = %v", blocked.err)
+	}
+}
+
 func TestUnprovenFinalizationBlocksReplacementGeneration(t *testing.T) {
 	var starts atomic.Int32
 	handler := func(_ context.Context, stdin io.Reader, stdout io.Writer) error {

--- a/muxcore/owner/materialization_controller_test.go
+++ b/muxcore/owner/materialization_controller_test.go
@@ -2917,6 +2917,201 @@ func TestBlockedMaterializationFinalizationReprovesAutomatically(t *testing.T) {
 	}, "blocked materialization finalization was not automatically re-proven")
 }
 
+func TestRetirementReproofBeforeAttemptFailureStillRestartsLiveOwner(t *testing.T) {
+	var starts atomic.Int32
+	handler := func(_ context.Context, stdin io.Reader, stdout io.Writer) error {
+		starts.Add(1)
+		scanner := bufio.NewScanner(stdin)
+		for scanner.Scan() {
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+				return err
+			}
+			switch req.Method {
+			case "initialize":
+				if err := writeControllerResponse(stdout, req.ID, `{"protocolVersion":"2025-11-25","capabilities":{},"serverInfo":{"name":"reproof","version":"2"}}`); err != nil {
+					return err
+				}
+			case "tools/list":
+				if err := writeControllerResponse(stdout, req.ID, `{"tools":[]}`); err != nil {
+					return err
+				}
+			}
+		}
+		return scanner.Err()
+	}
+
+	o, err := NewOwnerFromSnapshot(OwnerConfig{
+		HandlerFunc:           handler,
+		IPCPath:               testIPCPath(t),
+		MaterializationPolicy: MaterializationOnDemand,
+		Logger:                testLogger(t),
+	}, controllerSnapshot())
+	if err != nil {
+		t.Fatalf("NewOwnerFromSnapshot: %v", err)
+	}
+	defer o.Shutdown()
+	session := newControllerTestSession(o)
+	defer session.close()
+
+	retired := upstream.NewProcessFromHandler(context.Background(), func(context.Context, io.Reader, io.Writer) error { return nil })
+	select {
+	case <-retired.Done:
+	case <-time.After(time.Second):
+		t.Fatal("retired fixture did not exit")
+	}
+	a := newMaterializationAttempt(1, MaterializationTriggerUpstreamExit)
+	a.process = retired
+	o.upstreamEventMu.Lock()
+	o.materializationMu.Lock()
+	o.mu.Lock()
+	o.upstream = retired
+	o.upstreamDead.Store(true)
+	o.mu.Unlock()
+	o.materializationGeneration = 1
+	o.materializationAttempt = a
+	o.materializationState = MaterializationFinalizeBlocked
+	o.materializationBlockedErr = errors.New("synthetic authority remained")
+	o.retiringProcess = retired
+	o.materializationMu.Unlock()
+	o.upstreamEventMu.Unlock()
+	o.materializationFinalizationProbe = func(got *upstream.Process) error {
+		if got != retired {
+			return fmt.Errorf("reproof process = %p, want %p", got, retired)
+		}
+		return nil
+	}
+
+	if !o.completeRetiringProcess(retired, MaterializationTriggerUpstreamExit) {
+		t.Fatal("retirement reproof did not succeed")
+	}
+	o.finishMaterializationFailure(a, errors.New("replacement readiness failed"))
+
+	waitForCondition(t, 2*time.Second, func() bool {
+		return starts.Load() == 1 && o.MaterializationState() == MaterializationReady
+	}, "live owner did not restart after retirement reproof won the attempt-settlement race")
+}
+
+func TestRetirementReproofKeepsFreshDemandForPostAttemptRecovery(t *testing.T) {
+	var starts atomic.Int32
+	handler := func(_ context.Context, stdin io.Reader, stdout io.Writer) error {
+		starts.Add(1)
+		scanner := bufio.NewScanner(stdin)
+		for scanner.Scan() {
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+				return err
+			}
+			switch req.Method {
+			case "initialize":
+				if err := writeControllerResponse(stdout, req.ID, `{"protocolVersion":"2025-11-25","capabilities":{},"serverInfo":{"name":"reproof-demand","version":"2"}}`); err != nil {
+					return err
+				}
+			case "tools/list":
+				if err := writeControllerResponse(stdout, req.ID, `{"tools":[]}`); err != nil {
+					return err
+				}
+			case "custom/recover":
+				if err := writeControllerResponse(stdout, req.ID, `{"replacement":true}`); err != nil {
+					return err
+				}
+			}
+		}
+		return scanner.Err()
+	}
+
+	o, err := NewOwnerFromSnapshot(OwnerConfig{
+		HandlerFunc:           handler,
+		IPCPath:               testIPCPath(t),
+		MaterializationPolicy: MaterializationOnDemand,
+		Logger:                testLogger(t),
+	}, controllerSnapshot())
+	if err != nil {
+		t.Fatalf("NewOwnerFromSnapshot: %v", err)
+	}
+	defer o.Shutdown()
+	session := newControllerTestSession(o)
+	defer session.close()
+
+	retired := upstream.NewProcessFromHandler(context.Background(), func(context.Context, io.Reader, io.Writer) error { return nil })
+	select {
+	case <-retired.Done:
+	case <-time.After(time.Second):
+		t.Fatal("retired fixture did not exit")
+	}
+	a := newMaterializationAttempt(1, MaterializationTriggerUpstreamExit)
+	a.process = retired
+	o.upstreamEventMu.Lock()
+	o.materializationMu.Lock()
+	o.mu.Lock()
+	o.upstream = retired
+	o.upstreamDead.Store(true)
+	o.mu.Unlock()
+	o.materializationGeneration = 1
+	o.materializationAttempt = a
+	o.materializationState = MaterializationFinalizeBlocked
+	o.materializationBlockedErr = errors.New("synthetic authority remained")
+	o.retiringProcess = retired
+	o.materializationMu.Unlock()
+	o.upstreamEventMu.Unlock()
+	o.materializationFinalizationProbe = func(got *upstream.Process) error {
+		if got != retired {
+			return fmt.Errorf("reproof process = %p, want %p", got, retired)
+		}
+		return nil
+	}
+
+	if !o.completeRetiringProcess(retired, MaterializationTriggerUpstreamExit) {
+		t.Fatal("retirement reproof did not succeed")
+	}
+	msg, err := jsonrpc.Parse([]byte(`{"jsonrpc":"2.0","id":72,"method":"custom/recover","params":{}}`))
+	if err != nil {
+		t.Fatalf("parse recovery demand: %v", err)
+	}
+	handled, err := o.enqueueLocalDemand(session.session, msg)
+	if err != nil {
+		t.Fatalf("enqueue recovery demand: %v", err)
+	}
+	if !handled {
+		t.Fatal("recovery demand bypassed materialization controller")
+	}
+	key := string(remap.Remap(session.session.ID, msg.ID))
+	o.materializationMu.Lock()
+	demand := o.pendingDemands[key]
+	trigger := o.restartResumeTrigger
+	o.materializationMu.Unlock()
+	if trigger != MaterializationTriggerUpstreamExit {
+		t.Fatalf("post-attempt trigger = %q, want %q", trigger, MaterializationTriggerUpstreamExit)
+	}
+	if demand == nil {
+		t.Fatal("recovery demand was not retained")
+	}
+	if demand.generation != 0 {
+		t.Fatalf("recovery demand generation = %d, want 0 until failed attempt settles", demand.generation)
+	}
+
+	o.finishMaterializationFailure(a, errors.New("replacement readiness failed"))
+	result := make(chan controllerResponseResult, 1)
+	go func() { result <- scanControllerResponseWithID(session.read, 72) }()
+	select {
+	case got := <-result:
+		if got.err != nil || !strings.Contains(string(got.response), `"replacement":true`) {
+			t.Fatalf("recovery response: response=%s err=%v", got.response, got.err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("recovery demand was not served by the successor generation")
+	}
+	if got := starts.Load(); got != 1 {
+		t.Fatalf("successor starts = %d, want 1", got)
+	}
+}
+
 func TestBlockedQueuedWriteDoesNotHoldMaterializationMutex(t *testing.T) {
 	o := newMinimalOwner()
 	var upstream bytes.Buffer

--- a/muxcore/owner/materialization_controller_test.go
+++ b/muxcore/owner/materialization_controller_test.go
@@ -1,0 +1,1950 @@
+package owner
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	muxcore "github.com/thebtf/mcp-mux/muxcore"
+	"github.com/thebtf/mcp-mux/muxcore/jsonrpc"
+	"github.com/thebtf/mcp-mux/muxcore/remap"
+	"github.com/thebtf/mcp-mux/muxcore/upstream"
+)
+
+type controllerTestSession struct {
+	session *Session
+	read    *io.PipeReader
+	write   *io.PipeWriter
+}
+
+func newControllerTestSession(o *Owner) controllerTestSession {
+	clientR, serverW := io.Pipe()
+	serverR, clientW := io.Pipe()
+	s := NewSession(serverR, serverW)
+	o.AddSession(s)
+	return controllerTestSession{session: s, read: clientR, write: clientW}
+}
+
+func (s controllerTestSession) close() {
+	_ = s.write.Close()
+	_ = s.read.Close()
+	s.session.Close()
+}
+
+func controllerSnapshot() OwnerSnapshot {
+	initResp := `{"jsonrpc":"2.0","id":"old-init","result":{"protocolVersion":"2025-11-25","capabilities":{},"serverInfo":{"name":"cached","version":"1"}}}`
+	toolsResp := `{"jsonrpc":"2.0","id":"old-tools","result":{"tools":[{"name":"old-tool"}]}}`
+	return OwnerSnapshot{
+		Classification: "shared",
+		CachedInit:     base64Encode([]byte(initResp)),
+		CachedTools:    base64Encode([]byte(toolsResp)),
+	}
+}
+
+func writeControllerResponse(w io.Writer, id json.RawMessage, result string) error {
+	_, err := fmt.Fprintf(w, `{"jsonrpc":"2.0","id":%s,"result":%s}`+"\n", id, result)
+	return err
+}
+
+type controllerResponseResult struct {
+	response []byte
+	err      error
+}
+
+func scanControllerResponseWithID(r io.Reader, id int) controllerResponseResult {
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		response := append([]byte(nil), scanner.Bytes()...)
+		var obj map[string]json.RawMessage
+		if err := json.Unmarshal(response, &obj); err != nil {
+			return controllerResponseResult{err: fmt.Errorf("unmarshal response: %w (raw: %s)", err, response)}
+		}
+		if string(obj["id"]) == strconv.Itoa(id) {
+			return controllerResponseResult{response: response}
+		}
+		if obj["id"] == nil && obj["method"] != nil {
+			continue
+		}
+		return controllerResponseResult{err: fmt.Errorf("unexpected response while waiting for id %d: %s", id, response)}
+	}
+	if err := scanner.Err(); err != nil {
+		return controllerResponseResult{err: err}
+	}
+	return controllerResponseResult{err: io.EOF}
+}
+
+type controllerBarrierResult struct {
+	response      []byte
+	notifications map[string]int
+	err           error
+}
+
+func scanControllerResponseThroughBarrier(r io.Reader, id int, barrier string) controllerBarrierResult {
+	result := controllerBarrierResult{notifications: make(map[string]int)}
+	scanner := bufio.NewScanner(r)
+	barrierSeen := false
+	for scanner.Scan() {
+		message := append([]byte(nil), scanner.Bytes()...)
+		var obj map[string]json.RawMessage
+		if err := json.Unmarshal(message, &obj); err != nil {
+			result.err = fmt.Errorf("unmarshal response: %w (raw: %s)", err, message)
+			return result
+		}
+		if string(obj["id"]) == strconv.Itoa(id) {
+			result.response = message
+		} else if obj["id"] == nil && obj["method"] != nil {
+			var method string
+			if err := json.Unmarshal(obj["method"], &method); err != nil {
+				result.err = fmt.Errorf("unmarshal notification method: %w", err)
+				return result
+			}
+			result.notifications[method]++
+			barrierSeen = barrierSeen || method == barrier
+		} else {
+			result.err = fmt.Errorf("unexpected response while waiting for id %d: %s", id, message)
+			return result
+		}
+		if result.response != nil && barrierSeen {
+			return result
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		result.err = err
+	} else {
+		result.err = io.EOF
+	}
+	return result
+}
+
+func TestConcurrentUncachedDemandsShareOneMaterialization(t *testing.T) {
+	var starts atomic.Int32
+	handler := func(_ context.Context, stdin io.Reader, stdout io.Writer) error {
+		starts.Add(1)
+		scanner := bufio.NewScanner(stdin)
+		for scanner.Scan() {
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+				return err
+			}
+			switch req.Method {
+			case "initialize":
+				if err := writeControllerResponse(stdout, req.ID, `{"protocolVersion":"2025-11-25","capabilities":{},"serverInfo":{"name":"live","version":"1"}}`); err != nil {
+					return err
+				}
+			case "tools/list":
+				if err := writeControllerResponse(stdout, req.ID, `{"tools":[]}`); err != nil {
+					return err
+				}
+			case "custom/one", "custom/two":
+				if err := writeControllerResponse(stdout, req.ID, `{"ok":true}`); err != nil {
+					return err
+				}
+			}
+		}
+		return scanner.Err()
+	}
+
+	o, err := NewOwnerFromSnapshot(OwnerConfig{
+		HandlerFunc:           handler,
+		IPCPath:               testIPCPath(t),
+		MaterializationPolicy: MaterializationOnDemand,
+		Logger:                testLogger(t),
+	}, controllerSnapshot())
+	if err != nil {
+		t.Fatalf("NewOwnerFromSnapshot: %v", err)
+	}
+	defer o.Shutdown()
+	s1 := newControllerTestSession(o)
+	s2 := newControllerTestSession(o)
+	defer s1.close()
+	defer s2.close()
+
+	result1 := make(chan controllerResponseResult, 1)
+	result2 := make(chan controllerResponseResult, 1)
+	go func() { result1 <- scanControllerResponseWithID(s1.read, 1) }()
+	go func() { result2 <- scanControllerResponseWithID(s2.read, 2) }()
+	sendReq(t, s1.write, 1, "custom/one", `{}`)
+	sendReq(t, s2.write, 2, "custom/two", `{}`)
+	for id, resultCh := range map[int]<-chan controllerResponseResult{1: result1, 2: result2} {
+		select {
+		case result := <-resultCh:
+			if result.err != nil {
+				t.Fatalf("response %d: %v", id, result.err)
+			}
+			assertResponseID(t, result.response, id)
+		case <-time.After(3 * time.Second):
+			t.Fatalf("response %d timed out", id)
+		}
+	}
+	if got := starts.Load(); got != 1 {
+		t.Fatalf("upstream starts = %d, want exactly 1", got)
+	}
+	if state := o.MaterializationState(); state != MaterializationReady {
+		t.Fatalf("materialization state = %s, want ready", state)
+	}
+}
+
+func TestCancellationRacingForwardingWritesRequestBeforeUpstreamCancel(t *testing.T) {
+	var orderMu sync.Mutex
+	var order []string
+	cancelSeen := make(chan struct{})
+	var cancelOnce sync.Once
+	handler := func(_ context.Context, stdin io.Reader, stdout io.Writer) error {
+		scanner := bufio.NewScanner(stdin)
+		for scanner.Scan() {
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+				return err
+			}
+			switch req.Method {
+			case "initialize":
+				if err := writeControllerResponse(stdout, req.ID, `{"protocolVersion":"2025-11-25","capabilities":{},"serverInfo":{"name":"order","version":"1"}}`); err != nil {
+					return err
+				}
+			case "tools/list":
+				if err := writeControllerResponse(stdout, req.ID, `{"tools":[]}`); err != nil {
+					return err
+				}
+			case "custom/order":
+				orderMu.Lock()
+				order = append(order, req.Method)
+				orderMu.Unlock()
+				if err := writeControllerResponse(stdout, req.ID, `{"ok":true}`); err != nil {
+					return err
+				}
+			case "notifications/cancelled":
+				orderMu.Lock()
+				order = append(order, req.Method)
+				orderMu.Unlock()
+				cancelOnce.Do(func() { close(cancelSeen) })
+			}
+		}
+		return scanner.Err()
+	}
+
+	o, err := NewOwnerFromSnapshot(OwnerConfig{
+		HandlerFunc:           handler,
+		IPCPath:               testIPCPath(t),
+		MaterializationPolicy: MaterializationOnDemand,
+		Logger:                testLogger(t),
+	}, controllerSnapshot())
+	if err != nil {
+		t.Fatalf("NewOwnerFromSnapshot: %v", err)
+	}
+	defer o.Shutdown()
+	s := newControllerTestSession(o)
+	defer s.close()
+	writeEntered := make(chan struct{})
+	releaseWrite := make(chan struct{})
+	cancelAttempted := make(chan struct{})
+	var writeOnce sync.Once
+	var attemptedOnce sync.Once
+	o.beforeQueuedDemandWrite = func() {
+		writeOnce.Do(func() { close(writeEntered) })
+		<-releaseWrite
+	}
+	o.beforeLocalDemandCancel = func() { attemptedOnce.Do(func() { close(cancelAttempted) }) }
+
+	sendReq(t, s.write, 41, "custom/order", `{}`)
+	select {
+	case <-writeEntered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("queued demand did not reach forwarding boundary")
+	}
+	if _, err := fmt.Fprintln(s.write, `{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":41}}`); err != nil {
+		t.Fatalf("write cancellation: %v", err)
+	}
+	select {
+	case <-cancelAttempted:
+	case <-time.After(time.Second):
+		t.Fatal("cancellation did not race the forwarding boundary")
+	}
+	close(releaseWrite)
+	result := scanControllerResponseWithID(s.read, 41)
+	if result.err != nil || !strings.Contains(string(result.response), `"ok":true`) {
+		t.Fatalf("forwarded request result: response=%s err=%v", result.response, result.err)
+	}
+	select {
+	case <-cancelSeen:
+	case <-time.After(time.Second):
+		t.Fatal("remapped cancellation did not reach upstream")
+	}
+	orderMu.Lock()
+	gotOrder := append([]string(nil), order...)
+	orderMu.Unlock()
+	if len(gotOrder) != 2 || gotOrder[0] != "custom/order" || gotOrder[1] != "notifications/cancelled" {
+		t.Fatalf("upstream order=%v, want request then cancellation", gotOrder)
+	}
+	waitForCondition(t, time.Second, func() bool { return o.Status()["pending_requests"] == int64(0) }, "forwarded request left pending residue")
+}
+
+func TestUnauthorizedWaiterRejectedAfterMaterialization(t *testing.T) {
+	var forwarded atomic.Int32
+	handler := func(_ context.Context, stdin io.Reader, stdout io.Writer) error {
+		scanner := bufio.NewScanner(stdin)
+		for scanner.Scan() {
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+				return err
+			}
+			switch req.Method {
+			case "initialize":
+				if err := writeControllerResponse(stdout, req.ID, `{"protocolVersion":"2025-11-25","capabilities":{},"serverInfo":{"name":"auth","version":"1"}}`); err != nil {
+					return err
+				}
+			case "tools/list":
+				if err := writeControllerResponse(stdout, req.ID, `{"tools":[]}`); err != nil {
+					return err
+				}
+			case "custom/unauthorized":
+				forwarded.Add(1)
+			}
+		}
+		return scanner.Err()
+	}
+
+	o, err := NewOwnerFromSnapshot(OwnerConfig{
+		HandlerFunc:           handler,
+		IPCPath:               testIPCPath(t),
+		MaterializationPolicy: MaterializationOnDemand,
+		AuthorizeSession: func(context.Context, muxcore.ConnInfo, muxcore.ProjectContext) muxcore.SessionAuth {
+			return muxcore.SessionAuth{Decision: muxcore.AuthAllow}
+		},
+		Logger: testLogger(t),
+	}, controllerSnapshot())
+	if err != nil {
+		t.Fatalf("NewOwnerFromSnapshot: %v", err)
+	}
+	defer o.Shutdown()
+	s := newControllerTestSession(o)
+	defer s.close()
+
+	sendReq(t, s.write, 51, "custom/unauthorized", `{}`)
+	result := scanControllerResponseWithID(s.read, 51)
+	if result.err != nil || !strings.Contains(string(result.response), "request no longer admitted") {
+		t.Fatalf("unauthorized waiter result: response=%s err=%v", result.response, result.err)
+	}
+	if got := forwarded.Load(); got != 0 {
+		t.Fatalf("unauthorized waiter forwarded %d times", got)
+	}
+	if status := o.Status(); status["pending_demand_count"] != 0 || status["pending_requests"] != int64(0) {
+		t.Fatalf("unauthorized waiter left residue: %#v", status)
+	}
+}
+
+func TestCancellationDuringMaterializationRemovesRemappedQueuedDemand(t *testing.T) {
+	initSeen := make(chan struct{})
+	releaseInit := make(chan struct{})
+	var forwarded atomic.Int32
+	var once sync.Once
+	handler := func(_ context.Context, stdin io.Reader, stdout io.Writer) error {
+		scanner := bufio.NewScanner(stdin)
+		for scanner.Scan() {
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+				return err
+			}
+			switch req.Method {
+			case "initialize":
+				once.Do(func() { close(initSeen) })
+				<-releaseInit
+				if err := writeControllerResponse(stdout, req.ID, `{"protocolVersion":"2025-11-25","capabilities":{},"serverInfo":{"name":"live","version":"1"}}`); err != nil {
+					return err
+				}
+			case "tools/list":
+				if err := writeControllerResponse(stdout, req.ID, `{"tools":[]}`); err != nil {
+					return err
+				}
+			case "custom/slow":
+				forwarded.Add(1)
+				if err := writeControllerResponse(stdout, req.ID, `{"unexpected":true}`); err != nil {
+					return err
+				}
+			}
+		}
+		return scanner.Err()
+	}
+
+	o, err := NewOwnerFromSnapshot(OwnerConfig{
+		HandlerFunc:           handler,
+		IPCPath:               testIPCPath(t),
+		MaterializationPolicy: MaterializationOnDemand,
+		Logger:                testLogger(t),
+	}, controllerSnapshot())
+	if err != nil {
+		t.Fatalf("NewOwnerFromSnapshot: %v", err)
+	}
+	defer o.Shutdown()
+	s := newControllerTestSession(o)
+	defer s.close()
+
+	sendReq(t, s.write, 7, "custom/slow", `{}`)
+	select {
+	case <-initSeen:
+	case <-time.After(time.Second):
+		t.Fatal("materialization did not reach initialize")
+	}
+	expectedKey := string(remap.Remap(s.session.ID, json.RawMessage(`7`)))
+	o.materializationMu.Lock()
+	_, queuedByRemappedID := o.pendingDemands[expectedKey]
+	o.materializationMu.Unlock()
+	if !queuedByRemappedID {
+		t.Fatalf("queued demand missing remapped key %q", expectedKey)
+	}
+	if _, err := fmt.Fprintln(s.write, `{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":7}}`); err != nil {
+		t.Fatalf("write cancellation: %v", err)
+	}
+	waitForCondition(t, time.Second, func() bool { return o.Status()["pending_demand_count"] == 0 }, "cancelled remapped demand remained queued")
+	responseCh := make(chan controllerResponseResult, 1)
+	go func() { responseCh <- scanControllerResponseWithID(s.read, 7) }()
+	select {
+	case result := <-responseCh:
+		t.Fatalf("cancelled local demand produced terminal read: response=%s err=%v", result.response, result.err)
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	close(releaseInit)
+	waitForCondition(t, 2*time.Second, func() bool { return o.MaterializationState() == MaterializationReady }, "materialization did not finish")
+	select {
+	case result := <-responseCh:
+		t.Fatalf("cancelled demand produced late terminal read after readiness: response=%s err=%v", result.response, result.err)
+	case <-time.After(150 * time.Millisecond):
+	}
+	if got := forwarded.Load(); got != 0 {
+		t.Fatalf("cancelled demand forwarded %d times, want 0", got)
+	}
+}
+
+func TestTimedOutDemandNeverForwardsWhileLaterWaiterContinues(t *testing.T) {
+	originalTimeout := materializationDemandTimeout
+	materializationDemandTimeout = 120 * time.Millisecond
+	t.Cleanup(func() { materializationDemandTimeout = originalTimeout })
+
+	initSeen := make(chan struct{})
+	releaseInit := make(chan struct{})
+	var starts atomic.Int32
+	var forwardedOne atomic.Int32
+	var forwardedTwo atomic.Int32
+	var once sync.Once
+	handler := func(_ context.Context, stdin io.Reader, stdout io.Writer) error {
+		starts.Add(1)
+		scanner := bufio.NewScanner(stdin)
+		for scanner.Scan() {
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+				return err
+			}
+			switch req.Method {
+			case "initialize":
+				once.Do(func() { close(initSeen) })
+				<-releaseInit
+				if err := writeControllerResponse(stdout, req.ID, `{"protocolVersion":"2025-11-25","capabilities":{},"serverInfo":{"name":"live","version":"1"}}`); err != nil {
+					return err
+				}
+			case "tools/list":
+				if err := writeControllerResponse(stdout, req.ID, `{"tools":[]}`); err != nil {
+					return err
+				}
+			case "custom/one":
+				forwardedOne.Add(1)
+				if err := writeControllerResponse(stdout, req.ID, `{"one":true}`); err != nil {
+					return err
+				}
+			case "custom/two":
+				forwardedTwo.Add(1)
+				if err := writeControllerResponse(stdout, req.ID, `{"two":true}`); err != nil {
+					return err
+				}
+			}
+		}
+		return scanner.Err()
+	}
+
+	o, err := NewOwnerFromSnapshot(OwnerConfig{
+		HandlerFunc:           handler,
+		IPCPath:               testIPCPath(t),
+		MaterializationPolicy: MaterializationOnDemand,
+		Logger:                testLogger(t),
+	}, controllerSnapshot())
+	if err != nil {
+		t.Fatalf("NewOwnerFromSnapshot: %v", err)
+	}
+	defer o.Shutdown()
+	s := newControllerTestSession(o)
+	defer s.close()
+
+	sendReq(t, s.write, 1, "custom/one", `{}`)
+	select {
+	case <-initSeen:
+	case <-time.After(time.Second):
+		t.Fatal("materialization did not reach initialize")
+	}
+	time.Sleep(70 * time.Millisecond)
+	sendReq(t, s.write, 2, "custom/two", `{}`)
+
+	first := scanControllerResponseWithID(s.read, 1)
+	if first.err != nil || !strings.Contains(string(first.response), "materialization timed out") {
+		t.Fatalf("first waiter result: response=%s err=%v", first.response, first.err)
+	}
+	close(releaseInit)
+	second := scanControllerResponseWithID(s.read, 2)
+	if second.err != nil || !strings.Contains(string(second.response), `"two":true`) {
+		t.Fatalf("second waiter result: response=%s err=%v", second.response, second.err)
+	}
+	if got := starts.Load(); got != 1 {
+		t.Fatalf("upstream starts=%d, want 1 shared controller", got)
+	}
+	if got := forwardedOne.Load(); got != 0 {
+		t.Fatalf("timed-out demand forwarded %d times", got)
+	}
+	if got := forwardedTwo.Load(); got != 1 {
+		t.Fatalf("later demand forwarded %d times, want 1", got)
+	}
+	if status := o.Status(); status["pending_demand_count"] != 0 {
+		t.Fatalf("pending demand residue: %#v", status)
+	}
+}
+
+func TestMaterializationDiagnosticsDoNotExposeRawEnvValues(t *testing.T) {
+	originalTimeout := materializationDemandTimeout
+	materializationDemandTimeout = 120 * time.Millisecond
+	t.Cleanup(func() { materializationDemandTimeout = originalTimeout })
+
+	const secret = "diagnostic-secret-value"
+	var logs bytes.Buffer
+	o, err := NewOwnerFromSnapshot(OwnerConfig{
+		Command:               "",
+		IPCPath:               testIPCPath(t),
+		MaterializationPolicy: MaterializationOnDemand,
+		Logger:                log.New(&logs, "", 0),
+	}, controllerSnapshot())
+	if err != nil {
+		t.Fatalf("NewOwnerFromSnapshot: %v", err)
+	}
+	defer o.Shutdown()
+	s := newControllerTestSession(o)
+	defer s.close()
+	s.session.Cwd = "/project/redaction"
+	s.session.Env = map[string]string{"GITHUB_TOKEN": secret}
+
+	sendReq(t, s.write, 1, "custom/redact", `{}`)
+	result := scanControllerResponseWithID(s.read, 1)
+	if result.err != nil || !strings.Contains(string(result.response), "materialization timed out") {
+		t.Fatalf("materialization result: response=%s err=%v", result.response, result.err)
+	}
+	diagnostics := logs.String() + fmt.Sprintf("%#v", o.Status())
+	if strings.Contains(diagnostics, secret) {
+		t.Fatalf("raw env value leaked in diagnostics: %s", diagnostics)
+	}
+}
+
+func TestLaunchContextPinnedAndIncompatibleWaiterRejected(t *testing.T) {
+	initSeen := make(chan struct{})
+	releaseInit := make(chan struct{})
+	var once sync.Once
+	handler := func(_ context.Context, stdin io.Reader, stdout io.Writer) error {
+		scanner := bufio.NewScanner(stdin)
+		for scanner.Scan() {
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+				return err
+			}
+			switch req.Method {
+			case "initialize":
+				once.Do(func() { close(initSeen) })
+				<-releaseInit
+				if err := writeControllerResponse(stdout, req.ID, `{"protocolVersion":"2025-11-25","capabilities":{},"serverInfo":{"name":"live","version":"1"}}`); err != nil {
+					return err
+				}
+			case "tools/list":
+				if err := writeControllerResponse(stdout, req.ID, `{"tools":[]}`); err != nil {
+					return err
+				}
+			case "custom/run":
+				if err := writeControllerResponse(stdout, req.ID, `{"ok":true}`); err != nil {
+					return err
+				}
+			}
+		}
+		return scanner.Err()
+	}
+
+	o, err := NewOwnerFromSnapshot(OwnerConfig{
+		HandlerFunc:           handler,
+		IPCPath:               testIPCPath(t),
+		MaterializationPolicy: MaterializationOnDemand,
+		Logger:                testLogger(t),
+	}, controllerSnapshot())
+	if err != nil {
+		t.Fatalf("NewOwnerFromSnapshot: %v", err)
+	}
+	defer o.Shutdown()
+	first := newControllerTestSession(o)
+	defer first.close()
+	first.session.Cwd = "/project/first"
+	first.session.Env = map[string]string{"GITHUB_TOKEN": "first-secret"}
+	second := newControllerTestSession(o)
+	defer second.close()
+	second.session.Cwd = "/project/second"
+	second.session.Env = map[string]string{"GITHUB_TOKEN": "second-secret"}
+
+	sendReq(t, first.write, 1, "custom/run", `{}`)
+	select {
+	case <-initSeen:
+	case <-time.After(time.Second):
+		t.Fatal("materialization did not reach initialize")
+	}
+	first.session.Env["GITHUB_TOKEN"] = "mutated-after-start"
+	sendReq(t, second.write, 2, "custom/run", `{}`)
+	rejected := scanControllerResponseWithID(second.read, 2)
+	if rejected.err != nil || !strings.Contains(string(rejected.response), "context incompatible") {
+		t.Fatalf("incompatible waiter result: response=%s err=%v", rejected.response, rejected.err)
+	}
+
+	o.materializationMu.Lock()
+	launch := o.materializationAttempt.launch
+	o.materializationMu.Unlock()
+	if launch.SessionID != first.session.ID || launch.Env["GITHUB_TOKEN"] != "first-secret" {
+		t.Fatalf("pinned launch context mutated: %+v", launch)
+	}
+	first.session.Env["GITHUB_TOKEN"] = "first-secret"
+	close(releaseInit)
+	accepted := scanControllerResponseWithID(first.read, 1)
+	if accepted.err != nil || !strings.Contains(string(accepted.response), `"ok":true`) {
+		t.Fatalf("initiating waiter result: response=%s err=%v", accepted.response, accepted.err)
+	}
+}
+
+func TestZeroSessionsCancelDisposableMaterialization(t *testing.T) {
+	initSeen := make(chan struct{})
+	handlerExited := make(chan struct{})
+	var initOnce sync.Once
+	var exitOnce sync.Once
+	var starts atomic.Int32
+	handler := func(_ context.Context, stdin io.Reader, _ io.Writer) error {
+		starts.Add(1)
+		defer exitOnce.Do(func() { close(handlerExited) })
+		scanner := bufio.NewScanner(stdin)
+		for scanner.Scan() {
+			var req struct {
+				Method string `json:"method"`
+			}
+			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+				return err
+			}
+			if req.Method == "initialize" {
+				initOnce.Do(func() { close(initSeen) })
+			}
+		}
+		return scanner.Err()
+	}
+
+	o, err := NewOwnerFromSnapshot(OwnerConfig{
+		HandlerFunc:           handler,
+		IPCPath:               testIPCPath(t),
+		MaterializationPolicy: MaterializationOnDemand,
+		Logger:                testLogger(t),
+	}, controllerSnapshot())
+	if err != nil {
+		t.Fatalf("NewOwnerFromSnapshot: %v", err)
+	}
+	defer o.Shutdown()
+	s := newControllerTestSession(o)
+	sendReq(t, s.write, 31, "custom/disconnect", `{}`)
+	select {
+	case <-initSeen:
+	case <-time.After(time.Second):
+		t.Fatal("materialization did not reach initialize")
+	}
+	s.close()
+	select {
+	case <-handlerExited:
+	case <-time.After(2 * time.Second):
+		t.Fatal("zero-session materialization process did not finalize")
+	}
+	waitForCondition(t, time.Second, func() bool {
+		o.materializationMu.Lock()
+		defer o.materializationMu.Unlock()
+		return o.materializationAttempt == nil && o.materializationState == MaterializationCacheOnly && len(o.pendingDemands) == 0
+	}, "zero-session materialization did not return to clean cache-only state")
+	if got := starts.Load(); got != 1 {
+		t.Fatalf("zero-session cancellation started %d generations, want 1", got)
+	}
+}
+
+func TestFailureOnlyTerminatesItsGenerationDemands(t *testing.T) {
+	oldMessage, err := jsonrpc.Parse([]byte(`{"jsonrpc":"2.0","id":1,"method":"custom/old","params":{}}`))
+	if err != nil {
+		t.Fatalf("parse old message: %v", err)
+	}
+	newMessage, err := jsonrpc.Parse([]byte(`{"jsonrpc":"2.0","id":2,"method":"custom/new","params":{}}`))
+	if err != nil {
+		t.Fatalf("parse new message: %v", err)
+	}
+	var oldResponse bytes.Buffer
+	var newResponse bytes.Buffer
+	oldSession := NewSessionWithRawWriter(1, &oldResponse)
+	newSession := NewSessionWithRawWriter(2, &newResponse)
+	oldAttempt := newMaterializationAttempt(1, MaterializationTriggerDemand)
+	newAttempt := newMaterializationAttempt(2, MaterializationTriggerDemand)
+	o := &Owner{
+		logger:                 testLogger(t),
+		materializationStop:    make(chan struct{}),
+		materializationState:   MaterializationMaterializing,
+		materializationAttempt: newAttempt,
+		pendingDemands: map[string]*localDemand{
+			"old": {key: "old", session: oldSession, message: oldMessage, state: localDemandWaiting, generation: 1},
+			"new": {key: "new", session: newSession, message: newMessage, state: localDemandWaiting, generation: 2},
+		},
+		pendingDemandOrder: []string{"old", "new"},
+	}
+
+	o.finishMaterializationFailure(oldAttempt, errors.New("old generation failed"))
+
+	o.materializationMu.Lock()
+	_, oldPending := o.pendingDemands["old"]
+	newDemand := o.pendingDemands["new"]
+	current := o.materializationAttempt
+	order := append([]string(nil), o.pendingDemandOrder...)
+	o.materializationMu.Unlock()
+	if oldPending || newDemand == nil || current != newAttempt {
+		t.Fatalf("generation cleanup crossed attempts: old=%v new=%+v current=%p want=%p", oldPending, newDemand, current, newAttempt)
+	}
+	if len(order) != 1 || order[0] != "new" {
+		t.Fatalf("pending order = %v, want [new]", order)
+	}
+	if !strings.Contains(oldResponse.String(), "old generation failed") {
+		t.Fatalf("old generation did not receive failure: %s", oldResponse.String())
+	}
+	if newResponse.Len() != 0 {
+		t.Fatalf("new generation received stale failure: %s", newResponse.String())
+	}
+}
+
+func TestAcquireRestartPinCancelsMaterializationAndFreezesSnapshot(t *testing.T) {
+	initSeen := make(chan struct{})
+	var starts atomic.Int32
+	var once sync.Once
+	handler := func(_ context.Context, stdin io.Reader, _ io.Writer) error {
+		starts.Add(1)
+		scanner := bufio.NewScanner(stdin)
+		for scanner.Scan() {
+			var req struct {
+				Method string `json:"method"`
+			}
+			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+				return err
+			}
+			if req.Method == "initialize" {
+				once.Do(func() { close(initSeen) })
+			}
+		}
+		return scanner.Err()
+	}
+
+	o, err := NewOwnerFromSnapshot(OwnerConfig{
+		HandlerFunc:           handler,
+		IPCPath:               testIPCPath(t),
+		MaterializationPolicy: MaterializationOnDemand,
+		Logger:                testLogger(t),
+	}, controllerSnapshot())
+	if err != nil {
+		t.Fatalf("NewOwnerFromSnapshot: %v", err)
+	}
+	defer o.Shutdown()
+	s := newControllerTestSession(o)
+	defer s.close()
+	s.session.Cwd = "/project/restart"
+	s.session.Env = map[string]string{"GITHUB_TOKEN": "restart-secret"}
+
+	sendReq(t, s.write, 1, "custom/wait", `{}`)
+	select {
+	case <-initSeen:
+	case <-time.After(time.Second):
+		t.Fatal("materialization did not reach initialize")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	pin, err := o.AcquireRestartPin(ctx)
+	if err != nil {
+		t.Fatalf("AcquireRestartPin: %v", err)
+	}
+	if pin.Snapshot.Cwd != "/project/restart" || pin.Snapshot.Env["GITHUB_TOKEN"] != "restart-secret" {
+		t.Fatalf("restart snapshot lost launch context: %+v", pin.Snapshot)
+	}
+	if pin.Snapshot.CachedInit == "" || pin.Snapshot.CachedTools == "" || len(pin.Sessions) != 1 {
+		t.Fatalf("restart snapshot lost cache/session state: snapshot=%+v sessions=%+v", pin.Snapshot, pin.Sessions)
+	}
+	if state := o.MaterializationState(); state != MaterializationCacheOnly {
+		t.Fatalf("materialization state=%s, want cache_only", state)
+	}
+	if !o.MaterializationBlocksEviction() || o.Status()["restart_pin_count"] != int64(1) {
+		t.Fatalf("restart pin did not block eviction: %#v", o.Status())
+	}
+
+	sendReq(t, s.write, 2, "custom/during-restart", `{}`)
+	first := scanControllerResponseWithID(s.read, 1)
+	if first.err != nil || !strings.Contains(string(first.response), "cancelled for restart") {
+		t.Fatalf("cancelled demand result: response=%s err=%v", first.response, first.err)
+	}
+	second := scanControllerResponseWithID(s.read, 2)
+	if second.err != nil || !strings.Contains(string(second.response), "restart snapshot in progress") {
+		t.Fatalf("pinned demand result: response=%s err=%v", second.response, second.err)
+	}
+	pin.Release()
+	if o.Status()["restart_pin_count"] != int64(0) {
+		t.Fatalf("restart pin leaked: %#v", o.Status())
+	}
+	waitForCondition(t, time.Second, func() bool { return starts.Load() == 2 }, "pin release did not resume the cancelled materialization obligation")
+	time.Sleep(50 * time.Millisecond)
+	if got := starts.Load(); got != 2 {
+		t.Fatalf("pin release started %d generations, want exactly 2 total", got)
+	}
+}
+
+func TestUnprovenFinalizationBlocksReplacementGeneration(t *testing.T) {
+	var starts atomic.Int32
+	handler := func(_ context.Context, stdin io.Reader, stdout io.Writer) error {
+		starts.Add(1)
+		scanner := bufio.NewScanner(stdin)
+		if !scanner.Scan() {
+			return scanner.Err()
+		}
+		var req struct {
+			ID json.RawMessage `json:"id"`
+		}
+		if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+			return err
+		}
+		if err := writeControllerResponse(stdout, req.ID, `{"protocolVersion":"2025-11-25","capabilities":{},"serverInfo":{"name":"crash","version":"1"}}`); err != nil {
+			return err
+		}
+		return errors.New("synthetic exit before discovery")
+	}
+
+	o, err := NewOwnerFromSnapshot(OwnerConfig{
+		HandlerFunc:           handler,
+		IPCPath:               testIPCPath(t),
+		MaterializationPolicy: MaterializationOnDemand,
+		Logger:                testLogger(t),
+	}, controllerSnapshot())
+	if err != nil {
+		t.Fatalf("NewOwnerFromSnapshot: %v", err)
+	}
+	defer o.Shutdown()
+	o.materializationFinalizationProbe = func(*upstream.Process) error {
+		return errors.New("synthetic process-tree finalization unproven")
+	}
+	s := newControllerTestSession(o)
+	defer s.close()
+
+	sendReq(t, s.write, 1, "custom/first", `{}`)
+	first := scanControllerResponseWithID(s.read, 1)
+	if first.err != nil || !strings.Contains(string(first.response), "finalization unproven") {
+		t.Fatalf("first demand result: response=%s err=%v", first.response, first.err)
+	}
+	waitForCondition(t, time.Second, func() bool { return o.MaterializationState() == MaterializationFinalizeBlocked }, "owner did not enter finalize_blocked")
+	sendReq(t, s.write, 2, "custom/second", `{}`)
+	second := scanControllerResponseWithID(s.read, 2)
+	if second.err != nil || !strings.Contains(string(second.response), "finalization unproven") {
+		t.Fatalf("blocked demand result: response=%s err=%v", second.response, second.err)
+	}
+	if got := starts.Load(); got != 1 {
+		t.Fatalf("replacement generation started %d upstreams, want 1", got)
+	}
+	status := o.Status()
+	if status["finalization_error"] == "" || !o.MaterializationBlocksEviction() {
+		t.Fatalf("finalization block not observable/protected: %#v", status)
+	}
+}
+
+func TestLaterProcessExitClearsRecoverableFinalizationBlock(t *testing.T) {
+	proc := upstream.NewProcessFromHandler(context.Background(), func(context.Context, io.Reader, io.Writer) error {
+		return nil
+	})
+	select {
+	case <-proc.Done:
+	case <-time.After(time.Second):
+		t.Fatal("fixture process did not exit")
+	}
+	o := &Owner{
+		upstream:                  proc,
+		logger:                    testLogger(t),
+		initResp:                  []byte(`{"jsonrpc":"2.0","id":1,"result":{}}`),
+		sessionMgr:                NewSessionManager(),
+		materializationStop:       make(chan struct{}),
+		materializationState:      MaterializationFinalizeBlocked,
+		materializationBlockedErr: fmt.Errorf("%w after timeout", errFinalizationUnproven),
+		retiringProcess:           proc,
+		pendingDemands:            make(map[string]*localDemand),
+	}
+
+	o.monitorMaterializedProcessExit(proc)
+
+	if state := o.MaterializationState(); state != MaterializationCacheOnly {
+		t.Fatalf("materialization state = %s, want cache_only after late retirement proof", state)
+	}
+	if o.currentUpstream() != nil || o.MaterializationBlocksEviction() {
+		t.Fatalf("late retirement proof did not clear authority/block: status=%#v", o.Status())
+	}
+}
+
+func TestFreshIsolatedClassificationRetainsInitiatingSession(t *testing.T) {
+	initSeen := make(chan struct{})
+	releaseInit := make(chan struct{})
+	var once sync.Once
+	var highForwarded atomic.Int32
+	var lowForwarded atomic.Int32
+	handler := func(_ context.Context, stdin io.Reader, stdout io.Writer) error {
+		scanner := bufio.NewScanner(stdin)
+		for scanner.Scan() {
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+				return err
+			}
+			switch req.Method {
+			case "initialize":
+				once.Do(func() { close(initSeen) })
+				<-releaseInit
+				if err := writeControllerResponse(stdout, req.ID, `{"protocolVersion":"2025-11-25","capabilities":{"x-mux":{"sharing":"isolated"}},"serverInfo":{"name":"live","version":"1"}}`); err != nil {
+					return err
+				}
+			case "tools/list":
+				if err := writeControllerResponse(stdout, req.ID, `{"tools":[]}`); err != nil {
+					return err
+				}
+			case "custom/high":
+				highForwarded.Add(1)
+				if err := writeControllerResponse(stdout, req.ID, `{"high":true}`); err != nil {
+					return err
+				}
+			case "custom/low":
+				lowForwarded.Add(1)
+				if err := writeControllerResponse(stdout, req.ID, `{"low":true}`); err != nil {
+					return err
+				}
+			}
+		}
+		return scanner.Err()
+	}
+
+	o, err := NewOwnerFromSnapshot(OwnerConfig{
+		HandlerFunc:           handler,
+		IPCPath:               testIPCPath(t),
+		MaterializationPolicy: MaterializationOnDemand,
+		Logger:                testLogger(t),
+	}, controllerSnapshot())
+	if err != nil {
+		t.Fatalf("NewOwnerFromSnapshot: %v", err)
+	}
+	defer o.Shutdown()
+	low := newControllerTestSession(o)
+	defer low.close()
+	low.session.Cwd = "/project/low"
+	low.session.Env = map[string]string{"GITHUB_TOKEN": "same"}
+	high := newControllerTestSession(o)
+	defer high.close()
+	high.session.Cwd = "/project/high"
+	high.session.Env = map[string]string{"GITHUB_TOKEN": "same"}
+
+	sendReq(t, high.write, 9, "custom/high", `{}`)
+	select {
+	case <-initSeen:
+	case <-time.After(time.Second):
+		t.Fatal("materialization did not reach initialize")
+	}
+	sendReq(t, low.write, 8, "custom/low", `{}`)
+	close(releaseInit)
+	highResult := scanControllerResponseWithID(high.read, 9)
+	if highResult.err != nil || !strings.Contains(string(highResult.response), `"high":true`) {
+		t.Fatalf("initiating session result: response=%s err=%v", highResult.response, highResult.err)
+	}
+	waitForCondition(t, time.Second, func() bool {
+		select {
+		case <-low.session.Done():
+			return true
+		default:
+			return false
+		}
+	}, "non-initiating session was not evicted")
+	select {
+	case <-high.session.Done():
+		t.Fatal("initiating higher-ID session was evicted")
+	default:
+	}
+	if got := highForwarded.Load(); got != 1 {
+		t.Fatalf("initiating demand forwarded %d times, want 1", got)
+	}
+	if got := lowForwarded.Load(); got != 0 {
+		t.Fatalf("evicted demand forwarded %d times, want 0", got)
+	}
+	snapshot := o.ExportSnapshot()
+	if snapshot.Cwd != "/project/high" || snapshot.Classification != "isolated" {
+		t.Fatalf("committed initiating context/classification = %+v", snapshot)
+	}
+}
+
+func TestMaterializationIsolatedCommitRevokesTokenDuringAuthorization(t *testing.T) {
+	toolsSeen := make(chan struct{})
+	releaseTools := make(chan struct{})
+	authSeen := make(chan struct{})
+	releaseAuth := make(chan struct{})
+	var toolsOnce sync.Once
+	var authOnce sync.Once
+	var releaseToolsOnce sync.Once
+	var releaseAuthOnce sync.Once
+	defer releaseToolsOnce.Do(func() { close(releaseTools) })
+	defer releaseAuthOnce.Do(func() { close(releaseAuth) })
+
+	handler := func(_ context.Context, stdin io.Reader, stdout io.Writer) error {
+		scanner := bufio.NewScanner(stdin)
+		for scanner.Scan() {
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+				return err
+			}
+			switch req.Method {
+			case "initialize":
+				if err := writeControllerResponse(stdout, req.ID, `{"protocolVersion":"2025-11-25","capabilities":{"x-mux":{"sharing":"isolated"}},"serverInfo":{"name":"live","version":"1"}}`); err != nil {
+					return err
+				}
+			case "tools/list":
+				toolsOnce.Do(func() { close(toolsSeen) })
+				<-releaseTools
+				if err := writeControllerResponse(stdout, req.ID, `{"tools":[]}`); err != nil {
+					return err
+				}
+			case "custom/wake":
+				if err := writeControllerResponse(stdout, req.ID, `{"ok":true}`); err != nil {
+					return err
+				}
+			}
+		}
+		return scanner.Err()
+	}
+
+	o, err := NewOwnerFromSnapshot(OwnerConfig{
+		HandlerFunc:           handler,
+		IPCPath:               testIPCPath(t),
+		ServerID:              "isolated-auth-race",
+		TokenHandshake:        true,
+		MaterializationPolicy: MaterializationOnDemand,
+		AuthorizeSession: func(_ context.Context, _ muxcore.ConnInfo, project muxcore.ProjectContext) muxcore.SessionAuth {
+			if project.Cwd != "/project/extra" {
+				t.Errorf("authorization cwd = %q, want pending context", project.Cwd)
+			}
+			authOnce.Do(func() { close(authSeen) })
+			<-releaseAuth
+			return muxcore.SessionAuth{Decision: muxcore.AuthAllow}
+		},
+		Logger: testLogger(t),
+	}, controllerSnapshot())
+	if err != nil {
+		t.Fatalf("NewOwnerFromSnapshot: %v", err)
+	}
+	defer o.Shutdown()
+	initiator := newControllerTestSession(o)
+	defer initiator.close()
+	initiator.session.Cwd = "/project/initiator"
+
+	const token = "deadbeef"
+	if !o.PreRegister(token, "/project/extra", map[string]string{"PROJECT": "extra"}) {
+		t.Fatal("extra token preregistration rejected before isolation")
+	}
+	response := make(chan controllerResponseResult, 1)
+	go func() { response <- scanControllerResponseWithID(initiator.read, 77) }()
+	sendReq(t, initiator.write, 77, "custom/wake", `{}`)
+	select {
+	case <-toolsSeen:
+	case <-time.After(time.Second):
+		t.Fatal("materialization did not reach tools/list")
+	}
+
+	conn := connectWithToken(t, o.IPCPath(), token)
+	defer conn.Close()
+	select {
+	case <-authSeen:
+	case <-time.After(time.Second):
+		t.Fatal("authorization callback did not start")
+	}
+	releaseToolsOnce.Do(func() { close(releaseTools) })
+	if result := <-response; result.err != nil {
+		t.Fatalf("initiating demand: %v", result.err)
+	}
+	waitForCondition(t, time.Second, func() bool {
+		return o.MaterializationState() == MaterializationReady && o.IsClassifiedIsolated()
+	}, "isolated generation did not commit")
+	if got := o.SessionMgr().PendingCount(); got != 0 {
+		t.Fatalf("pending tokens after isolated commit = %d, want 0", got)
+	}
+	if got := o.SessionCount(); got != 1 {
+		t.Fatalf("sessions at isolated commit = %d, want initiator only", got)
+	}
+	select {
+	case <-initiator.session.Done():
+		t.Fatal("isolated commit evicted initiating session")
+	default:
+	}
+
+	releaseAuthOnce.Do(func() { close(releaseAuth) })
+	if err := conn.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
+		t.Fatalf("set rejection deadline: %v", err)
+	}
+	if _, err := conn.Read(make([]byte, 1)); err == nil {
+		t.Fatal("revoked authorization connection remained open")
+	}
+	waitForCondition(t, time.Second, func() bool { return o.SessionCount() == 1 }, "revoked authorization added a session")
+	probe := NewSession(strings.NewReader(""), io.Discard)
+	defer probe.Close()
+	if o.SessionMgr().Bind(token, o.ServerID(), probe) {
+		t.Fatal("revoked token remained bindable after authorization returned")
+	}
+}
+
+func TestFreshIsolatedClassificationFinalizesWhenInitiatorDisconnects(t *testing.T) {
+	initSeen := make(chan struct{})
+	releaseFirstInit := make(chan struct{})
+	var initOnce sync.Once
+	var starts atomic.Int32
+	var lowForwarded atomic.Int32
+	handler := func(_ context.Context, stdin io.Reader, stdout io.Writer) error {
+		generation := starts.Add(1)
+		scanner := bufio.NewScanner(stdin)
+		for scanner.Scan() {
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+				return err
+			}
+			switch req.Method {
+			case "initialize":
+				if generation == 1 {
+					initOnce.Do(func() { close(initSeen) })
+					<-releaseFirstInit
+				}
+				if err := writeControllerResponse(stdout, req.ID, `{"protocolVersion":"2025-11-25","capabilities":{"x-mux":{"sharing":"isolated"}},"serverInfo":{"name":"live","version":"1"}}`); err != nil {
+					return err
+				}
+			case "tools/list":
+				if err := writeControllerResponse(stdout, req.ID, `{"tools":[]}`); err != nil {
+					return err
+				}
+			case "custom/low":
+				lowForwarded.Add(1)
+				if err := writeControllerResponse(stdout, req.ID, `{"low":true}`); err != nil {
+					return err
+				}
+			}
+		}
+		return scanner.Err()
+	}
+
+	o, err := NewOwnerFromSnapshot(OwnerConfig{
+		HandlerFunc:           handler,
+		IPCPath:               testIPCPath(t),
+		MaterializationPolicy: MaterializationOnDemand,
+		Logger:                testLogger(t),
+	}, controllerSnapshot())
+	if err != nil {
+		t.Fatalf("NewOwnerFromSnapshot: %v", err)
+	}
+	defer o.Shutdown()
+	low := newControllerTestSession(o)
+	defer low.close()
+	low.session.Cwd = "/project/low"
+	low.session.Env = map[string]string{"GITHUB_TOKEN": "same"}
+	high := newControllerTestSession(o)
+	defer high.close()
+	high.session.Cwd = "/project/high"
+	high.session.Env = map[string]string{"GITHUB_TOKEN": "same"}
+
+	sendReq(t, high.write, 9, "custom/high", `{}`)
+	select {
+	case <-initSeen:
+	case <-time.After(time.Second):
+		t.Fatal("materialization did not reach initialize")
+	}
+	sendReq(t, low.write, 8, "custom/low", `{}`)
+	high.close()
+	waitForCondition(t, time.Second, func() bool { return o.SessionCount() == 1 }, "initiating session did not disconnect")
+	close(releaseFirstInit)
+
+	firstLow := scanControllerResponseWithID(low.read, 8)
+	if firstLow.err != nil || !strings.Contains(string(firstLow.response), "initiator disconnected") {
+		t.Fatalf("non-initiating waiter result: response=%s err=%v", firstLow.response, firstLow.err)
+	}
+	if got := lowForwarded.Load(); got != 0 {
+		t.Fatalf("first isolated generation forwarded %d non-initiating demands", got)
+	}
+	select {
+	case <-low.session.Done():
+		t.Fatal("non-initiating session was rebound to the departed context and evicted")
+	default:
+	}
+	waitForCondition(t, time.Second, func() bool {
+		return o.MaterializationState() == MaterializationCacheOnly
+	}, "departed initiator generation did not finalize to cache-only")
+
+	sendReq(t, low.write, 10, "custom/low", `{}`)
+	secondLow := scanControllerResponseWithID(low.read, 10)
+	if secondLow.err != nil || !strings.Contains(string(secondLow.response), `"low":true`) {
+		t.Fatalf("fresh low-context generation result: response=%s err=%v", secondLow.response, secondLow.err)
+	}
+	if got := starts.Load(); got != 2 {
+		t.Fatalf("upstream starts = %d, want one finalized generation plus one fresh generation", got)
+	}
+	if got := lowForwarded.Load(); got != 1 {
+		t.Fatalf("fresh low-context demand forwarded %d times, want 1", got)
+	}
+	snapshot := o.ExportSnapshot()
+	if snapshot.Cwd != "/project/low" || snapshot.Classification != "isolated" {
+		t.Fatalf("fresh generation committed wrong context: %+v", snapshot)
+	}
+}
+
+func TestUpstreamExitDuringQueuedDemandRetriesSameController(t *testing.T) {
+	var starts atomic.Int32
+	handler := func(_ context.Context, stdin io.Reader, stdout io.Writer) error {
+		generation := starts.Add(1)
+		scanner := bufio.NewScanner(stdin)
+		for scanner.Scan() {
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+				return err
+			}
+			if generation == 1 && req.Method == "initialize" {
+				return errors.New("first generation exits during initialize")
+			}
+			switch req.Method {
+			case "initialize":
+				if err := writeControllerResponse(stdout, req.ID, `{"protocolVersion":"2025-11-25","capabilities":{},"serverInfo":{"name":"retry","version":"2"}}`); err != nil {
+					return err
+				}
+			case "tools/list":
+				if err := writeControllerResponse(stdout, req.ID, `{"tools":[]}`); err != nil {
+					return err
+				}
+			case "custom/retry":
+				if err := writeControllerResponse(stdout, req.ID, `{"generation":2}`); err != nil {
+					return err
+				}
+			}
+		}
+		return scanner.Err()
+	}
+
+	o, err := NewOwnerFromSnapshot(OwnerConfig{
+		HandlerFunc:           handler,
+		IPCPath:               testIPCPath(t),
+		MaterializationPolicy: MaterializationOnDemand,
+		Logger:                testLogger(t),
+	}, controllerSnapshot())
+	if err != nil {
+		t.Fatalf("NewOwnerFromSnapshot: %v", err)
+	}
+	defer o.Shutdown()
+	s := newControllerTestSession(o)
+	defer s.close()
+
+	sendReq(t, s.write, 9, "custom/retry", `{}`)
+	resp := readRespWithID(t, s.read, 9)
+	assertResponseID(t, resp, 9)
+	if !strings.Contains(string(resp), `"generation":2`) {
+		t.Fatalf("retry response = %s", resp)
+	}
+	if got := starts.Load(); got != 2 {
+		t.Fatalf("upstream generations = %d, want 2", got)
+	}
+}
+
+func TestCacheRefreshCommitsAtomically(t *testing.T) {
+	toolsRequested := make(chan struct{})
+	releaseTools := make(chan struct{})
+	var toolsOnce sync.Once
+	handler := func(_ context.Context, stdin io.Reader, stdout io.Writer) error {
+		scanner := bufio.NewScanner(stdin)
+		for scanner.Scan() {
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+				return err
+			}
+			switch req.Method {
+			case "initialize":
+				if err := writeControllerResponse(stdout, req.ID, `{"protocolVersion":"2025-11-25","capabilities":{},"serverInfo":{"name":"new","version":"2"}}`); err != nil {
+					return err
+				}
+			case "tools/list":
+				toolsOnce.Do(func() { close(toolsRequested) })
+				<-releaseTools
+				if err := writeControllerResponse(stdout, req.ID, `{"tools":[{"name":"new-tool"}]}`); err != nil {
+					return err
+				}
+			case "custom/wake":
+				if err := writeControllerResponse(stdout, req.ID, `{"ok":true}`); err != nil {
+					return err
+				}
+			}
+		}
+		return scanner.Err()
+	}
+
+	o, err := NewOwnerFromSnapshot(OwnerConfig{
+		HandlerFunc:           handler,
+		IPCPath:               testIPCPath(t),
+		MaterializationPolicy: MaterializationOnDemand,
+		Logger:                testLogger(t),
+	}, controllerSnapshot())
+	if err != nil {
+		t.Fatalf("NewOwnerFromSnapshot: %v", err)
+	}
+	defer o.Shutdown()
+	wake := newControllerTestSession(o)
+	lists := newControllerTestSession(o)
+	defer wake.close()
+	defer lists.close()
+
+	sendReq(t, wake.write, 11, "custom/wake", `{}`)
+	select {
+	case <-toolsRequested:
+	case <-time.After(time.Second):
+		t.Fatal("refresh did not reach tools/list")
+	}
+	sendReq(t, lists.write, 12, "tools/list", `{}`)
+	oldResp := readResp(t, lists.read)
+	if !strings.Contains(string(oldResp), "old-tool") || strings.Contains(string(oldResp), "new-tool") {
+		t.Fatalf("cache changed before discovery commit: %s", oldResp)
+	}
+
+	close(releaseTools)
+	waitForCondition(t, 2*time.Second, func() bool { return o.MaterializationState() == MaterializationReady }, "refresh did not commit")
+	const barrierMethod = "test/cache-commit-barrier"
+	wake.session.SendNotification([]byte(`{"jsonrpc":"2.0","method":"` + barrierMethod + `"}`))
+	resultCh := make(chan controllerBarrierResult, 1)
+	go func() { resultCh <- scanControllerResponseThroughBarrier(wake.read, 11, barrierMethod) }()
+	var committed controllerBarrierResult
+	select {
+	case committed = <-resultCh:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for cache commit response and notification barrier")
+	}
+	if committed.err != nil {
+		t.Fatalf("cache commit response: %v", committed.err)
+	}
+	assertResponseID(t, committed.response, 11)
+	for _, method := range []string{"notifications/tools/list_changed", "notifications/prompts/list_changed", "notifications/resources/list_changed"} {
+		if got := committed.notifications[method]; got != 1 {
+			t.Fatalf("%s notifications = %d, want exactly 1 (all=%v)", method, got, committed.notifications)
+		}
+	}
+	if got := committed.notifications[barrierMethod]; got != 1 {
+		t.Fatalf("barrier notifications = %d, want 1", got)
+	}
+
+	sendReq(t, lists.write, 13, "tools/list", `{}`)
+	newResp := readRespWithID(t, lists.read, 13)
+	if !strings.Contains(string(newResp), "new-tool") || strings.Contains(string(newResp), "old-tool") {
+		t.Fatalf("cache did not swap after discovery commit: %s", newResp)
+	}
+}
+
+func TestQueuedDemandWaitsForGenerationInstallAcknowledgement(t *testing.T) {
+	publishStarted := make(chan struct{})
+	releasePublish := make(chan struct{})
+	demandForwarded := make(chan struct{})
+	var publishOnce sync.Once
+	var demandOnce sync.Once
+	handler := func(_ context.Context, stdin io.Reader, stdout io.Writer) error {
+		scanner := bufio.NewScanner(stdin)
+		for scanner.Scan() {
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+				return err
+			}
+			switch req.Method {
+			case "initialize":
+				if err := writeControllerResponse(stdout, req.ID, `{"protocolVersion":"2025-11-25","capabilities":{},"serverInfo":{"name":"install-ack","version":"1"}}`); err != nil {
+					return err
+				}
+			case "tools/list":
+				if err := writeControllerResponse(stdout, req.ID, `{"tools":[{"name":"installed-tool"}]}`); err != nil {
+					return err
+				}
+			case "custom/wake":
+				demandOnce.Do(func() { close(demandForwarded) })
+				if err := writeControllerResponse(stdout, req.ID, `{"installed":true}`); err != nil {
+					return err
+				}
+			}
+		}
+		return scanner.Err()
+	}
+
+	o, err := NewOwnerFromSnapshot(OwnerConfig{
+		HandlerFunc:           handler,
+		IPCPath:               testIPCPath(t),
+		MaterializationPolicy: MaterializationOnDemand,
+		Logger:                testLogger(t),
+	}, controllerSnapshot())
+	if err != nil {
+		t.Fatalf("NewOwnerFromSnapshot: %v", err)
+	}
+	defer o.Shutdown()
+	s := newControllerTestSession(o)
+	defer s.close()
+	o.onCacheReady = func(*Owner, OwnerSnapshot) bool {
+		publishOnce.Do(func() { close(publishStarted) })
+		<-releasePublish
+		return true
+	}
+
+	sendReq(t, s.write, 41, "custom/wake", `{}`)
+	select {
+	case <-publishStarted:
+	case <-time.After(time.Second):
+		t.Fatal("generation never reached install acknowledgement")
+	}
+	select {
+	case <-demandForwarded:
+		t.Fatal("queued demand reached upstream before generation install acknowledgement")
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(releasePublish)
+	select {
+	case <-demandForwarded:
+	case <-time.After(time.Second):
+		t.Fatal("queued demand was not forwarded after generation install acknowledgement")
+	}
+	response := readRespWithID(t, s.read, 41)
+	if !strings.Contains(string(response), `"installed":true`) {
+		t.Fatalf("queued demand response=%s", response)
+	}
+}
+
+func TestFailedCacheRefreshPreservesLastKnownGoodSnapshot(t *testing.T) {
+	oldDemandTimeout := materializationDemandTimeout
+	materializationDemandTimeout = 250 * time.Millisecond
+	defer func() { materializationDemandTimeout = oldDemandTimeout }()
+	var starts atomic.Int32
+	handler := func(_ context.Context, stdin io.Reader, stdout io.Writer) error {
+		starts.Add(1)
+		scanner := bufio.NewScanner(stdin)
+		for scanner.Scan() {
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+				return err
+			}
+			if req.Method == "initialize" {
+				if err := writeControllerResponse(stdout, req.ID, `{"protocolVersion":"2025-11-25","capabilities":{},"serverInfo":{"name":"failed-new","version":"2"}}`); err != nil {
+					return err
+				}
+				continue
+			}
+			if req.Method == "tools/list" {
+				return errors.New("synthetic discovery failure")
+			}
+		}
+		return scanner.Err()
+	}
+	o, err := NewOwnerFromSnapshot(OwnerConfig{
+		HandlerFunc:           handler,
+		IPCPath:               testIPCPath(t),
+		MaterializationPolicy: MaterializationOnDemand,
+		Logger:                testLogger(t),
+	}, controllerSnapshot())
+	if err != nil {
+		t.Fatalf("NewOwnerFromSnapshot: %v", err)
+	}
+	defer o.Shutdown()
+	s := newControllerTestSession(o)
+	defer s.close()
+
+	sendReq(t, s.write, 31, "custom/fail-refresh", `{}`)
+	failed := scanControllerResponseWithID(s.read, 31)
+	if failed.err != nil || !strings.Contains(string(failed.response), "materialization timed out") {
+		t.Fatalf("failed materialization response: response=%s err=%v", failed.response, failed.err)
+	}
+	waitForCondition(t, time.Second, func() bool { return o.MaterializationState() == MaterializationCacheOnly }, "failed refresh did not return to cache_only")
+	sendReq(t, s.write, 32, "tools/list", `{}`)
+	cached := readRespWithID(t, s.read, 32)
+	if !strings.Contains(string(cached), "old-tool") || strings.Contains(string(cached), "failed-new") {
+		t.Fatalf("failed staging mutated last-known-good cache: %s", cached)
+	}
+	if got := starts.Load(); got < 1 {
+		t.Fatalf("failed refresh started %d upstream generations, want at least 1", got)
+	}
+}
+
+func TestPendingPersistenceRetriesAfterDiscoveryFailureWithoutSessions(t *testing.T) {
+	firstToolsSeen := make(chan struct{})
+	releaseFirstTools := make(chan struct{})
+	var starts atomic.Int32
+	handler := func(_ context.Context, stdin io.Reader, stdout io.Writer) error {
+		generation := starts.Add(1)
+		scanner := bufio.NewScanner(stdin)
+		for scanner.Scan() {
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+				return err
+			}
+			switch req.Method {
+			case "initialize":
+				if err := writeControllerResponse(stdout, req.ID, `{"protocolVersion":"2025-11-25","capabilities":{"x-mux":{"persistent":true}},"serverInfo":{"name":"persistent-retry","version":"1"}}`); err != nil {
+					return err
+				}
+			case "tools/list":
+				if generation == 1 {
+					close(firstToolsSeen)
+					<-releaseFirstTools
+					return errors.New("synthetic first discovery failure")
+				}
+				if err := writeControllerResponse(stdout, req.ID, `{"tools":[]}`); err != nil {
+					return err
+				}
+			}
+		}
+		return scanner.Err()
+	}
+	o, err := NewOwnerFromSnapshot(OwnerConfig{
+		HandlerFunc:           handler,
+		IPCPath:               testIPCPath(t),
+		MaterializationPolicy: MaterializationOnDemand,
+		Logger:                testLogger(t),
+	}, controllerSnapshot())
+	if err != nil {
+		t.Fatalf("NewOwnerFromSnapshot: %v", err)
+	}
+	defer o.Shutdown()
+	s := newControllerTestSession(o)
+	sendReq(t, s.write, 41, "custom/persistent-retry", `{}`)
+	select {
+	case <-firstToolsSeen:
+	case <-time.After(time.Second):
+		t.Fatal("first generation did not latch persistence before tools failure")
+	}
+	if !o.PersistentPending() {
+		t.Fatal("initialize persistent declaration was not latched")
+	}
+	s.close()
+	waitForCondition(t, time.Second, func() bool { return o.SessionCount() == 0 }, "initiating session did not disconnect")
+	close(releaseFirstTools)
+	waitForCondition(t, 3*time.Second, func() bool {
+		return starts.Load() >= 2 && o.MaterializationState() == MaterializationReady
+	}, "pending persistence did not retain one retry obligation")
+	if o.PersistentPending() {
+		t.Fatal("successful persistent commit did not promote the pending obligation")
+	}
+}
+
+func TestMaterializationStatusReportsCacheOnlyAndLiveGeneration(t *testing.T) {
+	handler := func(_ context.Context, stdin io.Reader, stdout io.Writer) error {
+		scanner := bufio.NewScanner(stdin)
+		for scanner.Scan() {
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+				return err
+			}
+			switch req.Method {
+			case "initialize":
+				if err := writeControllerResponse(stdout, req.ID, `{"protocolVersion":"2025-11-25","capabilities":{},"serverInfo":{"name":"status","version":"1"}}`); err != nil {
+					return err
+				}
+			case "tools/list":
+				if err := writeControllerResponse(stdout, req.ID, `{"tools":[]}`); err != nil {
+					return err
+				}
+			default:
+				if err := writeControllerResponse(stdout, req.ID, `{"ok":true}`); err != nil {
+					return err
+				}
+			}
+		}
+		return scanner.Err()
+	}
+	o, err := NewOwnerFromSnapshot(OwnerConfig{
+		HandlerFunc:           handler,
+		IPCPath:               testIPCPath(t),
+		MaterializationPolicy: MaterializationOnDemand,
+		Logger:                testLogger(t),
+	}, controllerSnapshot())
+	if err != nil {
+		t.Fatalf("NewOwnerFromSnapshot: %v", err)
+	}
+	defer o.Shutdown()
+
+	status := o.Status()
+	if status["materialization_state"] != string(MaterializationCacheOnly) || status["cache_ready"] != true || status["upstream_live"] != false {
+		t.Fatalf("cache-only status = %#v", status)
+	}
+	s := newControllerTestSession(o)
+	defer s.close()
+	sendReq(t, s.write, 21, "custom/status", `{}`)
+	assertResponseID(t, readRespWithID(t, s.read, 21), 21)
+	status = o.Status()
+	if status["materialization_state"] != string(MaterializationReady) || status["upstream_live"] != true {
+		t.Fatalf("ready status = %#v", status)
+	}
+	if generation, ok := status["materialization_generation"].(uint64); !ok || generation != 1 {
+		t.Fatalf("materialization generation = %#v, want uint64(1)", status["materialization_generation"])
+	}
+	if status["pending_demand_count"] != 0 || status["persistent_pending"] != false || status["finalization_error"] != "" {
+		t.Fatalf("materialization status residue = %#v", status)
+	}
+}
+
+func TestCacheCommitPublishesBeforeVisibilityAndIsolatedEviction(t *testing.T) {
+	handler := func(_ context.Context, stdin io.Reader, stdout io.Writer) error {
+		scanner := bufio.NewScanner(stdin)
+		for scanner.Scan() {
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+				return err
+			}
+			switch req.Method {
+			case "initialize":
+				if err := writeControllerResponse(stdout, req.ID, `{"protocolVersion":"2025-11-25","capabilities":{"x-mux":{"sharing":"isolated"}},"serverInfo":{"name":"new","version":"1"}}`); err != nil {
+					return err
+				}
+			case "tools/list":
+				if err := writeControllerResponse(stdout, req.ID, `{"tools":[{"name":"new-tool"}]}`); err != nil {
+					return err
+				}
+			case "custom/wake":
+				if err := writeControllerResponse(stdout, req.ID, `{"ok":true}`); err != nil {
+					return err
+				}
+			}
+		}
+		return scanner.Err()
+	}
+	o, err := NewOwnerFromSnapshot(OwnerConfig{HandlerFunc: handler, IPCPath: testIPCPath(t), MaterializationPolicy: MaterializationOnDemand, Logger: testLogger(t)}, controllerSnapshot())
+	if err != nil {
+		t.Fatalf("NewOwnerFromSnapshot: %v", err)
+	}
+	defer o.Shutdown()
+	initiator := newControllerTestSession(o)
+	evictee := newControllerTestSession(o)
+	defer initiator.close()
+	defer evictee.close()
+	published := make(chan error, 1)
+	o.onCacheReady = func(got *Owner, snap OwnerSnapshot) bool {
+		if got != o {
+			published <- errors.New("cache callback received wrong owner")
+			return false
+		}
+		if current := string(o.getCachedResponse("tools/list")); !strings.Contains(current, "old-tool") {
+			published <- fmt.Errorf("old cache changed before publish: %s", current)
+			return false
+		}
+		select {
+		case <-evictee.session.Done():
+			published <- errors.New("isolated session evicted before publish")
+			return false
+		default:
+		}
+		if o.PreRegister("during-commit", "/other", nil) {
+			published <- errors.New("fresh admission remained open during cache publish")
+			return false
+		}
+		tools, decodeErr := Base64Decode(snap.CachedTools)
+		if decodeErr != nil || !strings.Contains(string(tools), "new-tool") {
+			published <- fmt.Errorf("published snapshot missing new cache: %s err=%v", tools, decodeErr)
+			return false
+		}
+		published <- nil
+		return true
+	}
+	response := make(chan controllerResponseResult, 1)
+	go func() { response <- scanControllerResponseWithID(initiator.read, 91) }()
+	sendReq(t, initiator.write, 91, "custom/wake", `{}`)
+	if err := <-published; err != nil {
+		t.Fatal(err)
+	}
+	if result := <-response; result.err != nil {
+		t.Fatalf("demand response: %v", result.err)
+	}
+	select {
+	case <-evictee.session.Done():
+	case <-time.After(time.Second):
+		t.Fatal("isolated evictee remained after successful publish")
+	}
+	if current := string(o.getCachedResponse("tools/list")); !strings.Contains(current, "new-tool") {
+		t.Fatalf("new cache not visible after publish: %s", current)
+	}
+}
+
+func TestMaterializationListChangedFailurePreservesLastKnownGoodCache(t *testing.T) {
+	o := newMinimalOwner()
+	oldInit := []byte(`{"jsonrpc":"2.0","id":"old-init","result":{"capabilities":{}}}`)
+	oldTools := []byte(`{"jsonrpc":"2.0","id":"old-tools","result":{"tools":[{"name":"old"}]}}`)
+	proc := &upstream.Process{Done: make(chan struct{})}
+	a := newMaterializationAttempt(1, MaterializationTriggerDemand)
+	a.process = proc
+	a.signals = newMaterializationSignals()
+
+	o.mu.Lock()
+	o.upstream = proc
+	o.initResp = append([]byte(nil), oldInit...)
+	o.toolList = append([]byte(nil), oldTools...)
+	o.initDone = true
+	o.mu.Unlock()
+	o.materializationMu.Lock()
+	o.materializationState = MaterializationMaterializing
+	o.materializationAttempt = a
+	o.cacheStage = &cacheStage{generation: a.generation, process: proc, signals: a.signals}
+	o.materializationMu.Unlock()
+	var invalidations atomic.Int32
+	var publishes atomic.Int32
+	o.onCacheInvalidated = func(*Owner) { invalidations.Add(1) }
+	o.onCacheReady = func(*Owner, OwnerSnapshot) bool {
+		publishes.Add(1)
+		return true
+	}
+
+	o.cacheResponseFrom(proc, "initialize", []byte(`{"jsonrpc":"2.0","id":"fresh-init","result":{"capabilities":{}}}`))
+	notification, err := jsonrpc.Parse([]byte(`{"jsonrpc":"2.0","method":"notifications/tools/list_changed"}`))
+	if err != nil {
+		t.Fatalf("parse notification: %v", err)
+	}
+	if err := o.handleUpstreamMessageFrom(proc, notification); err != nil {
+		t.Fatalf("handle list_changed: %v", err)
+	}
+	o.finishMaterializationFailure(a, errors.New("tools discovery failed"))
+
+	if got := string(o.getCachedResponse("initialize")); got != string(oldInit) {
+		t.Fatalf("failed generation changed initialize cache: %s", got)
+	}
+	if got := string(o.getCachedResponse("tools/list")); got != string(oldTools) {
+		t.Fatalf("failed generation changed tools cache: %s", got)
+	}
+	if got := invalidations.Load(); got != 0 {
+		t.Fatalf("failed staged notification invalidated live cache %d times", got)
+	}
+	if got := publishes.Load(); got != 0 {
+		t.Fatalf("failed generation published template %d times", got)
+	}
+}
+
+func TestStaleProcessEventsQueuedBehindSuccessorInstallAreInert(t *testing.T) {
+	o := newMinimalOwner()
+	old := &upstream.Process{Done: make(chan struct{})}
+	successor := &upstream.Process{Done: make(chan struct{})}
+	o.mu.Lock()
+	o.upstream = old
+	o.mu.Unlock()
+	o.materializationMu.Lock()
+	o.materializationState = MaterializationReady
+	o.materializationMu.Unlock()
+
+	msg, err := jsonrpc.Parse([]byte(`{"jsonrpc":"2.0","id":"s1:n:7","result":{"tools":[{"name":"stale"}]}}`))
+	if err != nil {
+		t.Fatalf("parse stale response: %v", err)
+	}
+	requestID := string(msg.ID)
+
+	// Queue all three old-generation paths behind the writer lease. Installing
+	// the successor while owning that lease deterministically reproduces the
+	// former check/use windows without timing sleeps or source hooks.
+	o.upstreamEventMu.Lock()
+	started := make(chan struct{}, 3)
+	done := make(chan struct{}, 3)
+	handlerErr := make(chan error, 1)
+	markResult := make(chan bool, 1)
+	go func() {
+		started <- struct{}{}
+		handlerErr <- o.handleUpstreamMessageFrom(old, msg)
+		done <- struct{}{}
+	}()
+	go func() {
+		started <- struct{}{}
+		o.monitorMaterializedProcessExit(old)
+		done <- struct{}{}
+	}()
+	go func() {
+		started <- struct{}{}
+		markResult <- o.markCurrentUpstreamDead(old)
+		done <- struct{}{}
+	}()
+	for range 3 {
+		<-started
+	}
+
+	o.materializationMu.Lock()
+	o.mu.Lock()
+	o.upstream = successor
+	o.toolList = []byte(`{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"successor"}]}}`)
+	o.upstreamDead.Store(false)
+	o.mu.Unlock()
+	o.materializationState = MaterializationReady
+
+	o.materializationMu.Unlock()
+	o.methodTags.Store(requestID, "tools/list")
+	o.inflightTracker.Store(requestID, &InflightRequest{Method: "tools/list", SessionID: 1})
+	o.pendingRequests.Store(1)
+	o.upstreamEventMu.Unlock()
+
+	for range 3 {
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("stale process event did not settle")
+		}
+	}
+	if err := <-handlerErr; err != nil {
+		t.Fatalf("stale response handler: %v", err)
+	}
+	if marked := <-markResult; marked {
+		t.Fatal("stale deferred reader marked successor dead")
+	}
+	if got := string(o.getCachedResponse("tools/list")); !strings.Contains(got, "successor") || strings.Contains(got, "stale") {
+		t.Fatalf("stale response changed successor cache: %s", got)
+	}
+	if _, ok := o.methodTags.Load(requestID); !ok {
+		t.Fatal("stale response claimed successor method tag")
+	}
+	if _, ok := o.inflightTracker.Load(requestID); !ok {
+		t.Fatal("stale response claimed successor inflight tracker")
+	}
+	if o.PendingRequests() != 1 {
+		t.Fatalf("pending requests = %d, want successor value 1", o.PendingRequests())
+	}
+	if o.currentUpstream() != successor || o.MaterializationState() != MaterializationReady || o.UpstreamDead() {
+		t.Fatalf("stale exit changed successor generation: status=%#v", o.Status())
+	}
+}
+
+func TestStaleCacheResponseQueuedBehindSuccessorInstallIsInert(t *testing.T) {
+	o := newMinimalOwner()
+	old := &upstream.Process{Done: make(chan struct{})}
+	successor := &upstream.Process{Done: make(chan struct{})}
+	o.mu.Lock()
+	o.upstream = old
+	o.mu.Unlock()
+	o.materializationMu.Lock()
+	o.materializationState = MaterializationReady
+	o.materializationMu.Unlock()
+
+	o.upstreamEventMu.Lock()
+	started := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		close(started)
+		o.cacheResponseFrom(old, "tools/list", []byte(`{"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"stale"}]}}`))
+		close(done)
+	}()
+	<-started
+	o.materializationMu.Lock()
+	o.mu.Lock()
+	o.upstream = successor
+	o.toolList = []byte(`{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"successor"}]}}`)
+	o.upstreamDead.Store(false)
+	o.mu.Unlock()
+	o.materializationState = MaterializationReady
+	o.materializationMu.Unlock()
+	o.upstreamEventMu.Unlock()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("stale cache response did not settle")
+	}
+	if got := string(o.getCachedResponse("tools/list")); !strings.Contains(got, "successor") || strings.Contains(got, "stale") {
+		t.Fatalf("stale fallback changed successor cache: %s", got)
+	}
+}
+
+func TestMaterializationListChangedSuccessBroadcastsFromColdCommit(t *testing.T) {
+	o := newMinimalOwner()
+	var notifications safeBuf
+	s := NewSession(strings.NewReader(""), &notifications)
+	defer s.Close()
+	o.mu.Lock()
+	o.sessions[s.ID] = s
+	o.mu.Unlock()
+	proc := &upstream.Process{Done: make(chan struct{})}
+	a := newMaterializationAttempt(1, MaterializationTriggerDemand)
+	a.process = proc
+	a.signals = newMaterializationSignals()
+	o.mu.Lock()
+	o.upstream = proc
+	o.mu.Unlock()
+	o.materializationMu.Lock()
+	o.materializationState = MaterializationMaterializing
+	o.materializationAttempt = a
+	o.cacheStage = &cacheStage{generation: a.generation, process: proc, signals: a.signals}
+	o.materializationMu.Unlock()
+
+	o.cacheResponseFrom(proc, "initialize", []byte(`{"jsonrpc":"2.0","id":"fresh-init","result":{"capabilities":{}}}`))
+	notification, err := jsonrpc.Parse([]byte(`{"jsonrpc":"2.0","method":"notifications/tools/list_changed"}`))
+	if err != nil {
+		t.Fatalf("parse notification: %v", err)
+	}
+	if err := o.handleUpstreamMessageFrom(proc, notification); err != nil {
+		t.Fatalf("handle list_changed: %v", err)
+	}
+	o.cacheResponseFrom(proc, "tools/list", []byte(`{"jsonrpc":"2.0","id":"fresh-tools","result":{"tools":[{"name":"fresh"}]}}`))
+
+	waitForCondition(t, time.Second, func() bool {
+		return strings.Contains(notifications.String(), "notifications/tools/list_changed")
+	}, "cold staged list_changed was not broadcast after commit")
+	if got := string(o.getCachedResponse("tools/list")); !strings.Contains(got, "fresh") {
+		t.Fatalf("successful staged cache not committed: %s", got)
+	}
+}

--- a/muxcore/owner/materialization_controller_test.go
+++ b/muxcore/owner/materialization_controller_test.go
@@ -202,7 +202,9 @@ func TestConcurrentUncachedDemandsShareOneMaterialization(t *testing.T) {
 func TestCancellationRacingForwardingWritesRequestBeforeUpstreamCancel(t *testing.T) {
 	var orderMu sync.Mutex
 	var order []string
+	var orderRequestID json.RawMessage
 	cancelSeen := make(chan struct{})
+	releaseResponse := make(chan struct{})
 	var cancelOnce sync.Once
 	handler := func(_ context.Context, stdin io.Reader, stdout io.Writer) error {
 		scanner := bufio.NewScanner(stdin)
@@ -227,14 +229,16 @@ func TestCancellationRacingForwardingWritesRequestBeforeUpstreamCancel(t *testin
 				orderMu.Lock()
 				order = append(order, req.Method)
 				orderMu.Unlock()
-				if err := writeControllerResponse(stdout, req.ID, `{"ok":true}`); err != nil {
-					return err
-				}
+				orderRequestID = append(orderRequestID[:0], req.ID...)
 			case "notifications/cancelled":
 				orderMu.Lock()
 				order = append(order, req.Method)
 				orderMu.Unlock()
 				cancelOnce.Do(func() { close(cancelSeen) })
+				<-releaseResponse
+				if err := writeControllerResponse(stdout, orderRequestID, `{"ok":true}`); err != nil {
+					return err
+				}
 			}
 		}
 		return scanner.Err()
@@ -252,16 +256,49 @@ func TestCancellationRacingForwardingWritesRequestBeforeUpstreamCancel(t *testin
 	defer o.Shutdown()
 	s := newControllerTestSession(o)
 	defer s.close()
+
+	replacementFrames := make(chan string, 1)
+	replacement := upstream.NewProcessFromHandler(context.Background(), func(_ context.Context, stdin io.Reader, _ io.Writer) error {
+		scanner := bufio.NewScanner(stdin)
+		for scanner.Scan() {
+			replacementFrames <- scanner.Text()
+		}
+		return scanner.Err()
+	})
+	defer func() { _ = replacement.Close() }()
+
 	writeEntered := make(chan struct{})
 	releaseWrite := make(chan struct{})
+	requestWritten := make(chan struct{})
+	replacementInstalled := make(chan struct{})
+	releaseReady := make(chan struct{})
+	defer func() {
+		for _, ch := range []chan struct{}{releaseWrite, replacementInstalled, releaseResponse, releaseReady} {
+			select {
+			case <-ch:
+			default:
+				close(ch)
+			}
+		}
+	}()
 	cancelAttempted := make(chan struct{})
+	acceptingProcess := make(chan *upstream.Process, 1)
 	var writeOnce sync.Once
 	var attemptedOnce sync.Once
 	o.beforeQueuedDemandWrite = func() {
 		writeOnce.Do(func() { close(writeEntered) })
 		<-releaseWrite
 	}
-	o.beforeLocalDemandCancel = func() { attemptedOnce.Do(func() { close(cancelAttempted) }) }
+	o.beforeLocalDemandCancel = func() {
+		attemptedOnce.Do(func() { close(cancelAttempted) })
+		<-replacementInstalled
+	}
+	o.afterQueuedDemandWrite = func() {
+		acceptingProcess <- o.currentUpstream()
+		close(requestWritten)
+		<-replacementInstalled
+		<-releaseReady
+	}
 
 	sendReq(t, s.write, 41, "custom/order", `{}`)
 	select {
@@ -278,14 +315,65 @@ func TestCancellationRacingForwardingWritesRequestBeforeUpstreamCancel(t *testin
 		t.Fatal("cancellation did not race the forwarding boundary")
 	}
 	close(releaseWrite)
+	select {
+	case <-requestWritten:
+	case <-time.After(time.Second):
+		t.Fatal("queued request write did not reach the pre-ready boundary")
+	}
+	accepting := <-acceptingProcess
+	if accepting == nil {
+		t.Fatal("queued request did not bind an accepting process generation")
+	}
+	o.materializationMu.Lock()
+	state := o.materializationState
+	attempt := o.materializationAttempt
+	o.materializationMu.Unlock()
+	if state != MaterializationMaterializing {
+		t.Fatalf("state after queued write = %s, want %s before READY", state, MaterializationMaterializing)
+	}
+	if attempt == nil {
+		t.Fatal("queued write completed without an active materialization attempt")
+	}
+	if attempt.process != accepting {
+		t.Fatalf("accepting process = %p, active attempt process = %p", accepting, attempt.process)
+	}
+	o.mu.Lock()
+	if o.upstream != accepting {
+		current := o.upstream
+		o.mu.Unlock()
+		t.Fatalf("current process before replacement = %p, want accepting %p", current, accepting)
+	}
+	o.upstream = replacement
+	o.mu.Unlock()
+	close(replacementInstalled)
+
+	select {
+	case <-cancelSeen:
+	case line := <-replacementFrames:
+		t.Fatalf("cancellation reached replacement generation: %s", line)
+	case <-time.After(time.Second):
+		t.Fatal("remapped cancellation did not reach the accepting upstream before READY")
+	}
+	select {
+	case line := <-replacementFrames:
+		t.Fatalf("replacement generation received queued cancellation: %s", line)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	o.mu.Lock()
+	if o.upstream != replacement {
+		current := o.upstream
+		o.mu.Unlock()
+		t.Fatalf("current process during cancellation = %p, want replacement %p", current, replacement)
+	}
+	o.upstream = accepting
+	o.mu.Unlock()
+	close(releaseResponse)
+	close(releaseReady)
+
 	result := scanControllerResponseWithID(s.read, 41)
 	if result.err != nil || !strings.Contains(string(result.response), `"ok":true`) {
 		t.Fatalf("forwarded request result: response=%s err=%v", result.response, result.err)
-	}
-	select {
-	case <-cancelSeen:
-	case <-time.After(time.Second):
-		t.Fatal("remapped cancellation did not reach upstream")
 	}
 	orderMu.Lock()
 	gotOrder := append([]string(nil), order...)

--- a/muxcore/owner/mux_test.go
+++ b/muxcore/owner/mux_test.go
@@ -924,15 +924,13 @@ func TestNewOwnerFromSnapshot_CachedInit(t *testing.T) {
 	}
 }
 
-func TestSnapshotOwnerServesCachedToolsDuringBackgroundRefresh(t *testing.T) {
+func TestSnapshotOwnerServesCachedToolsWithoutMaterialization(t *testing.T) {
 	ipcPath := testIPCPath(t)
 	cwd := t.TempDir()
-
 	initResp := `{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"tools":{}},"serverInfo":{"name":"snap-server","version":"0.1.0"}}}`
 	toolsResp := `{"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"snapshot-tool"}]}}`
-
 	snap := OwnerSnapshot{
-		ServerID:       "test-background-refresh-cache",
+		ServerID:       "test-cache-only-hit",
 		Command:        "in-process-handler",
 		Cwd:            cwd,
 		CwdSet:         []string{cwd},
@@ -941,134 +939,42 @@ func TestSnapshotOwnerServesCachedToolsDuringBackgroundRefresh(t *testing.T) {
 		CachedInit:     base64Encode([]byte(initResp)),
 		CachedTools:    base64Encode([]byte(toolsResp)),
 	}
-
 	handlerStarted := make(chan struct{})
-	initializeReceived := make(chan struct{})
-	allowInitializeResponse := make(chan struct{})
-	initializeReleased := false
-	defer func() {
-		if !initializeReleased {
-			close(allowInitializeResponse)
-		}
-	}()
-	handlerFunc := func(ctx context.Context, stdin io.Reader, stdout io.Writer) error {
-		_ = ctx
+	handlerFunc := func(context.Context, io.Reader, io.Writer) error {
 		close(handlerStarted)
-		scanner := bufio.NewScanner(stdin)
-		var req struct {
-			ID     json.RawMessage `json:"id"`
-			Method string          `json:"method"`
-		}
-		for scanner.Scan() {
-			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
-				return err
-			}
-			if req.Method == "initialize" {
-				break
-			}
-		}
-		if err := scanner.Err(); err != nil {
-			return err
-		}
-		if req.Method != "initialize" {
-			return io.ErrUnexpectedEOF
-		}
-		close(initializeReceived)
-		<-allowInitializeResponse
-		if _, err := fmt.Fprintf(stdout, `{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":"2025-11-25","capabilities":{"tools":{}},"serverInfo":{"name":"snap-server","version":"0.1.0"}}}`+"\n", req.ID); err != nil {
-			return err
-		}
-		if !scanner.Scan() {
-			return scanner.Err()
-		}
-		_, _ = io.Copy(io.Discard, stdin)
 		return nil
 	}
-
-	owner, err := NewOwnerFromSnapshot(OwnerConfig{
-		Command:     snap.Command,
-		Cwd:         snap.Cwd,
-		IPCPath:     ipcPath,
-		ServerID:    snap.ServerID,
-		HandlerFunc: handlerFunc,
-		Logger:      testLogger(t),
+	o, err := NewOwnerFromSnapshot(OwnerConfig{
+		Command:               snap.Command,
+		Cwd:                   snap.Cwd,
+		IPCPath:               ipcPath,
+		ServerID:              snap.ServerID,
+		HandlerFunc:           handlerFunc,
+		MaterializationPolicy: MaterializationOnDemand,
+		Logger:                testLogger(t),
 	}, snap)
 	if err != nil {
 		t.Fatalf("NewOwnerFromSnapshot() error: %v", err)
 	}
-	defer owner.Shutdown()
-
-	bgCh := owner.backgroundSpawnCh
-	if bgCh == nil {
-		t.Fatal("snapshot owner should expose backgroundSpawnCh before background spawn")
-	}
-	owner.SpawnUpstreamBackground()
-	select {
-	case <-handlerStarted:
-	case <-time.After(2 * time.Second):
-		t.Fatal("background handler did not start")
-	}
-	select {
-	case <-initializeReceived:
-	case <-time.After(2 * time.Second):
-		t.Fatal("background handler did not receive proactive initialize")
-	}
-	select {
-	case <-bgCh:
-		t.Fatal("background spawn became publicly ready before proactive initialization")
-	default:
-	}
-
-	// A late initialize response from a dead predecessor must not release this
-	// generation's lifecycle gate or overwrite its public snapshot cache.
-	staleDone := make(chan struct{})
-	close(staleDone)
-	staleID := strconv.Quote(owner.proactiveNamespace + "-stale-0")
-	owner.registerProactive(staleID, proactiveRequest{method: "initialize", upstreamDone: staleDone})
-	if err := owner.handleUpstreamMessage(parseMessage([]byte(fmt.Sprintf(`{"jsonrpc":"2.0","id":%s,"result":{"serverInfo":{"name":"stale-server"}}}`, staleID)))); err != nil {
-		t.Fatalf("handle stale proactive initialize response: %v", err)
-	}
-	if cached := owner.getCachedResponse("initialize"); !strings.Contains(string(cached), "snap-server") {
-		t.Fatalf("stale generation response replaced public cached initialize: %s", cached)
-	}
-	select {
-	case <-bgCh:
-		t.Fatal("stale generation response released the current background spawn")
-	default:
-	}
-
-	// Session admission emits roots/listChanged synchronously. Discard that
-	// unrelated notification while this test deliberately holds initialize.
-	owner.mu.Lock()
-	owner.upstreamWriter = io.Discard
-	owner.mu.Unlock()
+	defer o.Shutdown()
 
 	conn, err := ipc.Dial(ipcPath)
 	if err != nil {
 		t.Fatalf("Dial() error: %v", err)
 	}
 	defer conn.Close()
-
 	scanner := bufio.NewScanner(conn)
 	readLineWithin := func(timeout time.Duration) string {
 		t.Helper()
 		done := make(chan scanResult, 1)
-		go func() {
-			ok := scanner.Scan()
-			done <- scanResult{ok: ok, line: scanner.Text(), err: scanner.Err()}
-		}()
-		timer := time.NewTimer(timeout)
-		defer timer.Stop()
+		go func() { done <- scanResult{ok: scanner.Scan(), line: scanner.Text(), err: scanner.Err()} }()
 		select {
 		case res := <-done:
 			if !res.ok {
-				if res.err != nil {
-					t.Fatalf("scanner error: %v", res.err)
-				}
-				t.Fatal("scanner returned EOF before any data")
+				t.Fatalf("cached response read failed: %v", res.err)
 			}
 			return res.line
-		case <-timer.C:
+		case <-time.After(timeout):
 			t.Fatalf("timeout waiting for cached response after %s", timeout)
 		}
 		return ""
@@ -1077,23 +983,8 @@ func TestSnapshotOwnerServesCachedToolsDuringBackgroundRefresh(t *testing.T) {
 	if _, err := conn.Write([]byte(`{"jsonrpc":"2.0","id":42,"method":"initialize","params":{}}` + "\n")); err != nil {
 		t.Fatalf("write init: %v", err)
 	}
-	initLine := readLineWithin(500 * time.Millisecond)
-	if !strings.Contains(initLine, `"id":42`) || !strings.Contains(initLine, "snap-server") {
-		t.Fatalf("unexpected cached initialize response: %s", initLine)
-	}
-
-	owner.mu.Lock()
-	owner.upstreamWriter = nil
-	owner.mu.Unlock()
-
-	// The snapshot's cached initialize remains public readiness while the new
-	// generation-local lifecycle handshake is intentionally still pending.
-	close(allowInitializeResponse)
-	initializeReleased = true
-	select {
-	case <-bgCh:
-	case <-time.After(2 * time.Second):
-		t.Fatal("background spawn did not finish after proactive initialization")
+	if line := readLineWithin(500 * time.Millisecond); !strings.Contains(line, `"id":42`) || !strings.Contains(line, "snap-server") {
+		t.Fatalf("unexpected cached initialize response: %s", line)
 	}
 
 	if _, err := conn.Write([]byte(`{"jsonrpc":"2.0","method":"notifications/initialized"}` + "\n")); err != nil {
@@ -1102,9 +993,17 @@ func TestSnapshotOwnerServesCachedToolsDuringBackgroundRefresh(t *testing.T) {
 	if _, err := conn.Write([]byte(`{"jsonrpc":"2.0","id":43,"method":"tools/list","params":{}}` + "\n")); err != nil {
 		t.Fatalf("write tools/list: %v", err)
 	}
-	toolsLine := readLineWithin(500 * time.Millisecond)
-	if !strings.Contains(toolsLine, `"id":43`) || !strings.Contains(toolsLine, "snapshot-tool") {
-		t.Fatalf("unexpected cached tools/list response: %s", toolsLine)
+	if line := readLineWithin(500 * time.Millisecond); !strings.Contains(line, `"id":43`) || !strings.Contains(line, "snapshot-tool") {
+		t.Fatalf("unexpected cached tools/list response: %s", line)
+	}
+
+	if state := o.MaterializationState(); state != MaterializationCacheOnly {
+		t.Fatalf("materialization state = %s, want cache-only", state)
+	}
+	select {
+	case <-handlerStarted:
+		t.Fatal("cached initialize/tools hits materialized an upstream")
+	default:
 	}
 }
 

--- a/muxcore/owner/owner.go
+++ b/muxcore/owner/owner.go
@@ -93,6 +93,7 @@ type InflightRequest struct {
 	Tool      string    `json:"tool,omitempty"`
 	SessionID int       `json:"session"`
 	StartTime time.Time `json:"started_at"`
+	process   atomic.Pointer[upstream.Process]
 }
 
 // proactiveRequest is claimed exactly once by its response or bound upstream death.
@@ -197,6 +198,7 @@ type Owner struct {
 	teardownOnce            sync.Once
 	removalMu               sync.Mutex
 	handoffPrepared         bool // guarded by removalMu; rejects duplicate transfer preparation
+	handoffAbortRequested   bool // guarded by removalMu; permits only explicit abort retirement retries
 	closeListenerOnce       sync.Once
 	isAccepting             atomic.Bool
 	admissionFrozen         atomic.Bool
@@ -231,6 +233,7 @@ type Owner struct {
 	restartResumeTrigger             MaterializationTrigger
 	materializationFinalizationProbe func(*upstream.Process) error
 	beforeQueuedDemandWrite          func()
+	afterQueuedDemandWrite           func() // test-only post-write/pre-ready cancellation seam
 	beforeLocalDemandCancel          func()
 	afterProactiveStore              func()                  // test-only registration race seam
 	beforeCurrentUpstreamWrite       func(*upstream.Process) // test-only generation race seam
@@ -2318,6 +2321,10 @@ func (o *Owner) FinalizeForRemoval(soft bool, timeout time.Duration) (int, bool,
 		return 0, true, nil
 	default:
 	}
+	abortPreparedHandoff := o.handoffPrepared && o.handoffAbortRequested
+	if o.handoffPrepared && !abortPreparedHandoff {
+		return 0, false, ErrHandoffAlreadyPrepared
+	}
 	if timeout <= 0 {
 		timeout = materializationFinalizeTimeout
 	}
@@ -2360,7 +2367,9 @@ func (o *Owner) FinalizeForRemoval(soft bool, timeout time.Duration) (int, bool,
 	exitCode := 0
 	var closeErr error
 	if proc != nil {
-		if soft {
+		if abortPreparedHandoff {
+			closeErr = proc.AbortDetach()
+		} else if soft {
 			exitCode, closeErr = proc.SoftClose(timeout)
 		} else {
 			closeErr = proc.Close()
@@ -2407,6 +2416,10 @@ func (o *Owner) FinalizeForRemoval(soft bool, timeout time.Duration) (int, bool,
 	}
 	o.materializationMu.Unlock()
 	o.upstreamEventMu.Unlock()
+	if abortPreparedHandoff {
+		o.handoffPrepared = false
+		o.handoffAbortRequested = false
+	}
 	o.completeShutdown("owner shut down")
 	return exitCode, true, closeErr
 }
@@ -2747,13 +2760,14 @@ func (o *Owner) touchActivity() {
 // to the injected writer followed by a newline, mirroring upstream.WriteLine
 // semantics. Used by tests to capture output without a subprocess.
 func (o *Owner) writeUpstream(data []byte) error {
-	_, err := o.writeUpstreamFromCurrent(data)
+	_, err := o.writeUpstreamFromCurrent(data, nil)
 	return err
 }
 
 // writeUpstreamFromCurrent returns the exact process generation used for the
-// write so a failure cannot retire a replacement generation.
-func (o *Owner) writeUpstreamFromCurrent(data []byte) (*upstream.Process, error) {
+// write so a failure cannot retire a replacement generation. bind runs after
+// generation selection and before the write begins.
+func (o *Owner) writeUpstreamFromCurrent(data []byte, bind func(*upstream.Process)) (*upstream.Process, error) {
 	o.touchActivity()
 	o.mu.RLock()
 	writer := o.upstreamWriter
@@ -2771,10 +2785,21 @@ func (o *Owner) writeUpstreamFromCurrent(data []byte) (*upstream.Process, error)
 	if up == nil {
 		return nil, errors.New("upstream writer unavailable")
 	}
+	if bind != nil {
+		bind(up)
+	}
 	if o.beforeCurrentUpstreamWrite != nil {
 		o.beforeCurrentUpstreamWrite(up)
 	}
 	return up, up.WriteLine(data)
+}
+
+func (o *Owner) writeUpstreamToProcess(proc *upstream.Process, data []byte) error {
+	if proc == nil {
+		return errors.New("upstream writer unavailable")
+	}
+	o.touchActivity()
+	return proc.WriteLine(data)
 }
 
 func (o *Owner) hasWritableUpstream() bool {
@@ -3281,6 +3306,13 @@ func (o *Owner) forwardCancelledNotification(s *Session, msg *jsonrpc.Message) e
 	o.clearProgressTokensForRequest(string(remappedRequestID))
 
 	o.logger.Printf("session %d: forwarding notifications/cancelled with remapped requestId", s.ID)
+	if tracked, ok := o.inflightTracker.Load(string(remappedRequestID)); ok {
+		if inflight, ok := tracked.(*InflightRequest); ok {
+			if proc := inflight.process.Load(); proc != nil {
+				return o.writeUpstreamToProcess(proc, remapped)
+			}
+		}
+	}
 	return o.forwardNotificationIfReady(remapped)
 }
 

--- a/muxcore/owner/owner.go
+++ b/muxcore/owner/owner.go
@@ -196,6 +196,7 @@ type Owner struct {
 	shutdownOnce            sync.Once
 	teardownOnce            sync.Once
 	removalMu               sync.Mutex
+	handoffPrepared         bool // guarded by removalMu; rejects duplicate transfer preparation
 	closeListenerOnce       sync.Once
 	isAccepting             atomic.Bool
 	admissionFrozen         atomic.Bool
@@ -2989,7 +2990,7 @@ func (o *Owner) ExportSnapshotState() (OwnerSnapshot, []SessionSnapshot) {
 }
 
 func (o *Owner) applyMaterializationSnapshotLocked(snap *OwnerSnapshot) {
-	snap.Persistent = snap.Persistent || o.persistentPending
+	snap.Persistent = snap.Persistent || o.persistentPending || o.persistentRequired || o.materializationPolicy == MaterializationPersistent
 	if a := o.materializationAttempt; a != nil {
 		snap.Cwd = a.launch.Cwd
 		snap.Env = cloneSnapshotEnv(a.launch.Env)
@@ -3160,6 +3161,25 @@ func (o *Owner) cacheResponseState(method string, raw []byte) bool {
 	}
 	cached := make([]byte, len(raw))
 	copy(cached, raw)
+	if method == "tools/list" && o.onCacheReady != nil {
+		o.mu.RLock()
+		initDone := o.initDone
+		o.mu.RUnlock()
+		if initDone {
+			staged := o.ExportSnapshot()
+			staged.CachedTools = base64Encode(cached)
+			if staged.ClassificationSource == "" {
+				mode, matched := classify.ClassifyTools(cached)
+				staged.Classification = mode
+				staged.ClassificationSource = "tools"
+				staged.ClassificationReason = matched
+			}
+			if !o.onCacheReady(o, staged) {
+				o.logger.Printf("cache publication rejected for live tools/list response")
+				return false
+			}
+		}
+	}
 
 	o.mu.Lock()
 	switch method {
@@ -3203,11 +3223,6 @@ func (o *Owner) cacheResponseState(method string, raw []byte) bool {
 		return false
 	}
 	o.classifyFromToolList(cached)
-	// Publish synchronously while a live response still owns its generation
-	// lease, so template publication cannot cross successor installation.
-	if o.onCacheReady != nil && o.initDone {
-		o.onCacheReady(o, o.ExportSnapshot())
-	}
 	if !o.listChangedAfterRefresh.Swap(false) {
 		return false
 	}

--- a/muxcore/owner/owner.go
+++ b/muxcore/owner/owner.go
@@ -204,10 +204,13 @@ type Owner struct {
 	done                    chan struct{}
 
 	restartPins atomic.Int64
-	// Lock order is upstreamEventMu, materializationMu, admissionMu, then mu.
+	// Lock order is launchContextMu, upstreamEventMu, materializationMu,
+	// admissionMu, then mu. launchContextMu fences final session-context
+	// validation and upstream.Start against owner-side session detachment.
 	// Writers never hold upstreamEventMu across process Close/SoftClose; readers
 	// may hold it across bounded session I/O. admissionMu serializes token bind +
 	// session registration against coherent classification commits.
+	launchContextMu                  sync.Mutex
 	upstreamEventMu                  sync.RWMutex
 	materializationMu                sync.Mutex
 	admissionMu                      sync.Mutex
@@ -218,6 +221,7 @@ type Owner struct {
 	materializationAttempt           *materializationAttempt
 	retiringProcess                  *upstream.Process
 	materializationBlockedErr        error
+	retirementRetryProcess           atomic.Pointer[upstream.Process]
 	materializationStop              chan struct{}
 	pendingDemands                   map[string]*localDemand
 	pendingDemandOrder               []string
@@ -227,7 +231,8 @@ type Owner struct {
 	materializationFinalizationProbe func(*upstream.Process) error
 	beforeQueuedDemandWrite          func()
 	beforeLocalDemandCancel          func()
-	afterProactiveStore              func() // test-only registration race seam
+	afterProactiveStore              func()                  // test-only registration race seam
+	beforeCurrentUpstreamWrite       func(*upstream.Process) // test-only generation race seam
 	cacheStage                       *cacheStage
 }
 
@@ -501,6 +506,24 @@ func (o *Owner) hydrateSnapshotCache(snap OwnerSnapshot) {
 		if data, err := Base64Decode(snap.CachedResourceTemplates); err == nil {
 			o.resourceTemplateList = data
 		}
+	}
+	o.applyCachedRuntimeSettings()
+}
+
+// applyCachedRuntimeSettings restores server-declared runtime policy from the
+// cached initialize response before a restored or handoff-adopted owner becomes
+// visible. Cache hydration deliberately does not invoke persistence callbacks:
+// daemon registration is not complete during construction.
+func (o *Owner) applyCachedRuntimeSettings() {
+	if len(o.initResp) == 0 {
+		return
+	}
+	o.parseDrainTimeout(o.initResp)
+	o.parseToolTimeout(o.initResp)
+	o.parseIdleTimeout(o.initResp)
+	if sec := classify.ParseProgressInterval(o.initResp); sec > 0 {
+		o.progressIntervalNs.Store(int64(time.Duration(sec) * time.Second))
+		o.logger.Printf("x-mux capability: progressInterval=%ds", sec)
 	}
 }
 
@@ -1632,9 +1655,6 @@ func (o *Owner) clearProgressTokensForRequest(requestID string) {
 
 // sendRootsListChanged notifies the upstream that roots have changed.
 func (o *Owner) sendRootsListChanged() {
-	if o.upstream == nil {
-		return // snapshot owner — upstream not yet spawned
-	}
 	notification := `{"jsonrpc":"2.0","method":"notifications/roots/list_changed"}`
 	if err := o.forwardNotificationIfReady([]byte(notification)); err != nil {
 		o.logger.Printf("failed to send roots/list_changed: %v", err)
@@ -1753,6 +1773,7 @@ func (n *ownerNotifier) Broadcast(notification []byte) {
 
 // removeSession removes a session from the owner.
 func (o *Owner) removeSession(s *Session) {
+	o.launchContextMu.Lock()
 	o.mu.Lock()
 	delete(o.sessions, s.ID)
 	remaining := len(o.sessions)
@@ -1769,6 +1790,7 @@ func (o *Owner) removeSession(s *Session) {
 		}
 	}
 	o.mu.Unlock()
+	o.launchContextMu.Unlock()
 	o.cancelLocalDemandsForSession(s.ID)
 	if remaining == 0 {
 		o.cancelDisposableMaterializationForZeroSessions()
@@ -2472,9 +2494,6 @@ func (o *Owner) IPCPath() string {
 // states produce "dial: connection refused" for shims even though the owner
 // entry is still registered in the daemon.
 func (o *Owner) IsAccepting() bool {
-	if o.admissionFrozen.Load() {
-		return false
-	}
 	// If the accept loop has explicitly set isAccepting true, trust it.
 	if o.isAccepting.Load() {
 		return true
@@ -2488,6 +2507,12 @@ func (o *Owner) IsAccepting() bool {
 	default:
 		return true
 	}
+}
+
+// AdmissionFrozen reports the short cache-commit barrier during which fresh
+// session reservations must wait instead of treating the live listener as dead.
+func (o *Owner) AdmissionFrozen() bool {
+	return o.admissionFrozen.Load()
 }
 
 // IsReachable returns true if the IPC listener is both marked-open
@@ -2745,6 +2770,9 @@ func (o *Owner) writeUpstreamFromCurrent(data []byte) (*upstream.Process, error)
 	if up == nil {
 		return nil, errors.New("upstream writer unavailable")
 	}
+	if o.beforeCurrentUpstreamWrite != nil {
+		o.beforeCurrentUpstreamWrite(up)
+	}
 	return up, up.WriteLine(data)
 }
 
@@ -2885,7 +2913,7 @@ func (o *Owner) Status() map[string]any {
 		"cached_resources":           hasCachedResources,
 		"materialization_state":      string(matState),
 		"materialization_trigger":    string(matTrigger),
-		"materialization_policy":     string(matPolicy),
+		"materialization_policy":     matPolicy.String(),
 		"materialization_generation": matGeneration,
 		"pending_demand_count":       pendingDemandCount,
 		"persistent_pending":         persistentPending,
@@ -3109,10 +3137,27 @@ func (o *Owner) cacheResponse(method string, raw []byte) {
 	}
 }
 
+// successfulJSONRPCResponse reports whether a parsed response carries a result
+// and no error. Discovery error frames are routed to their caller but never
+// become reusable cache or template authority.
+func successfulJSONRPCResponse(raw []byte) bool {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return false
+	}
+	_, hasResult := fields["result"]
+	_, hasError := fields["error"]
+	return hasResult && !hasError
+}
+
 // cacheResponseState commits cache and classification state without downstream
 // session I/O. The caller may hold upstreamEventMu to linearize a live process
 // response against process-generation replacement.
 func (o *Owner) cacheResponseState(method string, raw []byte) bool {
+	if !successfulJSONRPCResponse(raw) {
+		o.logger.Printf("not caching unsuccessful %s response", method)
+		return false
+	}
 	cached := make([]byte, len(raw))
 	copy(cached, raw)
 

--- a/muxcore/owner/owner.go
+++ b/muxcore/owner/owner.go
@@ -45,12 +45,6 @@ type (
 	SessionSnapshot = snapshot.SessionSnapshot
 )
 
-const (
-	upstreamRespawnWaitTimeout = 30 * time.Second
-	upstreamRespawnInitialWait = 100 * time.Millisecond
-	upstreamRespawnMaxWait     = 2 * time.Second
-)
-
 // Constructor aliases.
 var (
 	NewSession              = session.NewSession
@@ -134,11 +128,13 @@ type Owner struct {
 	serverID                    string    // server identity hash
 	listener                    net.Listener
 	logger                      *log.Logger
-	onZeroSessions              func(serverID string)
 
-	onUpstreamExit       func(serverID string)
-	onPersistentDetected func(serverID string)
-	onCacheReady         func(serverID string)
+	onZeroSessions       func(*Owner)
+	onUpstreamExit       func(*Owner)
+	onPersistentDetected func(*Owner)
+	onPersistentResolved func(*Owner, bool)
+	onCacheReady         func(*Owner, OwnerSnapshot) bool
+	onCacheInvalidated   func(*Owner)
 
 	// authorizeSession is the optional pre-dispatch session-admission gate
 	// forwarded from engine.Config / daemon.Config / OwnerConfig. nil = no
@@ -197,27 +193,42 @@ type Owner struct {
 	startTime               time.Time
 	controlServer           *control.Server
 
-	shutdownOnce      sync.Once
-	closeListenerOnce sync.Once
-	isAccepting       atomic.Bool
-	listenerDone      chan struct{} // closed when IPC listener is intentionally stopped
-	done              chan struct{}
+	shutdownOnce            sync.Once
+	teardownOnce            sync.Once
+	removalMu               sync.Mutex
+	closeListenerOnce       sync.Once
+	isAccepting             atomic.Bool
+	admissionFrozen         atomic.Bool
+	pendingAdmissionsPurged atomic.Int64
+	listenerDone            chan struct{} // closed when IPC listener is intentionally stopped
+	done                    chan struct{}
 
-	// backgroundSpawnCh is non-nil for owners created via NewOwnerFromSnapshot,
-	// where the upstream is started asynchronously via SpawnUpstreamBackground.
-	// It is closed (under mu) when background spawn finishes (success or failure),
-	// allowing Serve to block instead of treating nil upstream as dead.
-	backgroundSpawnCh         chan struct{}
-	beforeBackgroundSpawnWait func() // test-only synchronization seam; nil in production
-	afterProactiveStore       func() // test-only registration race seam
-
-	respawnMu sync.Mutex
-	respawn   *upstreamRespawn
-}
-
-type upstreamRespawn struct {
-	done chan struct{}
-	err  error
+	restartPins atomic.Int64
+	// Lock order is upstreamEventMu, materializationMu, admissionMu, then mu.
+	// Writers never hold upstreamEventMu across process Close/SoftClose; readers
+	// may hold it across bounded session I/O. admissionMu serializes token bind +
+	// session registration against coherent classification commits.
+	upstreamEventMu                  sync.RWMutex
+	materializationMu                sync.Mutex
+	admissionMu                      sync.Mutex
+	materializationPolicy            MaterializationPolicy
+	materializationState             MaterializationState
+	materializationTrigger           MaterializationTrigger
+	materializationGeneration        uint64
+	materializationAttempt           *materializationAttempt
+	retiringProcess                  *upstream.Process
+	materializationBlockedErr        error
+	materializationStop              chan struct{}
+	pendingDemands                   map[string]*localDemand
+	pendingDemandOrder               []string
+	persistentPending                bool
+	persistentRequired               bool
+	restartResumeTrigger             MaterializationTrigger
+	materializationFinalizationProbe func(*upstream.Process) error
+	beforeQueuedDemandWrite          func()
+	beforeLocalDemandCancel          func()
+	afterProactiveStore              func() // test-only registration race seam
+	cacheStage                       *cacheStage
 }
 
 // OwnerConfig holds parameters for creating an Owner.
@@ -240,28 +251,47 @@ type OwnerConfig struct {
 	// ServerID is the server identity hash. Used in callbacks to identify this owner.
 	ServerID string
 
-	// OnZeroSessions is called when the last session disconnects.
-	// If nil, the owner does not auto-shutdown on zero sessions (legacy behavior
-	// shuts down only on upstream exit or signal).
-	OnZeroSessions func(serverID string)
+	// OnZeroSessions is called with the exact owner whose last session left.
+	// If nil, the owner does not auto-shutdown on zero sessions.
+	OnZeroSessions func(*Owner)
 
-	// OnUpstreamExit is called when the upstream process exits.
-	// If nil, the owner auto-shuts down (legacy behavior).
-	OnUpstreamExit func(serverID string)
+	// OnUpstreamExit is called with the exact owner whose controller cannot
+	// recover the upstream. If nil, the owner auto-shuts down.
+	OnUpstreamExit func(*Owner)
 
-	// OnPersistentDetected is called when the upstream declares x-mux.persistent: true.
-	// Used by the daemon to mark the owner entry as persistent.
-	OnPersistentDetected func(serverID string)
+	// OnPersistentDetected latches a fresh generation's early persistent=true
+	// declaration before coherent discovery commit.
+	OnPersistentDetected func(*Owner)
 
-	// OnCacheReady is called when the owner has cached both init and tools/list responses.
-	// Used by the daemon to update the template cache for instant isolated server spawns.
-	OnCacheReady func(serverID string)
+	// OnCacheReady synchronously publishes one coherent cache/template snapshot.
+	// Returning false rejects a stale owner generation and aborts the commit.
+	OnCacheReady func(*Owner, OwnerSnapshot) bool
+
+	// OnCacheInvalidated removes only this exact owner's daemon template.
+	OnCacheInvalidated func(*Owner)
+
+	// OnPersistentResolved receives a coherent generation's exact persistence
+	// verdict for non-template consumers.
+	OnPersistentResolved func(*Owner, bool)
+
+	// MaterializationPolicy controls owners created without a live upstream.
+	// The zero value is eager, preserving existing direct consumer behavior.
+	MaterializationPolicy MaterializationPolicy
+	// DeferInitialMaterialization lets the daemon register the exact OwnerEntry
+	// before a fast upstream can publish its first cache generation.
+	DeferInitialMaterialization bool
 
 	// TokenHandshake enables reading the shim's handshake token from each new IPC
 	// connection before the MCP session begins. Only set true when the owner is
 	// managed by the global daemon — shims always send a token in that mode.
 	// Legacy and test connections do not send a token; leave this false (default).
 	TokenHandshake bool
+	// PersistentPending protects cache-only restored owners from eviction until
+	// live discovery resolves x-mux.persistent.
+	PersistentPending bool
+	// PersistentRequired is an external daemon policy that fresh discovery may
+	// not downgrade.
+	PersistentRequired bool
 
 	// HandlerFunc is an in-process MCP server implementation.
 	// When set, Owner runs the handler via io.Pipe instead of spawning a subprocess.
@@ -292,6 +322,10 @@ type OwnerConfig struct {
 	// successor adopts its result directly.
 	CachedClassification classify.SharingMode
 
+	// AdoptedSnapshot carries the predecessor's coherent cache into a live
+	// process-backed handoff. It is in-memory only and adds no persistence field.
+	AdoptedSnapshot *OwnerSnapshot
+
 	// AuthorizeSession, when non-nil, gates every accepted session BEFORE
 	// AddSession is called. acceptLoop invokes the callback with peer
 	// credentials + project context and acts on the returned SessionAuth:
@@ -319,10 +353,9 @@ type OwnerConfig struct {
 	Logger *log.Logger
 }
 
-// NewOwnerFromSnapshot creates an Owner with pre-populated caches from a snapshot.
-// Does NOT spawn the upstream process — caller must call SpawnUpstreamBackground()
-// after the owner is registered in the daemon. The owner serves cached responses
-// immediately (cache-first mode) while the upstream starts in the background.
+// NewOwnerFromSnapshot creates a cache-backed Owner without a live upstream.
+// The caller chooses eager, persistent, or demand-driven materialization via
+// OwnerConfig.MaterializationPolicy after registering the owner in the daemon.
 func NewOwnerFromSnapshot(cfg OwnerConfig, snap OwnerSnapshot) (*Owner, error) {
 	logger := cfg.Logger
 	if logger == nil {
@@ -343,32 +376,31 @@ func NewOwnerFromSnapshot(cfg OwnerConfig, snap OwnerSnapshot) (*Owner, error) {
 		cwdSet[cfg.Cwd] = true
 	}
 	o := &Owner{
-		proactiveNamespace:   nextProactiveNamespace(),
-		ipcPath:              cfg.IPCPath,
-		cwd:                  cfg.Cwd,
-		cwdSet:               cwdSet,
-		command:              cfg.Command,
-		args:                 cfg.Args,
-		env:                  cfg.Env,
-		handlerFunc:          cfg.HandlerFunc,
-		sessionHandler:       cfg.SessionHandler,
-		serverID:             cfg.ServerID,
-		listener:             ln,
-		logger:               logger,
-		onZeroSessions:       cfg.OnZeroSessions,
-		onUpstreamExit:       cfg.OnUpstreamExit,
-		onPersistentDetected: cfg.OnPersistentDetected,
-		onCacheReady:         cfg.OnCacheReady,
-		authorizeSession:     cfg.AuthorizeSession,
-		onFrameReceived:      cfg.OnFrameReceived,
-		sessions:             make(map[int]*Session),
-		cachedInitSessions:   make(map[int]bool),
-		sessionMgr:           NewSessionManager(),
-		tokenHandshake:       cfg.TokenHandshake,
-		// rejectionLogger is created lazily below, only when tokenHandshake is
-		// enabled — legacy/test owners with tokenHandshake=false never rate-limit
-		// anything, so the per-Owner ticker goroutine adds cost without value
-		// (measurable scheduler pressure on CI under -race with many owners).
+		proactiveNamespace:     nextProactiveNamespace(),
+		ipcPath:                cfg.IPCPath,
+		cwd:                    cfg.Cwd,
+		cwdSet:                 cwdSet,
+		command:                cfg.Command,
+		args:                   cfg.Args,
+		env:                    cfg.Env,
+		handlerFunc:            cfg.HandlerFunc,
+		sessionHandler:         cfg.SessionHandler,
+		upstreamWriter:         cfg.UpstreamWriter,
+		serverID:               cfg.ServerID,
+		listener:               ln,
+		logger:                 logger,
+		onZeroSessions:         cfg.OnZeroSessions,
+		onUpstreamExit:         cfg.OnUpstreamExit,
+		onPersistentDetected:   cfg.OnPersistentDetected,
+		onPersistentResolved:   cfg.OnPersistentResolved,
+		onCacheReady:           cfg.OnCacheReady,
+		onCacheInvalidated:     cfg.OnCacheInvalidated,
+		authorizeSession:       cfg.AuthorizeSession,
+		onFrameReceived:        cfg.OnFrameReceived,
+		sessions:               make(map[int]*Session),
+		cachedInitSessions:     make(map[int]bool),
+		sessionMgr:             NewSessionManager(),
+		tokenHandshake:         cfg.TokenHandshake,
 		autoClassification:     snap.Classification,
 		classificationSource:   snap.ClassificationSource,
 		classificationReason:   snap.ClassificationReason,
@@ -381,7 +413,15 @@ func NewOwnerFromSnapshot(cfg OwnerConfig, snap OwnerSnapshot) (*Owner, error) {
 		startTime:              time.Now(),
 		listenerDone:           make(chan struct{}),
 		done:                   make(chan struct{}),
-		backgroundSpawnCh:      make(chan struct{}),
+		materializationPolicy:  cfg.MaterializationPolicy,
+		materializationState:   MaterializationCacheOnly,
+		persistentRequired:     cfg.PersistentRequired,
+		materializationStop:    make(chan struct{}),
+		pendingDemands:         make(map[string]*localDemand),
+		persistentPending:      cfg.PersistentPending,
+	}
+	if cfg.UpstreamWriter != nil || (cfg.SessionHandler != nil && cfg.HandlerFunc == nil) {
+		o.materializationState = MaterializationReady
 	}
 	o.progressIntervalNs.Store(int64(5 * time.Second))
 
@@ -392,42 +432,14 @@ func NewOwnerFromSnapshot(cfg OwnerConfig, snap OwnerSnapshot) (*Owner, error) {
 		imported := o.sessionMgr.ImportBoundHistory(boundTokenSnapshotsToSession(snap.BoundTokens))
 		logger.Printf("owner restored %d reconnect token history entries from snapshot", imported)
 	}
-
-	// Cache optional *WithSessionMeta interface upgrades for hot-path dispatch.
-	o.cacheHandlerInterfaces()
-
-	// Pre-populate caches from snapshot
-	if snap.CachedInit != "" {
-		if data, err := Base64Decode(snap.CachedInit); err == nil {
-			o.initResp = data
-			o.initDone = true
-		}
-	}
-	if snap.CachedTools != "" {
-		if data, err := Base64Decode(snap.CachedTools); err == nil {
-			o.toolList = data
-		}
-	}
-	if snap.CachedPrompts != "" {
-		if data, err := Base64Decode(snap.CachedPrompts); err == nil {
-			o.promptList = data
-		}
-	}
-	if snap.CachedResources != "" {
-		if data, err := Base64Decode(snap.CachedResources); err == nil {
-			o.resourceList = data
-		}
-	}
-	if snap.CachedResourceTemplates != "" {
-		if data, err := Base64Decode(snap.CachedResourceTemplates); err == nil {
-			o.resourceTemplateList = data
-		}
-	}
+	// Pre-populate one coherent cache generation from the snapshot.
+	o.hydrateSnapshotCache(snap)
 
 	// Close initReady and classified immediately — caches already populated
 	o.initReadyOnce.Do(func() { close(o.initReady) })
 	o.classifiedOnce.Do(func() { close(o.classified) })
 
+	o.cacheHandlerInterfaces()
 	// Wire notifier into sessionHandler if it supports NotifierAware.
 	if o.sessionHandler != nil {
 		if na, ok := o.sessionHandler.(muxcore.NotifierAware); ok {
@@ -457,93 +469,45 @@ func NewOwnerFromSnapshot(cfg OwnerConfig, snap OwnerSnapshot) (*Owner, error) {
 	return o, nil
 }
 
+// hydrateSnapshotCache installs a previously committed cache generation before
+// any owner goroutine starts. Callers must provide exclusive construction-time
+// ownership of o.
+func (o *Owner) hydrateSnapshotCache(snap OwnerSnapshot) {
+	o.autoClassification = snap.Classification
+	o.classificationSource = snap.ClassificationSource
+	o.classificationReason = append([]string(nil), snap.ClassificationReason...)
+	if snap.CachedInit != "" {
+		if data, err := Base64Decode(snap.CachedInit); err == nil {
+			o.initResp = data
+			o.initDone = true
+		}
+	}
+	if snap.CachedTools != "" {
+		if data, err := Base64Decode(snap.CachedTools); err == nil {
+			o.toolList = data
+		}
+	}
+	if snap.CachedPrompts != "" {
+		if data, err := Base64Decode(snap.CachedPrompts); err == nil {
+			o.promptList = data
+		}
+	}
+	if snap.CachedResources != "" {
+		if data, err := Base64Decode(snap.CachedResources); err == nil {
+			o.resourceList = data
+		}
+	}
+	if snap.CachedResourceTemplates != "" {
+		if data, err := Base64Decode(snap.CachedResourceTemplates); err == nil {
+			o.resourceTemplateList = data
+		}
+	}
+}
+
 // SpawnUpstreamBackground starts the upstream process in a goroutine and runs
 // proactive init to refresh caches. Called after NewOwnerFromSnapshot when the
 // owner is registered in the daemon. If upstream fails, owner continues serving
 // stale cached responses.
-func (o *Owner) SpawnUpstreamBackground() {
-	go func() {
-		// Check if owner is already shutting down before spawning
-		select {
-		case <-o.done:
-			return
-		default:
-		}
-		if o.sessionHandler != nil && o.handlerFunc == nil {
-			o.logger.Printf("background SessionHandler-only spawn: no upstream process")
-			o.finishBackgroundSpawn()
-			return
-		}
-
-		var proc *upstream.Process
-		var err error
-		if o.handlerFunc != nil {
-			proc = upstream.NewProcessFromHandler(context.Background(), o.handlerFunc)
-			o.logger.Printf("background handler spawn: in-process (no subprocess)")
-		} else {
-			// CRITICAL: pass o.env (captured at owner creation), NOT nil.
-			// upstream.Start treats nil env as "inherit daemon os.Environ()",
-			// which loses MCP-config-specific vars like CCLSP_CONFIG_PATH that
-			// only exist in the spawning shim's env, not in the daemon's.
-			// Observed failure: cclsp respawn emits
-			//   "Error: configPath is required when CCLSP_CONFIG_PATH environment variable is not set"
-			// on background respawn (first spawn used ownerCfg.Env correctly;
-			// this path dropped it). Causes 3+ minute recovery loops while
-			// suture retries via FailureBackoff.
-			proc, err = upstream.Start(o.command, o.args, o.env, o.cwd, o.logger)
-		}
-		if err != nil {
-			o.logger.Printf("background upstream spawn failed: %v (serving stale cache)", err)
-			o.finishBackgroundSpawn()
-			return
-		}
-
-		// Check again after spawn — owner may have shut down while process was starting
-		select {
-		case <-o.done:
-			proc.Close()
-			o.finishBackgroundSpawn()
-			return
-		default:
-		}
-
-		o.mu.Lock()
-		o.upstream = proc
-		// Keep public cached readiness intact while a separate generation-local
-		// proactive handshake proves this new process is lifecycle-ready.
-		hadCachedLists := o.toolList != nil || o.promptList != nil ||
-			o.resourceList != nil || o.resourceTemplateList != nil
-		if hadCachedLists {
-			// Keep snapshot list caches usable while the replacement upstream is
-			// warming. Clearing here creates a startup race: clients that already
-			// received cached initialize can miss cached tools/list and block on
-			// the live upstream until their MCP startup timeout expires. The first
-			// fresh tools/list response below will replace the tools cache, clear
-			// non-refreshed prompt/resource caches, and broadcast list_changed.
-			o.listChangedAfterRefresh.Store(true)
-		}
-		o.mu.Unlock()
-
-		// Start reading and monitoring before initialization so a failed generation
-		// always releases the pending background-spawn gate.
-		go o.readUpstream(proc)
-		go o.monitorUpstreamExit(proc)
-
-		// Keep backgroundSpawnCh pending until the new generation has answered
-		// initialize and notifications/initialized has been written. This prevents
-		// the first uncached request from overtaking the MCP lifecycle handshake.
-		o.sendProactiveInit(proc, o.finishBackgroundSpawn)
-	}()
-}
-
-func (o *Owner) finishBackgroundSpawn() {
-	o.mu.Lock()
-	if o.backgroundSpawnCh != nil {
-		close(o.backgroundSpawnCh)
-		o.backgroundSpawnCh = nil
-	}
-	o.mu.Unlock()
-}
 
 // NewOwner creates and starts a new Owner.
 // It spawns the upstream process and starts the IPC listener.
@@ -555,67 +519,37 @@ func NewOwner(cfg OwnerConfig) (*Owner, error) {
 		logger = log.Default()
 	}
 
-	// Spawn upstream — either in-process handler, subprocess, injected writer, or neither (SessionHandler-only).
-	var proc *upstream.Process
-	if cfg.UpstreamWriter != nil {
-		// Writer-injection mode: skip subprocess spawn entirely.
-		// writeUpstream routes bytes directly into the caller's writer.
-		// Intended for tests that exercise pure JSON-building methods without
-		// the subprocess-timing flake class. No upstream process, no exit event.
-		logger.Printf("owner: writer-injection mode (no subprocess)")
-	} else if cfg.SessionHandler != nil && cfg.HandlerFunc == nil {
-		// SessionHandler-only: no upstream process needed.
-		// Requests dispatch directly via dispatchToSessionHandler.
-		logger.Printf("owner: SessionHandler-only mode (no upstream process)")
-	} else if cfg.HandlerFunc != nil {
-		proc = upstream.NewProcessFromHandler(context.Background(), cfg.HandlerFunc)
-		logger.Printf("owner: started in-process handler (no subprocess)")
-	} else {
-		var err error
-		proc, err = upstream.Start(cfg.Command, cfg.Args, cfg.Env, cfg.Cwd, logger)
-		if err != nil {
-			return nil, fmt.Errorf("owner: start upstream: %w", err)
-		}
-	}
-
-	// Start IPC listener
 	ln, err := ipc.Listen(cfg.IPCPath)
 	if err != nil {
-		if proc != nil {
-			proc.Close()
-		}
 		return nil, fmt.Errorf("owner: listen %s: %w", cfg.IPCPath, err)
 	}
 
 	o := &Owner{
-		upstream:             proc,
-		ipcPath:              cfg.IPCPath,
-		cwd:                  cfg.Cwd,
-		cwdSet:               map[string]bool{serverid.CanonicalizePath(cfg.Cwd): true},
-		command:              cfg.Command,
-		args:                 cfg.Args,
-		env:                  cfg.Env,
-		handlerFunc:          cfg.HandlerFunc,
-		proactiveNamespace:   nextProactiveNamespace(),
-		sessionHandler:       cfg.SessionHandler,
-		upstreamWriter:       cfg.UpstreamWriter,
-		serverID:             cfg.ServerID,
-		listener:             ln,
-		logger:               logger,
-		onZeroSessions:       cfg.OnZeroSessions,
-		onUpstreamExit:       cfg.OnUpstreamExit,
-		onPersistentDetected: cfg.OnPersistentDetected,
-		onCacheReady:         cfg.OnCacheReady,
-		authorizeSession:     cfg.AuthorizeSession,
-		onFrameReceived:      cfg.OnFrameReceived,
-		sessions:             make(map[int]*Session),
-		cachedInitSessions:   make(map[int]bool),
-		sessionMgr:           NewSessionManager(),
-		tokenHandshake:       cfg.TokenHandshake,
-		// rejectionLogger is created lazily below, only when tokenHandshake is
-		// enabled — legacy/test owners with tokenHandshake=false never rate-limit
-		// anything, so the per-Owner ticker goroutine adds cost without value
-		// (measurable scheduler pressure on CI under -race with many owners).
+		proactiveNamespace:     nextProactiveNamespace(),
+		ipcPath:                cfg.IPCPath,
+		cwd:                    cfg.Cwd,
+		cwdSet:                 map[string]bool{serverid.CanonicalizePath(cfg.Cwd): true},
+		command:                cfg.Command,
+		args:                   cfg.Args,
+		env:                    cfg.Env,
+		handlerFunc:            cfg.HandlerFunc,
+		sessionHandler:         cfg.SessionHandler,
+		upstreamWriter:         cfg.UpstreamWriter,
+		serverID:               cfg.ServerID,
+		listener:               ln,
+		logger:                 logger,
+		onZeroSessions:         cfg.OnZeroSessions,
+		onUpstreamExit:         cfg.OnUpstreamExit,
+		onPersistentDetected:   cfg.OnPersistentDetected,
+		onPersistentResolved:   cfg.OnPersistentResolved,
+		onCacheReady:           cfg.OnCacheReady,
+		onCacheInvalidated:     cfg.OnCacheInvalidated,
+		authorizeSession:       cfg.AuthorizeSession,
+		onFrameReceived:        cfg.OnFrameReceived,
+		sessions:               make(map[int]*Session),
+		cachedInitSessions:     make(map[int]bool),
+		sessionMgr:             NewSessionManager(),
+		tokenHandshake:         cfg.TokenHandshake,
 		classified:             make(chan struct{}),
 		initReady:              make(chan struct{}),
 		progressOwners:         make(map[string]int),
@@ -625,58 +559,47 @@ func NewOwner(cfg OwnerConfig) (*Owner, error) {
 		startTime:              time.Now(),
 		listenerDone:           make(chan struct{}),
 		done:                   make(chan struct{}),
+		materializationPolicy:  cfg.MaterializationPolicy,
+		materializationState:   MaterializationCacheOnly,
+		persistentRequired:     cfg.PersistentRequired,
+		materializationStop:    make(chan struct{}),
+		pendingDemands:         make(map[string]*localDemand),
+		persistentPending:      cfg.PersistentPending,
 	}
 	o.progressIntervalNs.Store(int64(5 * time.Second))
 
 	if o.tokenHandshake {
 		o.rejectionLogger = newRejectionLogger(logger)
 	}
-
-	// Cache optional *WithSessionMeta interface upgrades for hot-path dispatch.
 	o.cacheHandlerInterfaces()
-
-	// Wire notifier into sessionHandler if it supports NotifierAware.
 	if o.sessionHandler != nil {
 		if na, ok := o.sessionHandler.(muxcore.NotifierAware); ok {
 			na.SetNotifier(&ownerNotifier{owner: o})
 		}
 	}
-
-	// Start control plane if configured
 	if cfg.ControlPath != "" {
-		ctlSrv, err := control.NewServer(cfg.ControlPath, o, logger)
-		if err != nil {
-			logger.Printf("warning: control server failed to start: %v", err)
+		ctlSrv, ctlErr := control.NewServer(cfg.ControlPath, o, logger)
+		if ctlErr != nil {
+			logger.Printf("warning: control server failed to start: %v", ctlErr)
 		} else {
 			o.controlServer = ctlSrv
 			logger.Printf("control socket: %s", cfg.ControlPath)
 		}
 	}
 
-	// Start reading from upstream
-	if proc != nil {
-		go o.readUpstream(proc)
+	if cfg.UpstreamWriter != nil || (cfg.SessionHandler != nil && cfg.HandlerFunc == nil) {
+		o.materializationState = MaterializationReady
+	} else if !cfg.DeferInitialMaterialization {
+		a := o.startMaterialization(MaterializationTriggerEager)
+		<-a.started
+		if a.startedErr != nil {
+			o.Shutdown()
+			return nil, fmt.Errorf("owner: start upstream: %w", a.startedErr)
+		}
 	}
 
-	// Send proactive initialize to upstream so init response is cached
-	// before any session connects. Without this, Daemon.Spawn blocks on
-	// InitReady() but init requires a session to send the request — deadlock.
-	// SessionHandler-only owners have no upstream, so skip the proactive init.
-	if proc != nil {
-		go o.sendProactiveInit(proc, nil)
-	}
-
-	// Start accepting IPC connections
 	go o.acceptLoop()
-
-	// Start synthetic progress reporter
 	go o.runProgressReporter(doneContext(o.done))
-
-	// Monitor upstream exit (skip in SessionHandler-only mode — proc is nil)
-	if proc != nil {
-		go o.monitorUpstreamExit(proc)
-	}
-
 	return o, nil
 }
 
@@ -686,14 +609,28 @@ func (o *Owner) SessionMgr() *SessionManager {
 	return o.sessionMgr
 }
 
+// PendingAdmissionsPurged reports reservations revoked when admission closed.
+// Daemon removal accounting combines this with any final manager cleanup.
+func (o *Owner) PendingAdmissionsPurged() int {
+	return int(o.pendingAdmissionsPurged.Load())
+}
+
 // PreRegister atomically reserves a token for a fresh shim while this owner is
 // accepting fresh consumers. A classified-isolated owner keeps its listener
 // alive for exact-token reconnects, but generic fresh admission remains closed.
-// The owner lock always precedes the session-manager lock; accept-loop session
-// lookups release the session-manager lock before entering owner state.
+// admissionMu precedes the owner and session-manager locks so classification
+// commit can atomically freeze and revoke provisional fan-in.
 func (o *Owner) PreRegister(token, cwd string, env map[string]string) bool {
+	if o.admissionFrozen.Load() {
+		return false
+	}
+	o.admissionMu.Lock()
+	defer o.admissionMu.Unlock()
 	o.mu.Lock()
 	defer o.mu.Unlock()
+	if o.admissionFrozen.Load() {
+		return false
+	}
 	select {
 	case <-o.listenerDone:
 		return false
@@ -712,19 +649,43 @@ func (o *Owner) PreRegister(token, cwd string, env map[string]string) bool {
 // installed; later fresh consumers must use PreRegister and are rejected once
 // isolation is known.
 func (o *Owner) PreRegisterInitial(token, cwd string, env map[string]string) bool {
-	o.mu.Lock()
-	defer o.mu.Unlock()
-	select {
-	case <-o.listenerDone:
-		return false
-	default:
+	deadline := time.Now().Add(materializationReadinessTimeout)
+	for {
+		o.admissionMu.Lock()
+		o.mu.Lock()
+		if o.admissionFrozen.Load() {
+			o.mu.Unlock()
+			o.admissionMu.Unlock()
+			if time.Now().After(deadline) {
+				return false
+			}
+			time.Sleep(time.Millisecond)
+			continue
+		}
+		select {
+		case <-o.listenerDone:
+			o.mu.Unlock()
+			o.admissionMu.Unlock()
+			return false
+		default:
+		}
+		if o.initialAdmissionToken != "" && o.initialAdmissionToken != token {
+			o.mu.Unlock()
+			o.admissionMu.Unlock()
+			return false
+		}
+		o.initialAdmissionToken = token
+		o.sessionMgr.PreRegisterForOwner(token, o.serverID, cwd, env)
+		o.mu.Unlock()
+		o.admissionMu.Unlock()
+		return true
 	}
-	if o.initialAdmissionToken != "" && o.initialAdmissionToken != token {
-		return false
+}
+
+func (o *Owner) revokePendingAdmission(token string) {
+	if token != "" {
+		o.sessionMgr.RemovePendingForOwnerToken(o.ServerID(), token)
 	}
-	o.initialAdmissionToken = token
-	o.sessionMgr.PreRegisterForOwner(token, o.serverID, cwd, env)
-	return true
 }
 
 // readToken reads the handshake token sent by the shim immediately after connecting.
@@ -796,11 +757,23 @@ func extractToolName(raw []byte) string {
 // AddSession registers a new downstream session and starts routing its messages.
 // This is used for the owner's own stdio session (first client).
 func (o *Owner) AddSession(s *Session) {
+	o.admissionMu.Lock()
+	o.addSessionLocked(s)
+	o.admissionMu.Unlock()
+	o.startRegisteredSession(s)
+}
+
+// addSessionLocked atomically publishes one admitted session. The caller holds
+// admissionMu so an isolated classification commit cannot split token Bind
+// from owner/session-manager registration.
+func (o *Owner) addSessionLocked(s *Session) {
 	o.mu.Lock()
 	o.sessions[s.ID] = s
 	o.mu.Unlock()
-
 	o.sessionMgr.RegisterSession(s, s.Cwd)
+}
+
+func (o *Owner) startRegisteredSession(s *Session) {
 	o.touchActivity()
 	o.logger.Printf("session %d connected (cwd: %q)", s.ID, s.Cwd)
 
@@ -817,7 +790,6 @@ func (o *Owner) AddSession(s *Session) {
 
 	// Notify upstream that roots may have changed (new client = new potential root)
 	o.sendRootsListChanged()
-
 	go o.readSession(s)
 }
 
@@ -919,7 +891,7 @@ func (o *Owner) handleDownstreamMessage(s *Session, msg *jsonrpc.Message) error 
 		if !o.hasWritableUpstream() {
 			return nil // snapshot owner — upstream not yet spawned, drop notification
 		}
-		return o.writeUpstream(msg.Raw)
+		return o.forwardNotificationIfReady(msg.Raw)
 
 	case msg.IsRequest():
 		// Replay from cache if available (avoids upstream round-trip).
@@ -942,106 +914,13 @@ func (o *Owner) handleDownstreamMessage(s *Session, msg *jsonrpc.Message) error 
 			return o.dispatchToSessionHandler(s, msg)
 		}
 
-		// Fail fast if upstream is dead or not yet spawned (pipe-based mode only).
-		if !o.hasWritableUpstream() || o.upstreamDead.Load() {
-			if err := o.ensureUpstreamReadyForRequest(); err != nil {
-				errResp := fmt.Sprintf(`{"jsonrpc":"2.0","id":%s,"error":{"code":-32603,"message":%q}}`, string(msg.ID), err.Error())
-				return s.WriteRaw([]byte(errResp))
+		if !o.materializationReadyForRequests() {
+			queued, err := o.enqueueLocalDemand(s, msg)
+			if queued || err != nil {
+				return err
 			}
 		}
-
-		// Track pending requests
-		o.pendingRequests.Add(1)
-
-		// Remap ID and forward to upstream
-		newID := remap.Remap(s.ID, msg.ID)
-		remapped, err := jsonrpc.ReplaceID(msg.Raw, newID)
-		if err != nil {
-			o.decrementPending() // undo increment on error
-			return fmt.Errorf("remap request: %w", err)
-		}
-
-		// Track inflight request for observability (mux_list --verbose)
-		o.inflightTracker.Store(string(newID), &InflightRequest{
-			Method:    msg.Method,
-			Tool:      extractToolName(msg.Raw),
-			SessionID: s.ID,
-			StartTime: time.Now(),
-		})
-
-		// Tag cacheable methods for response interception
-		if msg.Method == "initialize" || msg.Method == "tools/list" ||
-			msg.Method == "prompts/list" || msg.Method == "resources/list" ||
-			msg.Method == "resources/templates/list" {
-			o.methodTags.Store(string(newID), msg.Method)
-		}
-
-		// Capture protocolVersion from the first initialize request for fingerprint matching
-		if msg.Method == "initialize" {
-			o.captureInitFingerprint(msg.Raw)
-		}
-
-		// Inject _meta.muxSessionId, _meta.muxCwd, and _meta.muxEnv when the upstream
-		// needs to distinguish between CC sessions. Two cases:
-		// 1. session-aware: upstream declared x-mux.sharing: session-aware
-		// 2. in-process handler: single handler serves all CC sessions, always needs session identity
-		o.mu.RLock()
-		needsMeta := o.autoClassification == classify.ModeSessionAware || o.handlerFunc != nil
-		o.mu.RUnlock()
-		if needsMeta {
-			injected, err := jsonrpc.InjectMeta(remapped, "muxSessionId", s.MuxSessionID)
-			if err != nil {
-				o.logger.Printf("session %d: failed to inject muxSessionId: %v", s.ID, err)
-			} else {
-				remapped = injected
-			}
-			// Inject per-session cwd so upstream knows the CC session's project directory
-			if s.Cwd != "" {
-				injected, err := jsonrpc.InjectMeta(remapped, "muxCwd", s.Cwd)
-				if err != nil {
-					o.logger.Printf("session %d: failed to inject muxCwd: %v", s.ID, err)
-				} else {
-					remapped = injected
-				}
-			}
-			// Inject per-session env diff so upstream can use project-scope credentials
-			if len(s.Env) > 0 {
-				injected, err := jsonrpc.InjectMeta(remapped, "muxEnv", s.Env)
-				if err != nil {
-					o.logger.Printf("session %d: failed to inject muxEnv: %v", s.ID, err)
-				} else {
-					remapped = injected
-				}
-			}
-		}
-
-		// Track progressToken ownership for targeted notification routing
-		o.trackProgressToken(s.ID, string(newID), msg.Raw)
-
-		// Record the active session so server→client requests can be routed back
-		o.sessionMgr.TrackRequest(string(newID), s.ID)
-
-		// Start tool-call watchdog if the upstream declared x-mux.toolTimeout.
-		// The watchdog synthesizes a timeout error response if the upstream
-		// doesn't respond within the declared window. Prevents eternal hangs
-		// when upstream deadlocks or crashes silently during a tool call.
-		if msg.Method == "tools/call" && o.toolTimeoutNs.Load() > 0 {
-			o.startToolWatchdog(string(newID), msg.ID, s, msg.Method)
-		}
-
-		proc, writeErr := o.writeUpstreamFromCurrent(remapped)
-		if writeErr != nil {
-			o.logger.Printf("session %d: upstream write failed for request id=%s: %v", s.ID, string(newID), writeErr)
-			if proc != nil && o.markCurrentUpstreamDead(proc) {
-				o.initReadyOnce.Do(func() { close(o.initReady) })
-				_ = proc.Close()
-				if o.shouldRespawnUpstream() {
-					o.startUpstreamRespawn("write_error")
-				}
-			}
-			return nil
-		}
-		return nil
+		return o.forwardRequestNow(s, msg)
 
 	case msg.IsResponse():
 		// Client is responding to a server→client request (e.g., sampling/createMessage).
@@ -1236,6 +1115,7 @@ func (o *Owner) readUpstream(proc *upstream.Process) {
 			o.logger.Printf("upstream parse error: %v", err)
 			continue
 		}
+
 		if err := o.handleUpstreamMessageFrom(proc, msg); err != nil {
 			o.logger.Printf("upstream handle error: %v", err)
 		}
@@ -1245,28 +1125,20 @@ func (o *Owner) readUpstream(proc *upstream.Process) {
 func (o *Owner) monitorUpstreamExit(proc *upstream.Process) {
 	select {
 	case <-proc.Done:
-	case <-o.done:
+	case <-o.materializationStop:
 		return
 	}
 	if !o.isCurrentUpstream(proc) {
+		o.monitorMaterializedProcessExit(proc)
 		return
 	}
-
 	o.logger.Printf("upstream exited: %v", proc.ExitErr)
-	o.markCurrentUpstreamDead(proc)
-	// Signal init-ready so Daemon.Spawn or respawn waiters do not block forever
-	// on a crashed upstream generation.
 	o.initReadyOnce.Do(func() {
 		if o.initReady != nil {
 			close(o.initReady)
 		}
 	})
-
-	if o.shouldRespawnUpstream() {
-		o.startUpstreamRespawn("upstream_exit")
-		return
-	}
-	o.notifyUpstreamExit()
+	o.monitorMaterializedProcessExit(proc)
 }
 
 func (o *Owner) isCurrentUpstream(proc *upstream.Process) bool {
@@ -1276,40 +1148,12 @@ func (o *Owner) isCurrentUpstream(proc *upstream.Process) bool {
 	return current == proc
 }
 
-func (o *Owner) shouldRespawnUpstream() bool {
-	select {
-	case <-o.done:
-		return false
-	default:
-	}
-	if o.upstreamWriter != nil {
-		return false
-	}
-	if o.sessionHandler != nil && o.handlerFunc == nil {
-		return false
-	}
-	if o.handlerFunc == nil && o.command == "" {
-		return false
-	}
-	return o.SessionCount() > 0
-}
-
 func (o *Owner) notifyUpstreamExit() {
 	if o.onUpstreamExit != nil {
-		o.onUpstreamExit(o.serverID)
+		o.onUpstreamExit(o)
 		return
 	}
 	o.Shutdown()
-}
-
-func (o *Owner) markCurrentUpstreamDead(proc *upstream.Process) bool {
-	o.drainProactiveRequests(proc)
-	if !o.isCurrentUpstream(proc) {
-		return false
-	}
-	o.upstreamDead.Store(true)
-	o.drainInflightRequests()
-	return true
 }
 
 func (o *Owner) failProactiveGeneration(proc *upstream.Process) {
@@ -1317,144 +1161,27 @@ func (o *Owner) failProactiveGeneration(proc *upstream.Process) {
 	_ = proc.Close()
 }
 
-func (o *Owner) ensureUpstreamReadyForRequest() error {
+func (o *Owner) markCurrentUpstreamDead(proc *upstream.Process) bool {
+	o.drainProactiveRequests(proc)
+	o.upstreamEventMu.Lock()
+	o.materializationMu.Lock()
 	o.mu.RLock()
-	backgroundSpawnCh := o.backgroundSpawnCh
-	beforeWait := o.beforeBackgroundSpawnWait
+	current := o.upstream == proc
 	o.mu.RUnlock()
-	if backgroundSpawnCh != nil {
-		if beforeWait != nil {
-			beforeWait()
-		}
-		timer := time.NewTimer(upstreamRespawnWaitTimeout)
-		defer timer.Stop()
-		select {
-		case <-backgroundSpawnCh:
-		case <-timer.C:
-			return fmt.Errorf("background upstream spawn still pending after %s", upstreamRespawnWaitTimeout)
-		case <-o.done:
-			return errors.New("owner shutting down")
-		}
+	if !current {
+		o.materializationMu.Unlock()
+		o.upstreamEventMu.Unlock()
+		return false
 	}
-	if o.hasWritableUpstream() && !o.upstreamDead.Load() {
-		return nil
-	}
-	if !o.shouldRespawnUpstream() {
-		return errors.New("upstream process exited")
-	}
-	state := o.startUpstreamRespawn("request")
-	timer := time.NewTimer(upstreamRespawnWaitTimeout)
-	defer timer.Stop()
-	select {
-	case <-state.done:
-		return state.err
-	case <-timer.C:
-		return fmt.Errorf("upstream respawn still pending after %s", upstreamRespawnWaitTimeout)
-	case <-o.done:
-		return errors.New("owner shutting down")
-	}
+	o.upstreamDead.Store(true)
+	responses := o.claimInflightRequests()
+	o.materializationMu.Unlock()
+	o.upstreamEventMu.Unlock()
+	o.deliverInflightResponses(responses)
+	return true
 }
 
-func (o *Owner) startUpstreamRespawn(reason string) *upstreamRespawn {
-	o.respawnMu.Lock()
-	if o.respawn != nil {
-		state := o.respawn
-		o.respawnMu.Unlock()
-		return state
-	}
-	state := &upstreamRespawn{done: make(chan struct{})}
-	o.respawn = state
-	o.respawnMu.Unlock()
-
-	go func() {
-		state.err = o.runUpstreamRespawn(reason)
-		close(state.done)
-		o.respawnMu.Lock()
-		if o.respawn == state {
-			o.respawn = nil
-		}
-		o.respawnMu.Unlock()
-	}()
-	return state
-}
-
-func (o *Owner) runUpstreamRespawn(reason string) error {
-	wait := upstreamRespawnInitialWait
-	for attempt := 1; ; attempt++ {
-		select {
-		case <-o.done:
-			return errors.New("owner shutting down")
-		default:
-		}
-		if o.SessionCount() == 0 {
-			return errors.New("no live sessions remain")
-		}
-
-		proc, err := o.spawnReplacementUpstream()
-		if err != nil {
-			o.logger.Printf("upstream respawn failed attempt=%d reason=%s err=%v", attempt, reason, err)
-			if !o.waitBeforeRespawnRetry(wait) {
-				return errors.New("owner shutting down")
-			}
-			if wait < upstreamRespawnMaxWait {
-				wait *= 2
-				if wait > upstreamRespawnMaxWait {
-					wait = upstreamRespawnMaxWait
-				}
-			}
-			continue
-		}
-
-		o.mu.Lock()
-		o.upstream = proc
-		o.initReady = make(chan struct{})
-		o.initReadyOnce = sync.Once{}
-		o.initDone = false
-		ready := o.initReady
-		if o.toolList != nil || o.promptList != nil ||
-			o.resourceList != nil || o.resourceTemplateList != nil {
-			o.listChangedAfterRefresh.Store(true)
-		}
-		o.mu.Unlock()
-		o.upstreamDead.Store(true)
-
-		o.logger.Printf("upstream respawn started attempt=%d reason=%s", attempt, reason)
-		go o.readUpstream(proc)
-		go o.monitorUpstreamExit(proc)
-		o.sendProactiveInit(proc, nil)
-
-		timer := time.NewTimer(upstreamRespawnWaitTimeout)
-		select {
-		case <-ready:
-			timer.Stop()
-			if o.InitSuccess() && o.isCurrentUpstream(proc) {
-				o.upstreamDead.Store(false)
-				o.logger.Printf("upstream respawn ready attempt=%d reason=%s", attempt, reason)
-				return nil
-			}
-			o.logger.Printf("upstream respawn attempt=%d exited before initialize completed", attempt)
-		case <-timer.C:
-			o.logger.Printf("upstream respawn attempt=%d readiness timeout after %s", attempt, upstreamRespawnWaitTimeout)
-			_ = proc.Close()
-		case <-o.done:
-			timer.Stop()
-			_ = proc.Close()
-			return errors.New("owner shutting down")
-		}
-
-		if !o.waitBeforeRespawnRetry(wait) {
-			return errors.New("owner shutting down")
-		}
-		if wait < upstreamRespawnMaxWait {
-			wait *= 2
-			if wait > upstreamRespawnMaxWait {
-				wait = upstreamRespawnMaxWait
-			}
-		}
-	}
-}
-
-func (o *Owner) spawnReplacementUpstream() (*upstream.Process, error) {
+func (o *Owner) spawnReplacementUpstream(launch LaunchContext) (*upstream.Process, error) {
 	if o.handlerFunc != nil {
 		o.logger.Printf("upstream respawn: in-process handler")
 		return upstream.NewProcessFromHandler(context.Background(), o.handlerFunc), nil
@@ -1462,18 +1189,7 @@ func (o *Owner) spawnReplacementUpstream() (*upstream.Process, error) {
 	if o.command == "" {
 		return nil, errors.New("upstream command is empty")
 	}
-	return upstream.Start(o.command, o.args, o.env, o.cwd, o.logger)
-}
-
-func (o *Owner) waitBeforeRespawnRetry(wait time.Duration) bool {
-	timer := time.NewTimer(wait)
-	defer timer.Stop()
-	select {
-	case <-timer.C:
-		return true
-	case <-o.done:
-		return false
-	}
+	return upstream.Start(o.command, o.args, launch.Env, launch.Cwd, o.logger)
 }
 
 // isProactiveID identifies only this Owner's proactive namespace. A response
@@ -1527,17 +1243,32 @@ func (o *Owner) decrementPending() {
 	}
 }
 
-// handleUpstreamMessage routes a test-injected upstream message without a process source.
+// handleUpstreamMessage routes a synthetic/test message without generation
+// staging. Live process readers call handleUpstreamMessageFrom.
 func (o *Owner) handleUpstreamMessage(msg *jsonrpc.Message) error {
 	return o.handleUpstreamMessageFrom(nil, msg)
 }
 
-// handleUpstreamMessageFrom routes a message from one exact upstream generation.
 func (o *Owner) handleUpstreamMessageFrom(proc *upstream.Process, msg *jsonrpc.Message) error {
-	if proc != nil && !o.isCurrentUpstream(proc) {
+	if proc == nil {
+		return o.handleUpstreamMessageFromLocked(proc, msg)
+	}
+	o.upstreamEventMu.RLock()
+	defer o.upstreamEventMu.RUnlock()
+	if !o.acceptsProcessEvent(proc) {
+		o.logger.Printf("dropping stale upstream message pid=%d", proc.PID())
 		return nil
 	}
+	return o.handleUpstreamMessageFromLocked(proc, msg)
+}
+
+// handleUpstreamMessageFromLocked handles one live process event while its
+// caller holds upstreamEventMu for reading. Synthetic test messages pass nil.
+func (o *Owner) handleUpstreamMessageFromLocked(proc *upstream.Process, msg *jsonrpc.Message) error {
 	if msg.IsNotification() {
+		if proc != nil && o.stageMaterializationListChanged(proc, msg.Method) {
+			return nil
+		}
 		// Route progress notifications to owning session instead of broadcast.
 		//
 		// If the token is NOT in progressOwners (e.g. the originating request
@@ -1598,6 +1329,12 @@ func (o *Owner) handleUpstreamMessageFrom(proc *upstream.Process, msg *jsonrpc.M
 		return nil
 	}
 	if o.isProactiveID(msg.ID) {
+		if methodRaw, ok := o.methodTags.LoadAndDelete(string(msg.ID)); ok {
+			o.decrementPending()
+			o.sessionMgr.CompleteRequest(string(msg.ID))
+			o.clearProgressTokensForRequest(string(msg.ID))
+			o.cacheResponseFromLocked(proc, methodRaw.(string), msg.Raw)
+		}
 		return nil
 	}
 
@@ -1606,7 +1343,7 @@ func (o *Owner) handleUpstreamMessageFrom(proc *upstream.Process, msg *jsonrpc.M
 	if _, timedOut := o.timedOutIDs.LoadAndDelete(string(msg.ID)); timedOut {
 		o.logger.Printf("dropping late response for timed-out request id=%s", string(msg.ID))
 		if methodRaw, ok := o.methodTags.LoadAndDelete(string(msg.ID)); ok {
-			o.cacheResponse(methodRaw.(string), msg.Raw)
+			o.cacheResponseFromLocked(proc, methodRaw.(string), msg.Raw)
 		}
 		o.clearProgressTokensForRequest(string(msg.ID))
 		return nil
@@ -1622,7 +1359,7 @@ func (o *Owner) handleUpstreamMessageFrom(proc *upstream.Process, msg *jsonrpc.M
 	o.clearProgressTokensForRequest(string(msg.ID))
 
 	if methodRaw, ok := o.methodTags.LoadAndDelete(string(msg.ID)); ok {
-		o.cacheResponse(methodRaw.(string), msg.Raw)
+		o.cacheResponseFromLocked(proc, methodRaw.(string), msg.Raw)
 	}
 
 	// Deremap the ID to find the target session
@@ -1899,7 +1636,7 @@ func (o *Owner) sendRootsListChanged() {
 		return // snapshot owner — upstream not yet spawned
 	}
 	notification := `{"jsonrpc":"2.0","method":"notifications/roots/list_changed"}`
-	if err := o.writeUpstream([]byte(notification)); err != nil {
+	if err := o.forwardNotificationIfReady([]byte(notification)); err != nil {
 		o.logger.Printf("failed to send roots/list_changed: %v", err)
 	}
 }
@@ -2032,6 +1769,10 @@ func (o *Owner) removeSession(s *Session) {
 		}
 	}
 	o.mu.Unlock()
+	o.cancelLocalDemandsForSession(s.ID)
+	if remaining == 0 {
+		o.cancelDisposableMaterializationForZeroSessions()
+	}
 	if len(removedTokens) > 0 {
 		o.progressTracker.Cleanup(removedTokens)
 	}
@@ -2050,7 +1791,7 @@ func (o *Owner) removeSession(s *Session) {
 		// Notify upstream that roots may have changed (client left)
 		o.sendRootsListChanged()
 	} else if o.onZeroSessions != nil {
-		o.onZeroSessions(o.serverID)
+		o.onZeroSessions(o)
 	}
 }
 
@@ -2097,10 +1838,14 @@ func (o *Owner) acceptLoop() {
 		}
 
 		var token string
+		var pendingCwd string
+		var pendingEnv map[string]string
 		var reader io.Reader = conn
 		if o.tokenHandshake {
 			token, reader = readToken(conn)
-			if token == "" || !o.sessionMgr.IsPreRegistered(token) {
+			var ok bool
+			pendingCwd, pendingEnv, ok = o.sessionMgr.LookupPendingForOwner(token, o.ServerID())
+			if token == "" || !ok {
 				peerPID := readPeerPID(conn)
 				o.rejectionLogger.Log(o.logger, peerPID)
 				conn.Close()
@@ -2110,26 +1855,15 @@ func (o *Owner) acceptLoop() {
 		// reader may be io.MultiReader if readToken prepended unconsumed bytes.
 		// conn is always the writer and closer.
 		s := NewSession(reader, conn)
+		// Authorization gets a side-effect-free snapshot of pending project
+		// context. Exact Bind is deferred until the admission commit below.
+		if token != "" {
+			s.Cwd = pendingCwd
+			s.Env = pendingEnv
+		}
 		// io.MultiReader doesn't implement io.Closer — set closer to conn explicitly
 		// so Close() can forcefully disconnect the IPC connection.
 		s.SetCloser(conn)
-		if token != "" {
-			// Bind consumes the token and sets s.Cwd from the pre-registered
-			// session data. It can return false if the token was swept by
-			// SweepExpiredPending (TTL) between IsPreRegistered and Bind.
-			// In that edge case, reject the connection instead of adding a
-			// session with no Cwd (which would produce invalid project routing).
-			if !o.sessionMgr.Bind(token, o.ServerID(), s) {
-				// Token was swept by SweepExpiredPending (TTL) or consumed by a
-				// concurrent shim between IsPreRegistered and Bind. Counted +
-				// logged by rejectionLogger.Log; do not emit a second direct
-				// Printf — that would bypass the 10/min/owner rate limit.
-				peerPID := readPeerPID(conn)
-				o.rejectionLogger.Log(o.logger, peerPID)
-				s.Close()
-				continue
-			}
-		}
 
 		// Populate cached SessionMeta with OS-level peer credentials before
 		// dispatch (FR-5/FR-6). Unconditional — token-handshake-disabled
@@ -2154,6 +1888,7 @@ func (o *Owner) acceptLoop() {
 			select {
 			case <-o.done:
 				o.logger.Printf("auth_skipped_shutdown sid=%d", s.ID)
+				o.revokePendingAdmission(token)
 				conn.Close()
 				s.Close()
 				continue
@@ -2177,6 +1912,7 @@ func (o *Owner) acceptLoop() {
 			select {
 			case <-o.done:
 				o.logger.Printf("auth_aborted_shutdown sid=%d", s.ID)
+				o.revokePendingAdmission(token)
 				conn.Close()
 				s.Close()
 				continue
@@ -2203,6 +1939,7 @@ func (o *Owner) acceptLoop() {
 					o.logger.Printf("auth_deny_marshal_error sid=%d err=%v", s.ID, marshalErr)
 				}
 				o.logger.Printf("auth_deny sid=%d reason=%q", s.ID, reason)
+				o.revokePendingAdmission(token)
 				conn.Close()
 				s.Close()
 				continue
@@ -2218,7 +1955,26 @@ func (o *Owner) acceptLoop() {
 			o.logger.Printf("auth_allow sid=%d tenant=%q", s.ID, verdict.TenantID)
 		}
 
-		o.AddSession(s)
+		o.admissionMu.Lock()
+		select {
+		case <-o.done:
+			o.admissionMu.Unlock()
+			o.logger.Printf("admission_aborted_shutdown sid=%d", s.ID)
+			o.revokePendingAdmission(token)
+			s.Close()
+			continue
+		default:
+		}
+		if token != "" && !o.sessionMgr.Bind(token, o.ServerID(), s) {
+			o.admissionMu.Unlock()
+			peerPID := readPeerPID(conn)
+			o.rejectionLogger.Log(o.logger, peerPID)
+			s.Close()
+			continue
+		}
+		o.addSessionLocked(s)
+		o.admissionMu.Unlock()
+		o.startRegisteredSession(s)
 	}
 }
 
@@ -2431,11 +2187,15 @@ func (o *Owner) resetCwdSetToPrimary() (string, int) {
 // Nil-safe: owners constructed for tests may not have a listener.
 func (o *Owner) closeListener() {
 	o.closeListenerOnce.Do(func() {
+		// Serialize teardown with token reservation and bind. Once listenerDone is
+		// closed, purge every unconsumed reservation before admission can resume.
+		o.admissionMu.Lock()
 		o.mu.Lock()
 		o.isAccepting.Store(false)
 		close(o.listenerDone)
-		o.sessionMgr.RemovePendingForOwner(o.serverID)
 		o.mu.Unlock()
+		o.pendingAdmissionsPurged.Add(int64(o.sessionMgr.RemovePendingForOwner(o.serverID)))
+		o.admissionMu.Unlock()
 		if o.listener != nil {
 			o.listener.Close()
 		}
@@ -2448,12 +2208,22 @@ func (o *Owner) closeListener() {
 // drainInflightRequests sends JSON-RPC error responses for all in-flight requests
 // when the upstream process dies. Without this, clients wait forever for responses
 // that will never come.
-func (o *Owner) drainInflightRequests() {
+type drainedInflightResponse struct {
+	session   *Session
+	sessionID int
+	payload   []byte
+}
+
+// claimInflightRequests atomically detaches generation-owned request state.
+// It performs no downstream session I/O, so callers may hold upstreamEventMu.
+func (o *Owner) claimInflightRequests() []drainedInflightResponse {
 	entries := o.sessionMgr.DrainInflight()
 	if len(entries) == 0 {
-		return
+		return nil
 	}
 	o.logger.Printf("upstream died: sending error responses for %d in-flight requests", len(entries))
+
+	responses := make([]drainedInflightResponse, 0, len(entries))
 	for _, entry := range entries {
 		if _, claimed := o.inflightTracker.LoadAndDelete(entry.RemappedID); !claimed {
 			continue
@@ -2469,22 +2239,26 @@ func (o *Owner) drainInflightRequests() {
 			continue
 		}
 		o.mu.RLock()
-		session, ok := o.sessions[result.SessionID]
+		s, ok := o.sessions[result.SessionID]
 		o.mu.RUnlock()
 		if ok {
-			errResp := fmt.Sprintf(
-				`{"jsonrpc":"2.0","id":%s,"error":{"code":-32603,"message":"upstream process exited"}}`,
-				string(result.OriginalID),
-			)
-			if writeErr := session.WriteRaw([]byte(errResp)); writeErr != nil {
-				o.logger.Printf("drainInflight: write error to session %d: %v", result.SessionID, writeErr)
-			}
+			responses = append(responses, drainedInflightResponse{
+				session:   s,
+				sessionID: result.SessionID,
+				payload: []byte(fmt.Sprintf(
+					`{"jsonrpc":"2.0","id":%s,"error":{"code":-32603,"message":"upstream process exited"}}`,
+					string(result.OriginalID),
+				)),
+			})
 		}
+
 		o.methodTags.Delete(entry.RemappedID)
 		o.timedOutIDs.Delete(entry.RemappedID)
 		o.clearProgressTokensForRequest(entry.RemappedID)
 	}
+	return responses
 }
+
 func (o *Owner) drainProactiveRequests(proc *upstream.Process) {
 	o.proactiveRequests.Range(func(key, value any) bool {
 		request := value.(proactiveRequest)
@@ -2498,57 +2272,145 @@ func (o *Owner) drainProactiveRequests(proc *upstream.Process) {
 	})
 }
 
-// Shutdown stops the owner, closing all sessions and the upstream.
-// Cleanup completes before Done() is signaled, ensuring sockets are removed
-// before the process exits.
-func (o *Owner) Shutdown() {
-
-	o.shutdownOnce.Do(func() {
-		o.isAccepting.Store(false)
-		o.teardownExceptUpstream()
-
-		o.mu.Lock()
-		up := o.upstream
-		o.mu.Unlock()
-		if up != nil {
-			up.Close()
+func (o *Owner) deliverInflightResponses(responses []drainedInflightResponse) {
+	for _, response := range responses {
+		if err := response.session.WriteRaw(response.payload); err != nil {
+			o.logger.Printf("drainInflight: write error to session %d: %v", response.sessionID, err)
 		}
+	}
+}
 
-		o.logger.Printf("owner shut down")
+func (o *Owner) drainInflightRequests() {
+	o.deliverInflightResponses(o.claimInflightRequests())
+}
 
-		// Signal done AFTER cleanup, so main goroutine doesn't exit early
+// FinalizeForRemoval tears down admission and retries the owned process
+// generation's whole-tree finalizer. Done is closed only after authority
+// retirement is proven, so daemon state may safely be forgotten afterwards.
+func (o *Owner) FinalizeForRemoval(soft bool, timeout time.Duration) (int, bool, error) {
+	o.removalMu.Lock()
+	defer o.removalMu.Unlock()
+	select {
+	case <-o.done:
+		return 0, true, nil
+	default:
+	}
+	if timeout <= 0 {
+		timeout = materializationFinalizeTimeout
+	}
+
+	o.stopMaterialization()
+	o.teardownExceptUpstream()
+
+	o.materializationMu.Lock()
+	attempt := o.materializationAttempt
+	if attempt != nil {
+		attempt.cancelMaterialization()
+	}
+	o.materializationMu.Unlock()
+	if attempt != nil {
+		timer := time.NewTimer(timeout)
+		select {
+		case <-attempt.done:
+			timer.Stop()
+		case <-timer.C:
+			return 0, false, fmt.Errorf("owner finalization: materialization did not settle after %s", timeout)
+		}
+	}
+
+	o.upstreamEventMu.Lock()
+	o.materializationMu.Lock()
+	proc := o.retiringProcess
+	if proc == nil {
+		o.mu.RLock()
+		proc = o.upstream
+		o.mu.RUnlock()
+	}
+	if proc != nil {
+		o.retiringProcess = proc
+		o.materializationState = MaterializationFinalizing
+		o.upstreamDead.Store(true)
+	}
+	o.materializationMu.Unlock()
+	o.upstreamEventMu.Unlock()
+
+	exitCode := 0
+	var closeErr error
+	if proc != nil {
+		if soft {
+			exitCode, closeErr = proc.SoftClose(timeout)
+		} else {
+			closeErr = proc.Close()
+		}
+	}
+	proofErr := error(nil)
+	proven := proc == nil || proc.RetirementProven()
+	if proc != nil && o.materializationFinalizationProbe != nil {
+		proofErr = o.materializationFinalizationProbe(proc)
+		proven = proofErr == nil
+	}
+	if !proven {
+		if proofErr == nil {
+			proofErr = errFinalizationUnproven
+		}
+		if closeErr != nil {
+			proofErr = errors.Join(proofErr, closeErr)
+		}
+		o.upstreamEventMu.Lock()
+		o.materializationMu.Lock()
+		o.materializationState = MaterializationFinalizeBlocked
+		o.materializationBlockedErr = proofErr
+		o.retiringProcess = proc
+		o.materializationMu.Unlock()
+		o.upstreamEventMu.Unlock()
+		return exitCode, false, proofErr
+	}
+
+	o.upstreamEventMu.Lock()
+	o.materializationMu.Lock()
+	o.mu.Lock()
+	if o.upstream == proc {
+		o.upstream = nil
+	}
+	o.upstreamDead.Store(true)
+	o.mu.Unlock()
+	if o.retiringProcess == proc {
+		o.retiringProcess = nil
+	}
+	o.materializationBlockedErr = nil
+	o.materializationState = MaterializationCacheOnly
+	if o.cacheStage != nil && o.cacheStage.process == proc {
+		o.cacheStage = nil
+	}
+	o.materializationMu.Unlock()
+	o.upstreamEventMu.Unlock()
+	o.completeShutdown("owner shut down")
+	return exitCode, true, closeErr
+}
+
+func (o *Owner) completeShutdown(message string) {
+	o.shutdownOnce.Do(func() {
+		o.logger.Printf("%s", message)
 		close(o.done)
 	})
 }
 
-// SoftShutdown performs the same cleanup as Shutdown (closes listener, sessions,
-// control server) but instead of calling upstream.Close() it calls
-// upstream.SoftClose(timeout) — giving the upstream a chance to exit cleanly
-// via stdin close before resorting to SIGTERM/SIGKILL.
-//
-// Returns the upstream exit code (0 = clean) and any kill-escalation error.
-// Used by the idle reaper (US3) to avoid SIGKILL on polite upstreams.
+// Shutdown finalizes the owner synchronously. A failed proof leaves Done open
+// so a later daemon removal attempt can retry without losing authority.
+func (o *Owner) Shutdown() {
+	if _, finalized, err := o.FinalizeForRemoval(false, materializationFinalizeTimeout); !finalized {
+		o.logger.Printf("owner shutdown blocked: %v", err)
+	}
+}
+
+// SoftShutdown gives the upstream a bounded graceful exit before forceful
+// whole-tree retirement. It still refuses terminal completion without proof.
 func (o *Owner) SoftShutdown(timeout time.Duration) (int, error) {
-	exitCode := 0
-	var exitErr error
-
-	o.shutdownOnce.Do(func() {
-		o.teardownExceptUpstream()
-
-		o.mu.Lock()
-		up := o.upstream
-		o.mu.Unlock()
-		if up != nil {
-			exitCode, exitErr = up.SoftClose(timeout)
-		}
-
-		o.logger.Printf("owner soft shut down (upstream exit code %d)", exitCode)
-
-		// Signal done AFTER cleanup.
-		close(o.done)
-	})
-
-	return exitCode, exitErr
+	exitCode, finalized, err := o.FinalizeForRemoval(true, timeout)
+	if !finalized && err == nil {
+		err = errFinalizationUnproven
+	}
+	return exitCode, err
 }
 
 // Done returns a channel closed when the owner has shut down.
@@ -2574,162 +2436,17 @@ func (o *Owner) String() string {
 	return fmt.Sprintf("owner[%s %s]", sid, o.command)
 }
 
-// closedChan is a pre-closed channel used by upstreamDeadCh when the owner
-// has no upstream process. Returning a closed channel lets Serve observe
-// upstream-missing as a failure (so suture can backoff/restart) instead of
-// blocking forever. Package-level to avoid per-call allocation.
-var closedChan = func() chan struct{} {
-	ch := make(chan struct{})
-	close(ch)
-	return ch
-}()
-
-// Serve implements the suture.Service interface, enabling owner lifecycle
-// management via supervisor trees with exponential backoff on restart.
-//
-// Serve blocks until one of:
-//   - ctx is cancelled (external shutdown → returns ctx.Err() after Shutdown)
-//   - owner.done is closed via Shutdown (clean exit → returns nil, no restart)
-//   - upstream dies fatally (returns error → suture restarts with backoff,
-//     unless classification is isolated or ErrDoNotRestart is returned)
-//
-// Isolated owners intentionally return suture.ErrDoNotRestart on upstream
-// death — they should not be auto-restarted because each CC session creates
-// its own dedicated isolated owner.
-//
-// Race ordering: upstream death is checked FIRST (non-blocking) before entering
-// the select. This handles the case where o.done closes concurrently with
-// upstream death (daemon's onUpstreamExit callback may Shutdown before Serve
-// observes the upstream Done channel). Without this check, Serve would
-// non-deterministically return nil instead of the expected error/ErrDoNotRestart,
-// making restart/backoff policies unreliable.
+// Serve is the stable owner lifecycle service. Process exit and replacement are
+// handled by the owner-local materialization controller; a cache-only owner is
+// therefore healthy and must not cause suture restart/backoff cycles.
 func (o *Owner) Serve(ctx context.Context) error {
-	// SessionHandler-only: no upstream process to monitor.
-	// Block until ctx is cancelled or Shutdown is called, then return cleanly.
-	if o.sessionHandler != nil && o.upstream == nil {
-		select {
-		case <-ctx.Done():
-			o.Shutdown()
-			return ctx.Err()
-		case <-o.done:
-			// Owner already shut down — tell suture not to restart and do not
-			// emit a clean-exit event that would trigger cleanupDeadOwner on a
-			// freshly-spawned replacement at the same server ID.
-			return suture.ErrDoNotRestart
-		}
-	}
-
-	for {
-		// Snapshot the current dead/pending channel under a single lock read.
-		// If backgroundSpawnCh is non-nil, upstreamDeadCh returns it (blocking Serve
-		// until the spawn goroutine finishes). If nil and upstream is also nil,
-		// upstreamDeadCh returns closedChan (immediate death). If upstream is set,
-		// upstreamDeadCh returns proc.Done.
-		deadCh := o.upstreamDeadCh()
-
-		// Non-blocking priority checks: done/ctx take precedence over upstream death.
-		// Without these, a shutdown owner with nil upstream (deadCh == closedChan)
-		// would return error → suture restart → immediate return → tight CPU spin.
-		select {
-		case <-o.done:
-			return suture.ErrDoNotRestart // owner already shut down — tell suture not to restart
-		default:
-		}
-		select {
-		case <-ctx.Done():
-			o.Shutdown()
-			return ctx.Err()
-		default:
-		}
-		select {
-		case <-deadCh:
-			// If this was backgroundSpawnCh (now closed and cleared), loop to
-			// re-evaluate — the upstream may now be set or definitively absent.
-			o.mu.RLock()
-			bgCh := o.backgroundSpawnCh
-			o.mu.RUnlock()
-			if bgCh == nil && deadCh != closedChan {
-				// backgroundSpawnCh just fired; upstream may be set now — loop.
-				continue
-			}
-			return o.upstreamDeathResult()
-		default:
-		}
-
-		select {
-		case <-ctx.Done():
-			// External cancellation (daemon shutdown, supervisor stop)
-			o.Shutdown()
-			return ctx.Err()
-		case <-o.done:
-			// Owner already shut down — tell suture not to restart, do not emit clean-exit event
-			return suture.ErrDoNotRestart
-		case <-deadCh:
-			// Same logic as the non-blocking check above.
-			o.mu.RLock()
-			bgCh := o.backgroundSpawnCh
-			o.mu.RUnlock()
-			if bgCh == nil && deadCh != closedChan {
-				// backgroundSpawnCh just fired; loop to re-evaluate.
-				continue
-			}
-			return o.upstreamDeathResult()
-		}
-	}
-}
-
-// upstreamDeathResult determines the Serve return value when upstream has died.
-// Checks classification: isolated owners return ErrDoNotRestart (no auto-restart),
-// others return an error to trigger supervisor backoff+restart.
-//
-// Special case (BUG-001 / FR-1): if the owner has NEVER had a live upstream
-// (up == nil and no background spawn pending), the "death" signal came from
-// closedChan — meaning background spawn failed before upstream was ever set.
-// Returning an error here would cause suture to restart Serve, which would
-// immediately re-observe the same nil state and return the same error — a
-// tight CPU spin bounded only by FailureThreshold. Return ErrDoNotRestart
-// for this case so the supervisor stops cycling. The owner is effectively
-// broken and will be cleaned up by the reaper on the next sweep.
-func (o *Owner) upstreamDeathResult() error {
-	o.mu.RLock()
-	mode := o.autoClassification
-	hasUpstream := o.upstream != nil
-	hasPendingSpawn := o.backgroundSpawnCh != nil
-	o.mu.RUnlock()
-	if !hasUpstream && !hasPendingSpawn {
-		// Owner never had a live upstream (failed background spawn, or no
-		// spawn ever attempted). No restart — otherwise suture spins.
+	select {
+	case <-ctx.Done():
+		o.Shutdown()
+		return ctx.Err()
+	case <-o.done:
 		return suture.ErrDoNotRestart
 	}
-	if mode == classify.ModeIsolated {
-		// Isolated servers should not be restarted by the supervisor.
-		// Each CC session spawns its own dedicated isolated owner.
-		return suture.ErrDoNotRestart
-	}
-	return fmt.Errorf("owner %s: upstream exited", o.serverID[:8])
-}
-
-// upstreamDeadCh returns a channel that closes when the upstream process dies.
-//
-// Three cases:
-//  1. Upstream is set: return proc.Done (normal path).
-//  2. Background spawn is pending (backgroundSpawnCh != nil): return backgroundSpawnCh.
-//     Serve blocks on it; when it closes Serve loops and re-checks the upstream.
-//  3. Upstream is nil and no spawn pending (spawn failed or never started): return
-//     closedChan so Serve observes it as failure and suture applies backoff/restart.
-func (o *Owner) upstreamDeadCh() <-chan struct{} {
-	o.mu.RLock()
-	up := o.upstream
-	bgCh := o.backgroundSpawnCh
-	o.mu.RUnlock()
-	if up != nil {
-		return up.Done
-	}
-	if bgCh != nil {
-		// Template owner: upstream is starting in background. Block Serve until done.
-		return bgCh
-	}
-	return closedChan
 }
 
 // ServerID returns the server identity hash for this owner.
@@ -2755,6 +2472,9 @@ func (o *Owner) IPCPath() string {
 // states produce "dial: connection refused" for shims even though the owner
 // entry is still registered in the daemon.
 func (o *Owner) IsAccepting() bool {
+	if o.admissionFrozen.Load() {
+		return false
+	}
 	// If the accept loop has explicitly set isAccepting true, trust it.
 	if o.isAccepting.Load() {
 		return true
@@ -3139,29 +2859,40 @@ func (o *Owner) Status() map[string]any {
 		cwds = append(cwds, c)
 	}
 	primaryCwd := o.cwd
+	upstreamPresent := o.upstream != nil || o.upstreamWriter != nil || (o.sessionHandler != nil && o.handlerFunc == nil)
+	upstreamPID := 0
+	if o.upstream != nil {
+		upstreamPID = o.upstream.PID()
+	}
 	o.mu.RUnlock()
+	matState, matTrigger, matPolicy, matGeneration, pendingDemandCount, persistentPending, finalizationError := o.materializationStatus()
 
 	status := map[string]any{
-		"mux_version": Version,
-		"upstream_pid": func() int {
-			if o.upstream != nil {
-				return o.upstream.PID()
-			}
-			return 0
-		}(),
-		"ipc_path":         o.ipcPath,
-		"command":          o.command,
-		"args":             o.args,
-		"cwd":              primaryCwd,
-		"cwd_set":          cwds,
-		"sessions":         sessionIDs,
-		"session_count":    len(sessionIDs),
-		"pending_requests": o.pendingRequests.Load(),
-		"uptime_seconds":   time.Since(o.startTime).Seconds(),
-		"cached_init":      hasCachedInit,
-		"cached_tools":     hasCachedTools,
-		"cached_prompts":   hasCachedPrompts,
-		"cached_resources": hasCachedResources,
+		"mux_version":                Version,
+		"upstream_pid":               upstreamPID,
+		"ipc_path":                   o.ipcPath,
+		"command":                    o.command,
+		"args":                       o.args,
+		"cwd":                        primaryCwd,
+		"cwd_set":                    cwds,
+		"sessions":                   sessionIDs,
+		"session_count":              len(sessionIDs),
+		"pending_requests":           o.pendingRequests.Load(),
+		"uptime_seconds":             time.Since(o.startTime).Seconds(),
+		"cached_init":                hasCachedInit,
+		"cached_tools":               hasCachedTools,
+		"cached_prompts":             hasCachedPrompts,
+		"cached_resources":           hasCachedResources,
+		"materialization_state":      string(matState),
+		"materialization_trigger":    string(matTrigger),
+		"materialization_policy":     string(matPolicy),
+		"materialization_generation": matGeneration,
+		"pending_demand_count":       pendingDemandCount,
+		"persistent_pending":         persistentPending,
+		"restart_pin_count":          o.restartPins.Load(),
+		"cache_ready":                hasCachedInit && hasCachedTools,
+		"upstream_live":              upstreamPresent && !o.upstreamDead.Load(),
+		"finalization_error":         finalizationError,
 	}
 
 	if classification != "" {
@@ -3203,19 +2934,54 @@ func (o *Owner) Status() map[string]any {
 // ExportSnapshot captures the owner's serializable state for graceful restart.
 // Thread-safe: acquires RLock. Cached responses are base64-encoded.
 func (o *Owner) ExportSnapshot() OwnerSnapshot {
+	o.materializationMu.Lock()
 	o.mu.RLock()
+	snap := o.exportSnapshotLocked()
+	o.applyMaterializationSnapshotLocked(&snap)
+	o.mu.RUnlock()
+	o.materializationMu.Unlock()
+	o.appendBoundTokenSnapshots(&snap)
+	return snap
+}
+
+// ExportSnapshotState captures owner metadata, discovery caches, and active
+// sessions under one owner read lock. Daemon restart serialization uses this
+// view so it cannot combine cache/classification facts from one instant with
+// a session set from another.
+func (o *Owner) ExportSnapshotState() (OwnerSnapshot, []SessionSnapshot) {
+	o.materializationMu.Lock()
+	o.mu.RLock()
+	snap := o.exportSnapshotLocked()
+	o.applyMaterializationSnapshotLocked(&snap)
+	sessions := o.exportSessionsLocked()
+	o.mu.RUnlock()
+	o.materializationMu.Unlock()
+	o.appendBoundTokenSnapshots(&snap)
+	return snap, sessions
+}
+
+func (o *Owner) applyMaterializationSnapshotLocked(snap *OwnerSnapshot) {
+	snap.Persistent = snap.Persistent || o.persistentPending
+	if a := o.materializationAttempt; a != nil {
+		snap.Cwd = a.launch.Cwd
+		snap.Env = cloneSnapshotEnv(a.launch.Env)
+	}
+}
+
+func (o *Owner) exportSnapshotLocked() OwnerSnapshot {
 	cwds := make([]string, 0, len(o.cwdSet))
-	for c := range o.cwdSet {
-		cwds = append(cwds, c)
+	for cwd := range o.cwdSet {
+		cwds = append(cwds, cwd)
 	}
 	snap := OwnerSnapshot{
 		Command:              o.command,
-		Args:                 o.args,
+		Args:                 append([]string(nil), o.args...),
 		Cwd:                  o.cwd,
+		Env:                  cloneSnapshotEnv(o.env),
 		CwdSet:               cwds,
 		Classification:       o.autoClassification,
 		ClassificationSource: o.classificationSource,
-		ClassificationReason: o.classificationReason,
+		ClassificationReason: append([]string(nil), o.classificationReason...),
 	}
 	if o.initResp != nil {
 		snap.CachedInit = base64Encode(o.initResp)
@@ -3232,18 +2998,31 @@ func (o *Owner) ExportSnapshot() OwnerSnapshot {
 	if o.resourceTemplateList != nil {
 		snap.CachedResourceTemplates = base64Encode(o.resourceTemplateList)
 	}
-	o.mu.RUnlock()
+	return snap
+}
+
+func (o *Owner) appendBoundTokenSnapshots(snap *OwnerSnapshot) {
 	for _, hist := range o.sessionMgr.ExportBoundHistory() {
 		snap.BoundTokens = append(snap.BoundTokens, snapshot.BoundTokenSnapshot{
 			Token:    hist.Token,
 			OwnerKey: hist.OwnerKey,
 			Cwd:      hist.Cwd,
-			Env:      hist.Env,
+			Env:      cloneSnapshotEnv(hist.Env),
 			BoundAt:  hist.BoundAt,
 			LastUsed: hist.LastUsed,
 		})
 	}
-	return snap
+}
+
+func cloneSnapshotEnv(src map[string]string) map[string]string {
+	if len(src) == 0 {
+		return nil
+	}
+	dst := make(map[string]string, len(src))
+	for key, value := range src {
+		dst[key] = value
+	}
+	return dst
 }
 
 func boundTokenSnapshotsToSession(entries []snapshot.BoundTokenSnapshot) []session.BoundHistorySnapshot {
@@ -3268,12 +3047,16 @@ func boundTokenSnapshotsToSession(entries []snapshot.BoundTokenSnapshot) []sessi
 func (o *Owner) ExportSessions() []SessionSnapshot {
 	o.mu.RLock()
 	defer o.mu.RUnlock()
+	return o.exportSessionsLocked()
+}
+
+func (o *Owner) exportSessionsLocked() []SessionSnapshot {
 	sessions := make([]SessionSnapshot, 0, len(o.sessions))
 	for _, s := range o.sessions {
 		sessions = append(sessions, SessionSnapshot{
 			MuxSessionID: s.MuxSessionID,
 			Cwd:          s.Cwd,
-			Env:          s.Env,
+			Env:          cloneSnapshotEnv(s.Env),
 		})
 	}
 	return sessions
@@ -3321,6 +3104,15 @@ func (o *Owner) replayFromCache(s *Session, msg *jsonrpc.Message, cached []byte)
 
 // cacheResponse stores a raw JSON-RPC response for later replay.
 func (o *Owner) cacheResponse(method string, raw []byte) {
+	if o.cacheResponseState(method, raw) {
+		o.broadcastListChanged()
+	}
+}
+
+// cacheResponseState commits cache and classification state without downstream
+// session I/O. The caller may hold upstreamEventMu to linearize a live process
+// response against process-generation replacement.
+func (o *Owner) cacheResponseState(method string, raw []byte) bool {
 	cached := make([]byte, len(raw))
 	copy(cached, raw)
 
@@ -3362,22 +3154,24 @@ func (o *Owner) cacheResponse(method string, raw []byte) {
 			o.logger.Printf("using x-mux.progressInterval: %ds", sec)
 		}
 	}
-	if method == "tools/list" {
-		o.classifyFromToolList(cached)
-		// Notify daemon that a complete template is available (init + tools cached).
-		// Daemon stores this as a template for instant future isolated spawns.
-		if o.onCacheReady != nil && o.initDone {
-			go o.onCacheReady(o.serverID)
-		}
-		if o.listChangedAfterRefresh.Swap(false) {
-			o.mu.Lock()
-			o.promptList = nil
-			o.resourceList = nil
-			o.resourceTemplateList = nil
-			o.mu.Unlock()
-			o.broadcastListChanged()
-		}
+	if method != "tools/list" {
+		return false
 	}
+	o.classifyFromToolList(cached)
+	// Publish synchronously while a live response still owns its generation
+	// lease, so template publication cannot cross successor installation.
+	if o.onCacheReady != nil && o.initDone {
+		o.onCacheReady(o, o.ExportSnapshot())
+	}
+	if !o.listChangedAfterRefresh.Swap(false) {
+		return false
+	}
+	o.mu.Lock()
+	o.promptList = nil
+	o.resourceList = nil
+	o.resourceTemplateList = nil
+	o.mu.Unlock()
+	return true
 }
 
 // forwardCancelledNotification remaps the requestId in a notifications/cancelled
@@ -3387,22 +3181,25 @@ func (o *Owner) forwardCancelledNotification(s *Session, msg *jsonrpc.Message) e
 	var obj map[string]json.RawMessage
 	if err := json.Unmarshal(msg.Raw, &obj); err != nil {
 		// Fallback: forward as-is
-		return o.writeUpstream(msg.Raw)
+		return o.forwardNotificationIfReady(msg.Raw)
 	}
 
 	paramsRaw, hasParams := obj["params"]
 	if !hasParams {
-		return o.writeUpstream(msg.Raw)
+		return o.forwardNotificationIfReady(msg.Raw)
 	}
 
 	var params map[string]json.RawMessage
 	if err := json.Unmarshal(paramsRaw, &params); err != nil {
-		return o.writeUpstream(msg.Raw)
+		return o.forwardNotificationIfReady(msg.Raw)
 	}
 
 	requestIDRaw, hasRequestID := params["requestId"]
 	if !hasRequestID {
-		return o.writeUpstream(msg.Raw)
+		return o.forwardNotificationIfReady(msg.Raw)
+	}
+	if o.cancelLocalDemand(s, requestIDRaw) {
+		return nil
 	}
 
 	// Remap the requestId to the upstream-facing ID
@@ -3411,20 +3208,20 @@ func (o *Owner) forwardCancelledNotification(s *Session, msg *jsonrpc.Message) e
 
 	newParams, err := json.Marshal(params)
 	if err != nil {
-		return o.writeUpstream(msg.Raw)
+		return o.forwardNotificationIfReady(msg.Raw)
 	}
 
 	obj["params"] = newParams
 	remapped, err := json.Marshal(obj)
 	if err != nil {
-		return o.writeUpstream(msg.Raw)
+		return o.forwardNotificationIfReady(msg.Raw)
 	}
 
 	// Clean up progress tokens for the cancelled request (FIX 1).
 	o.clearProgressTokensForRequest(string(remappedRequestID))
 
 	o.logger.Printf("session %d: forwarding notifications/cancelled with remapped requestId", s.ID)
-	return o.writeUpstream(remapped)
+	return o.forwardNotificationIfReady(remapped)
 }
 
 // invalidateCacheIfNeeded checks if a notification from upstream signals that a
@@ -3434,20 +3231,27 @@ func (o *Owner) invalidateCacheIfNeeded(data []byte) {
 	if err != nil || !msg.IsNotification() {
 		return
 	}
+	invalidated := false
 	o.mu.Lock()
 	switch msg.Method {
 	case "notifications/tools/list_changed":
 		o.toolList = nil
+		invalidated = true
 		o.logger.Printf("cache invalidated: tools/list")
 	case "notifications/prompts/list_changed":
 		o.promptList = nil
+		invalidated = true
 		o.logger.Printf("cache invalidated: prompts/list")
 	case "notifications/resources/list_changed":
 		o.resourceList = nil
 		o.resourceTemplateList = nil
+		invalidated = true
 		o.logger.Printf("cache invalidated: resources/list + templates")
 	}
 	o.mu.Unlock()
+	if invalidated && o.onCacheInvalidated != nil {
+		o.onCacheInvalidated(o)
+	}
 }
 
 // captureInitFingerprint extracts protocolVersion from an initialize request
@@ -3585,12 +3389,17 @@ func (o *Owner) classifyFromToolList(toolsJSON []byte) {
 // checkPersistent checks if the upstream declares x-mux.persistent: true
 // and notifies the daemon via callback.
 func (o *Owner) checkPersistent(initJSON []byte) {
-	if !classify.ParsePersistent(initJSON) {
+	o.ResolvePersistent(classify.ParsePersistent(initJSON))
+	persistent := classify.ParsePersistent(initJSON)
+	if persistent {
+		o.logger.Printf("x-mux capability: persistent=true")
+	}
+	if o.onPersistentResolved != nil {
+		o.onPersistentResolved(o, persistent)
 		return
 	}
-	o.logger.Printf("x-mux capability: persistent=true")
-	if o.onPersistentDetected != nil {
-		o.onPersistentDetected(o.serverID)
+	if persistent && o.onPersistentDetected != nil {
+		o.onPersistentDetected(o)
 	}
 }
 

--- a/muxcore/owner/owner_serve_test.go
+++ b/muxcore/owner/owner_serve_test.go
@@ -73,8 +73,13 @@ func TestOwnerServe_CacheOnlyOwnerIsHealthy(t *testing.T) {
 	}
 
 	o.Shutdown()
-	if err := <-errCh; !errors.Is(err, suture.ErrDoNotRestart) {
-		t.Fatalf("cache-only Serve returned %v after Shutdown, want ErrDoNotRestart", err)
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, suture.ErrDoNotRestart) {
+			t.Fatalf("cache-only Serve returned %v after Shutdown, want ErrDoNotRestart", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("cache-only Serve did not return after Shutdown")
 	}
 }
 

--- a/muxcore/owner/owner_serve_test.go
+++ b/muxcore/owner/owner_serve_test.go
@@ -6,228 +6,78 @@ import (
 	"testing"
 	"time"
 
-	"github.com/thebtf/mcp-mux/muxcore/classify"
-	"github.com/thebtf/mcp-mux/muxcore/upstream"
 	"github.com/thejerf/suture/v4"
 )
 
-// mockLiveUpstream returns a minimal *upstream.Process with a Done channel
-// that never closes — simulates a healthy, running upstream for Serve tests
-// that need to block on ctx.Done or o.done instead of upstream death.
-// Sets drainTimeout via SetDrainTimeout to a tiny value so that Shutdown→Close
-// phase 2 (voluntary exit wait) returns quickly in tests.
-func mockLiveUpstream() *upstream.Process {
-	p := &upstream.Process{
-		Done: make(chan struct{}),
-	}
-	// Make Close() phase-2 wait very short for test speed
-	p.SetDrainTimeout(10 * time.Millisecond)
-	return p
-}
-
-// TestOwnerServe_BlocksUntilCancel verifies that Serve blocks until
-// the provided context is cancelled, then calls Shutdown and returns
-// the context's error. Uses a mock live upstream so Serve blocks on
-// ctx/done rather than returning immediately on upstream death.
 func TestOwnerServe_BlocksUntilCancel(t *testing.T) {
 	o := newMinimalOwner()
-	o.controlServer = nil // avoid control server shutdown in Shutdown()
-	mockUp := mockLiveUpstream()
-	o.upstream = mockUp
-
 	ctx, cancel := context.WithCancel(context.Background())
-
 	errCh := make(chan error, 1)
-	go func() {
-		errCh <- o.Serve(ctx)
-	}()
+	go func() { errCh <- o.Serve(ctx) }()
 
-	// Give Serve time to enter its select
-	time.Sleep(50 * time.Millisecond)
-
-	// Verify it's blocking (no early return)
 	select {
 	case err := <-errCh:
 		t.Fatalf("Serve returned early: %v", err)
-	default:
+	case <-time.After(50 * time.Millisecond):
 	}
 
-	// Cancel the context — Serve will observe ctx.Done() first (both
-	// upstream Done and ctx.Done fire in select; we want ctx to win to
-	// verify the cancellation path). Close mockUp.Done after a short
-	// delay so Shutdown→Close can proceed quickly.
 	cancel()
-	go func() {
-		// Give Serve's select time to pick ctx.Done() over upstream.Done.
-		time.Sleep(20 * time.Millisecond)
-		close(mockUp.Done)
-	}()
-
-	// Wait for Serve to return
 	select {
 	case err := <-errCh:
 		if !errors.Is(err, context.Canceled) {
-			t.Errorf("Serve returned %v, want context.Canceled", err)
+			t.Fatalf("Serve returned %v, want context.Canceled", err)
 		}
-	case <-time.After(3 * time.Second):
-		t.Fatal("Serve did not return after context cancel")
+	case <-time.After(2 * time.Second):
+		t.Fatal("Serve did not return after context cancellation")
 	}
-
-	// Verify Shutdown was called (done channel closed)
 	select {
 	case <-o.Done():
-		// Expected: Shutdown closed the done channel
-	case <-time.After(1 * time.Second):
-		t.Error("Shutdown was not called (done channel not closed)")
+	case <-time.After(time.Second):
+		t.Fatal("Shutdown did not close owner done channel")
 	}
 }
 
-// TestOwnerServe_ReturnsErrDoNotRestartOnCleanShutdown verifies that if
-// Shutdown is called externally while Serve is waiting, Serve returns
-// suture.ErrDoNotRestart — the correct signal for "permanently done, do
-// not restart AND do not emit a clean-exit event". Returning nil here
-// used to make suture schedule a restart AND fire a clean-exit hook,
-// which triggered supervisorEventHook → cleanupDeadOwner → destruction
-// of any fresh replacement Owner at the same server ID, reproducing as
-// a tight restart-loop on mcp-mux upgrade --restart.
 func TestOwnerServe_ReturnsErrDoNotRestartOnCleanShutdown(t *testing.T) {
 	o := newMinimalOwner()
-	o.controlServer = nil
-	o.upstream = mockLiveUpstream() // prevent early return from upstream-dead path
-
 	errCh := make(chan error, 1)
-	go func() {
-		errCh <- o.Serve(context.Background())
-	}()
-
-	// Give Serve time to enter blocking select
-	time.Sleep(50 * time.Millisecond)
-
-	// Call Shutdown — closes o.done, Serve returns suture.ErrDoNotRestart.
-	o.Shutdown()
+	go func() { errCh <- o.Serve(context.Background()) }()
 
 	select {
 	case err := <-errCh:
+		t.Fatalf("Serve returned early: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	o.Shutdown()
+	select {
+	case err := <-errCh:
 		if !errors.Is(err, suture.ErrDoNotRestart) {
-			t.Errorf("Serve after Shutdown returned %v, want suture.ErrDoNotRestart", err)
+			t.Fatalf("Serve returned %v, want suture.ErrDoNotRestart", err)
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("Serve did not return after Shutdown")
 	}
 }
 
-// TestOwnerServe_IsolatedReturnsErrDoNotRestart verifies that when an
-// isolated owner is served and the upstream is absent/dead, Serve returns
-// suture.ErrDoNotRestart. With a nil upstream, upstreamDeadCh returns the
-// package-level closedChan, so Serve observes "upstream dead" immediately.
-// The classification branch should then convert this to ErrDoNotRestart.
-func TestOwnerServe_IsolatedReturnsErrDoNotRestart(t *testing.T) {
+func TestOwnerServe_CacheOnlyOwnerIsHealthy(t *testing.T) {
 	o := newMinimalOwner()
-	o.controlServer = nil
-	o.autoClassification = classify.ModeIsolated
-	o.classificationSource = "tools"
-	// Leave o.upstream = nil — upstreamDeadCh will return closedChan.
-
-	err := o.Serve(context.Background())
-	if !errors.Is(err, suture.ErrDoNotRestart) {
-		t.Errorf("Serve returned %v, want suture.ErrDoNotRestart", err)
-	}
-}
-
-// TestOwnerServe_NonIsolatedNilUpstreamReturnsDoNotRestart verifies the FR-1
-// fix: a non-isolated owner that has NEVER had a live upstream (upstream == nil
-// AND backgroundSpawnCh == nil) returns suture.ErrDoNotRestart, NOT a
-// restartable error.
-//
-// Pre-fix: this returned a non-nil error, which caused suture to restart Serve
-// immediately. The new Serve iteration re-observed the same nil state and
-// returned the same error — a tight loop bounded only by suture's
-// FailureThreshold. This was BUG-001 from the 2026-04-15 audit.
-//
-// Post-fix: upstreamDeathResult checks for the "never had upstream" case and
-// returns ErrDoNotRestart so suture removes the owner cleanly without cycling.
-//
-// This is semantically the same as the isolated-owner case — an owner with no
-// realistic path to recovery should not be restarted.
-func TestOwnerServe_NonIsolatedNilUpstreamReturnsDoNotRestart(t *testing.T) {
-	o := newMinimalOwner()
-	o.controlServer = nil
-	o.autoClassification = classify.ModeShared
-	o.classificationSource = "tools"
-
-	err := o.Serve(context.Background())
-	if !errors.Is(err, suture.ErrDoNotRestart) {
-		t.Errorf("Serve with nil upstream returned %v, want suture.ErrDoNotRestart (FR-1 fix: cold owner should not restart)", err)
-	}
-}
-
-// TestOwnerServe_FailedBackgroundSpawnDoesNotSpin is the direct FR-1 regression
-// test: simulates SpawnUpstreamBackground's failure path (bgCh closed then
-// cleared, upstream still nil) and asserts Serve exits exactly once with
-// ErrDoNotRestart rather than spinning on suture restarts.
-//
-// Setup mirrors what SpawnUpstreamBackground does on error:
-//  1. bgCh was created at NewOwnerFromSnapshot
-//  2. goroutine tried upstream.Start, it failed
-//  3. goroutine closed bgCh and set bgCh = nil
-//  4. upstream remains nil
-//
-// Pre-fix Serve behavior:
-//  - iter 1: deadCh = bgCh (non-nil at entry, since we test right after close)
-//            Actually, bgCh is ALREADY nil in our setup because we mimic the
-//            post-close-and-clear state. deadCh = closedChan.
-//            Non-blocking select hits deadCh → returns upstreamDeathResult()
-//            → for non-isolated: non-nil error → suture restarts → loop
-//  - iter N (inside suture restart): same state, same error, tight loop
-//
-// Post-fix: upstreamDeathResult returns ErrDoNotRestart → suture removes.
-func TestOwnerServe_FailedBackgroundSpawnDoesNotSpin(t *testing.T) {
-	o := newMinimalOwner()
-	o.controlServer = nil
-	o.autoClassification = classify.ModeShared
-	o.classificationSource = "tools"
-	// Simulate post-failed-spawn state: bgCh was allocated, goroutine closed
-	// it and set it to nil, upstream never got set.
-	o.backgroundSpawnCh = nil
+	o.materializationState = MaterializationCacheOnly
 	o.upstream = nil
+	errCh := make(chan error, 1)
+	go func() { errCh <- o.Serve(context.Background()) }()
 
-	start := time.Now()
-	err := o.Serve(context.Background())
-	elapsed := time.Since(start)
-
-	if !errors.Is(err, suture.ErrDoNotRestart) {
-		t.Errorf("Serve after failed background spawn returned %v, want suture.ErrDoNotRestart", err)
-	}
-	// Serve should return immediately — no retry loop, no CPU spin.
-	if elapsed > 100*time.Millisecond {
-		t.Errorf("Serve took %v to return; expected near-instant exit (FR-1: no spin on failed spawn)", elapsed)
-	}
-}
-
-// TestOwnerUpstreamDeadCh_NilUpstreamReturnsClosedChannel verifies the
-// helper returns closedChan when upstream is nil, so Serve can observe
-// upstream absence as failure (not hang).
-func TestOwnerUpstreamDeadCh_NilUpstreamReturnsClosedChannel(t *testing.T) {
-	o := newMinimalOwner()
-	ch := o.upstreamDeadCh()
 	select {
-	case <-ch:
-		// Expected: closedChan is already closed
-	case <-time.After(50 * time.Millisecond):
-		t.Fatal("upstreamDeadCh with nil upstream must return a closed channel")
+	case err := <-errCh:
+		t.Fatalf("cache-only Serve returned early: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	o.Shutdown()
+	if err := <-errCh; !errors.Is(err, suture.ErrDoNotRestart) {
+		t.Fatalf("cache-only Serve returned %v after Shutdown, want ErrDoNotRestart", err)
 	}
 }
 
-// TestOwnerServe_ReturnsErrorOnUpstreamExit verifies that when a non-isolated
-// upstream dies, Serve returns a non-nil error (which suture will use as
-// signal to restart with backoff).
-func TestOwnerServe_ReturnsErrorOnUpstreamExit(t *testing.T) {
-	// This requires a real upstream.Process or a mock that can close Done.
-	// Deferred to Phase 4 integration tests where we have the test infra.
-	t.Skip("covered by Phase 4 TestSupervisor_ExponentialBackoff")
-}
-
-// Verify the Serve method signature matches suture.Service interface.
 func TestOwnerServe_ImplementsServiceInterface(t *testing.T) {
 	var _ suture.Service = (*Owner)(nil)
 }

--- a/muxcore/owner/owner_test.go
+++ b/muxcore/owner/owner_test.go
@@ -292,9 +292,9 @@ func TestSpawnUpstreamBackground_SessionHandlerOnly_NoSubprocess(t *testing.T) {
 	defer o.Shutdown()
 
 	o.SpawnUpstreamBackground()
-	if state := o.MaterializationState(); state != MaterializationReady {
-		t.Fatalf("materialization state = %s, want ready", state)
-	}
+	waitForCondition(t, time.Second, func() bool {
+		return o.MaterializationState() == MaterializationReady
+	}, "session-handler materialization did not reach ready state")
 	o.mu.RLock()
 	upstream := o.upstream
 	o.mu.RUnlock()

--- a/muxcore/owner/owner_test.go
+++ b/muxcore/owner/owner_test.go
@@ -272,22 +272,18 @@ func TestServe_SessionHandlerOnly_BlocksUntilDone(t *testing.T) {
 func TestSpawnUpstreamBackground_SessionHandlerOnly_NoSubprocess(t *testing.T) {
 	ipcPath := testIPCPath(t)
 	var logs bytes.Buffer
-
 	snap := OwnerSnapshot{
 		ServerID: "test-sessionhandler-background-spawn",
 		Command:  "definitely-not-a-real-sessionhandler-upstream-command",
 		Cwd:      t.TempDir(),
-		CwdSet:   []string{},
 		Mode:     "global",
 	}
-
-	handler := &mockSessionHandler{}
 	o, err := NewOwnerFromSnapshot(OwnerConfig{
 		Command:        snap.Command,
 		Cwd:            snap.Cwd,
 		IPCPath:        ipcPath,
 		ServerID:       snap.ServerID,
-		SessionHandler: handler,
+		SessionHandler: &mockSessionHandler{},
 		Logger:         log.New(&logs, "[test] ", 0),
 	}, snap)
 	if err != nil {
@@ -295,50 +291,27 @@ func TestSpawnUpstreamBackground_SessionHandlerOnly_NoSubprocess(t *testing.T) {
 	}
 	defer o.Shutdown()
 
-	bgCh := o.backgroundSpawnCh
-	if bgCh == nil {
-		t.Fatal("snapshot owner should start with pending backgroundSpawnCh")
-	}
-
 	o.SpawnUpstreamBackground()
-
-	select {
-	case <-bgCh:
-	case <-time.After(2 * time.Second):
-		t.Fatal("SessionHandler-only background spawn did not finish")
+	if state := o.MaterializationState(); state != MaterializationReady {
+		t.Fatalf("materialization state = %s, want ready", state)
 	}
-
 	o.mu.RLock()
 	upstream := o.upstream
-	backgroundSpawnCh := o.backgroundSpawnCh
 	o.mu.RUnlock()
 	if upstream != nil {
-		t.Fatalf("SessionHandler-only background spawn created upstream: %v", upstream)
+		t.Fatalf("SessionHandler-only materialization created upstream: %v", upstream)
 	}
-	if backgroundSpawnCh != nil {
-		t.Fatal("SessionHandler-only background spawn did not clear backgroundSpawnCh")
-	}
-
-	logText := logs.String()
-	if strings.Contains(logText, "background upstream spawn failed") {
-		t.Fatalf("SessionHandler-only background spawn attempted subprocess:\n%s", logText)
-	}
-	if !strings.Contains(logText, "background SessionHandler-only spawn: no upstream process") {
-		t.Fatalf("missing SessionHandler-only no-op marker in logs:\n%s", logText)
+	if strings.Contains(logs.String(), "upstream spawn failed") {
+		t.Fatalf("SessionHandler-only path attempted subprocess:\n%s", logs.String())
 	}
 
 	errCh := make(chan error, 1)
-	go func() {
-		errCh <- o.Serve(context.Background())
-	}()
-
-	time.Sleep(100 * time.Millisecond)
+	go func() { errCh <- o.Serve(context.Background()) }()
 	select {
 	case err := <-errCh:
-		t.Fatalf("Serve returned immediately for restored SessionHandler-only owner: %v", err)
-	default:
+		t.Fatalf("Serve returned immediately for SessionHandler-only owner: %v", err)
+	case <-time.After(100 * time.Millisecond):
 	}
-
 	o.Shutdown()
 	select {
 	case err := <-errCh:

--- a/muxcore/owner/respawn_test.go
+++ b/muxcore/owner/respawn_test.go
@@ -65,155 +65,68 @@ func TestOwnerRespawnsUpstreamForLiveSession(t *testing.T) {
 
 func TestSnapshotBackgroundSpawnBlocksRequestRespawn(t *testing.T) {
 	var starts atomic.Int32
-	requestWaiting := make(chan struct{})
-	initializeReceived := make(chan struct{})
-	allowInitializeResponse := make(chan struct{})
-	initializedReceived := make(chan error, 1)
+	allowDiscovery := make(chan struct{})
 	release := make(chan struct{})
 	handler := func(_ context.Context, stdin io.Reader, stdout io.Writer) error {
 		starts.Add(1)
 		scanner := bufio.NewScanner(stdin)
-		if !scanner.Scan() {
-			return scanner.Err()
-		}
-		var req struct {
-			ID json.RawMessage `json:"id"`
-		}
-		if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
-			return err
-		}
-		close(initializeReceived)
-		<-allowInitializeResponse
-		if _, err := fmt.Fprintf(stdout, `{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":"2025-11-25","capabilities":{},"serverInfo":{"name":"background-gate","version":"1"}}}`+"\n", req.ID); err != nil {
-			return err
-		}
-
-		if !scanner.Scan() {
-			err := scanner.Err()
-			if err == nil {
-				err = io.ErrUnexpectedEOF
+		for scanner.Scan() {
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
 			}
-			initializedReceived <- err
-			return err
+			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+				return err
+			}
+			switch req.Method {
+			case "initialize":
+				if _, err := fmt.Fprintf(stdout, `{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":"2025-11-25","capabilities":{},"serverInfo":{"name":"background-gate","version":"1"}}}`+"\n", req.ID); err != nil {
+					return err
+				}
+			case "tools/list":
+				<-allowDiscovery
+				if _, err := fmt.Fprintf(stdout, `{"jsonrpc":"2.0","id":%s,"result":{"tools":[]}}`+"\n", req.ID); err != nil {
+					return err
+				}
+				<-release
+				return nil
+			}
 		}
-		var notification struct {
-			Method string `json:"method"`
-		}
-		if err := json.Unmarshal(scanner.Bytes(), &notification); err != nil {
-			initializedReceived <- err
-			return err
-		}
-		if notification.Method != "notifications/initialized" {
-			err := fmt.Errorf("first post-initialize message method = %q, want notifications/initialized", notification.Method)
-			initializedReceived <- err
-			return err
-		}
-		initializedReceived <- nil
-		<-release
-		return nil
+		return scanner.Err()
 	}
 
 	o, err := NewOwnerFromSnapshot(OwnerConfig{
-		HandlerFunc: handler,
-		IPCPath:     testIPCPath(t),
-		Logger:      testLogger(t),
+		HandlerFunc:           handler,
+		IPCPath:               testIPCPath(t),
+		MaterializationPolicy: MaterializationOnDemand,
+		Logger:                testLogger(t),
 	}, OwnerSnapshot{})
 	if err != nil {
 		t.Fatalf("NewOwnerFromSnapshot() error: %v", err)
 	}
-	o.mu.Lock()
-	o.beforeBackgroundSpawnWait = func() {
-		close(requestWaiting)
-	}
-	spawnDone := o.backgroundSpawnCh
-	o.mu.Unlock()
-	if spawnDone == nil {
-		t.Fatal("snapshot owner has no pending background-spawn channel")
-	}
-
-	clientR, serverW := io.Pipe()
-	serverR, clientW := io.Pipe()
-	session := NewSession(serverR, serverW)
-	o.AddSession(session)
-
-	respawnLocked := true
-	initializeReleased := false
-	o.respawnMu.Lock()
 	t.Cleanup(func() {
-		if respawnLocked {
-			o.respawnMu.Unlock()
-		}
-		if !initializeReleased {
-			close(allowInitializeResponse)
-		}
-		o.removeSession(session)
-		session.Close()
-		_ = clientR.Close()
-		_ = clientW.Close()
 		close(release)
 		o.Shutdown()
 	})
 
-	ready := make(chan error, 1)
-	go func() {
-		ready <- o.ensureUpstreamReadyForRequest()
-	}()
-
-	select {
-	case <-requestWaiting:
-	case <-time.After(time.Second):
-		t.Fatal("request path did not enter the pending background-spawn wait")
-	}
 	o.SpawnUpstreamBackground()
-	waitForCondition(t, time.Second, func() bool {
-		return starts.Load() == 1
-	}, "background upstream did not start")
-	select {
-	case <-initializeReceived:
-	case <-time.After(time.Second):
-		t.Fatal("background upstream did not receive initialize")
-	}
+	waitForCondition(t, time.Second, func() bool { return starts.Load() == 1 }, "background upstream did not start")
+	ready := make(chan error, 1)
+	go func() { ready <- o.ensureUpstreamReadyForRequest() }()
 
-	select {
-	case <-spawnDone:
-		t.Fatal("background-spawn gate closed before the new upstream answered initialize")
-	default:
+	time.Sleep(100 * time.Millisecond)
+	if got := starts.Load(); got != 1 {
+		t.Fatalf("concurrent request started %d upstream generations, want 1", got)
 	}
-	select {
-	case err := <-ready:
-		t.Fatalf("request readiness returned before initialize completed: %v", err)
-	default:
-	}
-
-	close(allowInitializeResponse)
-	initializeReleased = true
-	select {
-	case err := <-initializedReceived:
-		if err != nil {
-			t.Fatalf("proactive initialization error: %v", err)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("background upstream did not receive notifications/initialized")
-	}
-	select {
-	case <-spawnDone:
-	case <-time.After(time.Second):
-		t.Fatal("background-spawn gate did not close after notifications/initialized")
-	}
-
+	close(allowDiscovery)
 	select {
 	case err := <-ready:
 		if err != nil {
 			t.Fatalf("ensureUpstreamReadyForRequest() error: %v", err)
 		}
-	case <-time.After(time.Second):
-		o.respawnMu.Unlock()
-		respawnLocked = false
-		t.Fatal("request path started a competing respawn instead of waiting for the pending background spawn")
+	case <-time.After(2 * time.Second):
+		t.Fatal("request did not join background materialization")
 	}
-
-	o.respawnMu.Unlock()
-	respawnLocked = false
 	if got := starts.Load(); got != 1 {
 		t.Fatalf("upstream starts = %d, want 1", got)
 	}

--- a/muxcore/session/session.go
+++ b/muxcore/session/session.go
@@ -39,9 +39,9 @@ type Session struct {
 	Env          map[string]string // per-session env diff bound via token handshake
 	reader       *jsonrpc.Scanner
 	writer       io.Writer
-	conn         net.Conn   // underlying connection for write deadlines (nil for stdio)
-	closer       io.Closer  // underlying connection (net.Conn for IPC sessions, nil for stdio)
-	mu           sync.Mutex // protects writer
+	conn         net.Conn    // underlying connection for write deadlines (nil for stdio)
+	closer       io.Closer   // underlying connection (net.Conn for IPC sessions, nil for stdio)
+	mu           sync.Mutex  // protects writer
 	notifCh      chan []byte // async notification send buffer (drained by drainNotifications goroutine)
 	done         chan struct{}
 	closed       atomic.Bool

--- a/muxcore/session/session.go
+++ b/muxcore/session/session.go
@@ -186,6 +186,11 @@ func (s *Session) Close() {
 	}
 }
 
+// IsClosed reports whether Close has completed for this session.
+func (s *Session) IsClosed() bool {
+	return s.closed.Load()
+}
+
 // SendNotification queues a notification for async delivery. Never blocks the
 // caller — if the buffer is full, the oldest notification is dropped to make room.
 // This prevents the upstream reader goroutine from deadlocking when a session's

--- a/muxcore/session/session_manager.go
+++ b/muxcore/session/session_manager.go
@@ -301,6 +301,19 @@ func (sm *Manager) IsPreRegistered(token string) bool {
 	return ok
 }
 
+// LookupPendingForOwner returns an unconsumed token's project context without
+// consuming it. The owner key must match exactly when the reservation is
+// owner-scoped. Returned environment data is cloned for authorization use.
+func (sm *Manager) LookupPendingForOwner(token, ownerKey string) (cwd string, env map[string]string, ok bool) {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+	pending, ok := sm.pending[token]
+	if !ok || (pending.OwnerKey != "" && pending.OwnerKey != ownerKey) {
+		return "", nil, false
+	}
+	return pending.Cwd, cloneEnv(pending.Env), true
+}
+
 // SweepExpiredPending removes pending tokens older than pendingTokenTTL.
 // Returns the number of swept entries. Called periodically by the daemon
 // to prevent memory leaks from orphan tokens (shim never connected after

--- a/muxcore/session/session_manager.go
+++ b/muxcore/session/session_manager.go
@@ -17,10 +17,11 @@ type Context struct {
 
 // pendingSession holds pre-registered session data waiting for a shim to connect.
 type pendingSession struct {
-	OwnerKey  string
-	Cwd       string
-	Env       map[string]string
-	CreatedAt time.Time // for TTL expiry — orphan tokens are swept if shim never connects
+	OwnerKey      string
+	Cwd           string
+	Env           map[string]string
+	CreatedAt     time.Time // for TTL expiry — orphan tokens are swept if shim never connects
+	SourceSession *Session  // reconnect lineage; nil for fresh admission
 }
 
 type boundHistory struct {
@@ -269,6 +270,25 @@ func (sm *Manager) RemovePendingForOwnerExcept(ownerKey, keepToken string) int {
 	return removed
 }
 
+// RemovePendingForOwnerExceptSession removes pending tokens associated with
+// ownerKey unless they derive from keep's reconnect lineage. Fresh admission
+// reservations have no SourceSession and are always revoked.
+func (sm *Manager) RemovePendingForOwnerExceptSession(ownerKey string, keep *Session) int {
+	if ownerKey == "" {
+		return 0
+	}
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	removed := 0
+	for token, pending := range sm.pending {
+		if pending.OwnerKey == ownerKey && (keep == nil || pending.SourceSession != keep) {
+			delete(sm.pending, token)
+			removed++
+		}
+	}
+	return removed
+}
+
 // RemovePendingForOwnerToken revokes one exact unconsumed reservation. Both
 // ownerKey and token must match so a late control-plane rollback cannot remove
 // a reservation belonging to a replacement owner or another concurrent shim.
@@ -366,6 +386,25 @@ func (sm *Manager) RemoveBoundForOwner(ownerKey string) int {
 	return removed
 }
 
+// RemoveBoundForOwnerExceptSession removes consumed-token reconnect history
+// associated with ownerKey unless it belongs to keep. Derived refresh tokens
+// retain their source session until Bind replaces it with the new connection.
+func (sm *Manager) RemoveBoundForOwnerExceptSession(ownerKey string, keep *Session) int {
+	if ownerKey == "" {
+		return 0
+	}
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	removed := 0
+	for token, hist := range sm.bound {
+		if hist.OwnerKey == ownerKey && (keep == nil || hist.Session != keep) {
+			delete(sm.bound, token)
+			removed++
+		}
+	}
+	return removed
+}
+
 // PendingCount returns the number of pending (pre-registered but not yet bound) tokens.
 // Exposed for observability (mux_list --verbose).
 func (sm *Manager) PendingCount() int {
@@ -452,10 +491,11 @@ func (sm *Manager) RegisterReconnect(prev string, ownerAlive func(key string) bo
 	cwd := hist.Cwd
 	env := cloneEnv(hist.Env)
 	sm.pending[token] = &pendingSession{
-		OwnerKey:  ownerKey,
-		Cwd:       cwd,
-		Env:       cloneEnv(env),
-		CreatedAt: now,
+		OwnerKey:      ownerKey,
+		Cwd:           cwd,
+		Env:           cloneEnv(env),
+		CreatedAt:     now,
+		SourceSession: hist.Session,
 	}
 	sm.mu.Unlock()
 
@@ -487,6 +527,7 @@ func (sm *Manager) RegisterReconnect(prev string, ownerAlive func(key string) bo
 		Env:      cloneEnv(env),
 		BoundAt:  now,
 		LastUsed: now,
+		Session:  hist.Session,
 	}
 	return token, nil
 }

--- a/muxcore/session/session_manager_test.go
+++ b/muxcore/session/session_manager_test.go
@@ -558,6 +558,9 @@ func TestRemovePendingForOwnerExceptSessionPreservesConcurrentReconnect(t *testi
 
 	enteredOwnerCheck := make(chan struct{})
 	releaseOwnerCheck := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseOwner := func() { releaseOnce.Do(func() { close(releaseOwnerCheck) }) }
+	t.Cleanup(releaseOwner)
 	type reconnectResult struct {
 		token string
 		err   error
@@ -571,13 +574,22 @@ func TestRemovePendingForOwnerExceptSessionPreservesConcurrentReconnect(t *testi
 		})
 		result <- reconnectResult{token: token, err: err}
 	}()
-	<-enteredOwnerCheck
+	select {
+	case <-enteredOwnerCheck:
+	case <-time.After(time.Second):
+		t.Fatal("RegisterReconnect did not enter owner liveness check")
+	}
 
 	if removed := sm.RemovePendingForOwnerExceptSession(ownerKey, retained); removed != 1 {
 		t.Fatalf("RemovePendingForOwnerExceptSession() = %d, want fresh reservation only", removed)
 	}
-	close(releaseOwnerCheck)
-	got := <-result
+	releaseOwner()
+	var got reconnectResult
+	select {
+	case got = <-result:
+	case <-time.After(time.Second):
+		t.Fatal("RegisterReconnect did not return after owner check release")
+	}
 	if got.err != nil {
 		t.Fatalf("RegisterReconnect() error = %v", got.err)
 	}

--- a/muxcore/session/session_manager_test.go
+++ b/muxcore/session/session_manager_test.go
@@ -105,6 +105,26 @@ func TestPreRegisterClonesMutableEnv(t *testing.T) {
 	}
 }
 
+func TestLookupPendingForOwnerIsExactAndSideEffectFree(t *testing.T) {
+	sm := NewManager()
+	sm.PreRegisterForOwner("pending", "owner-a", "/project/a", map[string]string{"TOKEN": "original"})
+	if _, _, ok := sm.LookupPendingForOwner("pending", "owner-b"); ok {
+		t.Fatal("lookup accepted wrong owner")
+	}
+	cwd, env, ok := sm.LookupPendingForOwner("pending", "owner-a")
+	if !ok || cwd != "/project/a" || env["TOKEN"] != "original" {
+		t.Fatalf("lookup = (%q, %v, %v), want exact pending context", cwd, env, ok)
+	}
+	env["TOKEN"] = "mutated"
+	_, again, ok := sm.LookupPendingForOwner("pending", "owner-a")
+	if !ok || again["TOKEN"] != "original" {
+		t.Fatal("lookup leaked mutable environment or consumed token")
+	}
+	if !sm.Bind("pending", "owner-a", &Session{ID: 2002}) {
+		t.Fatal("side-effect-free lookup consumed pending token")
+	}
+}
+
 func TestNilSessionContextDoesNotRefreshUnrelatedHistory(t *testing.T) {
 	for _, tc := range []struct {
 		name string

--- a/muxcore/session/session_manager_test.go
+++ b/muxcore/session/session_manager_test.go
@@ -276,6 +276,45 @@ func TestRemoveBoundForOwner(t *testing.T) {
 	}
 }
 
+func TestRemoveBoundForOwnerExceptSessionRevokesOtherLineages(t *testing.T) {
+	sm := NewManager()
+	keep := &Session{ID: 41}
+	evict := &Session{ID: 42}
+	for token, session := range map[string]*Session{"keep": keep, "evict": evict} {
+		sm.RegisterSession(session, "")
+		sm.PreRegisterForOwner(token, "owner-a", "/project/"+token, nil)
+		if !sm.Bind(token, "owner-a", session) {
+			t.Fatalf("Bind(%q) returned false", token)
+		}
+	}
+	keepRefresh, err := sm.RegisterReconnect("keep", func(string) bool { return true })
+	if err != nil {
+		t.Fatalf("RegisterReconnect(keep): %v", err)
+	}
+	evictRefresh, err := sm.RegisterReconnect("evict", func(string) bool { return true })
+	if err != nil {
+		t.Fatalf("RegisterReconnect(evict): %v", err)
+	}
+	if sm.bound[keepRefresh].Session != keep || sm.bound[evictRefresh].Session != evict {
+		t.Fatal("refresh token did not retain its source session lineage")
+	}
+
+	sm.RemovePendingForOwner("owner-a")
+	if removed := sm.RemoveBoundForOwnerExceptSession("owner-a", keep); removed != 2 {
+		t.Fatalf("RemoveBoundForOwnerExceptSession() = %d, want 2", removed)
+	}
+	for _, token := range []string{"evict", evictRefresh} {
+		if _, err := sm.RegisterReconnect(token, func(string) bool { return true }); !errors.Is(err, ErrUnknownToken) {
+			t.Fatalf("RegisterReconnect(%q) error = %v, want ErrUnknownToken", token, err)
+		}
+	}
+	for _, token := range []string{"keep", keepRefresh} {
+		if _, err := sm.RegisterReconnect(token, func(string) bool { return true }); err != nil {
+			t.Fatalf("RegisterReconnect(%q) error = %v, want retained authority", token, err)
+		}
+	}
+}
+
 func TestRemovePendingForOwnerIgnoresEmptyOwnerKey(t *testing.T) {
 	sm := NewManager()
 	sm.PreRegister("legacy", "/project/legacy", nil)
@@ -503,6 +542,50 @@ func TestRegisterReconnect_NewTokenFresh(t *testing.T) {
 	}
 	if s2.Env["X"] != "1" {
 		t.Fatalf("session Env[X] = %q, want %q", s2.Env["X"], "1")
+	}
+}
+
+func TestRemovePendingForOwnerExceptSessionPreservesConcurrentReconnect(t *testing.T) {
+	const ownerKey = "owner-reconnect-race"
+	sm := NewManager()
+	retained := &Session{ID: 101}
+	sm.RegisterSession(retained, "")
+	sm.PreRegisterForOwner("previous", ownerKey, "/project/retained", nil)
+	if !sm.Bind("previous", ownerKey, retained) {
+		t.Fatal("Bind(previous) returned false")
+	}
+	sm.PreRegisterForOwner("fresh", ownerKey, "/project/fresh", nil)
+
+	enteredOwnerCheck := make(chan struct{})
+	releaseOwnerCheck := make(chan struct{})
+	type reconnectResult struct {
+		token string
+		err   error
+	}
+	result := make(chan reconnectResult, 1)
+	go func() {
+		token, err := sm.RegisterReconnect("previous", func(string) bool {
+			close(enteredOwnerCheck)
+			<-releaseOwnerCheck
+			return true
+		})
+		result <- reconnectResult{token: token, err: err}
+	}()
+	<-enteredOwnerCheck
+
+	if removed := sm.RemovePendingForOwnerExceptSession(ownerKey, retained); removed != 1 {
+		t.Fatalf("RemovePendingForOwnerExceptSession() = %d, want fresh reservation only", removed)
+	}
+	close(releaseOwnerCheck)
+	got := <-result
+	if got.err != nil {
+		t.Fatalf("RegisterReconnect() error = %v", got.err)
+	}
+	if got.token == "" || !sm.IsPreRegistered(got.token) {
+		t.Fatalf("retained reconnect reservation %q was revoked", got.token)
+	}
+	if sm.IsPreRegistered("fresh") {
+		t.Fatal("fresh admission reservation survived isolated revocation")
 	}
 }
 

--- a/muxcore/upstream/process.go
+++ b/muxcore/upstream/process.go
@@ -110,6 +110,7 @@ type detachState uint8
 
 const (
 	detachAttached detachState = iota
+	detachLegacy
 	detachPrepared
 	detachCommitted
 	detachAborted
@@ -520,11 +521,16 @@ func (p *Process) Close() error {
 		p.mu.Unlock()
 		return nil
 	}
-	if p.detach != detachAttached {
+	switch p.detach {
+	case detachLegacy, detachCommitted:
 		p.mu.Unlock()
 		return nil
+	case detachPrepared, detachAborted:
+		p.mu.Unlock()
+		return p.AbortDetach()
+	case detachAttached:
+		p.retiring = true
 	}
-	p.retiring = true
 	stdinWait := p.drainTimeout
 	p.mu.Unlock()
 
@@ -625,7 +631,7 @@ func (p *Process) Detach() (pid int, stdinFD uintptr, stdoutFD uintptr, err erro
 	if err := prepareLegacyDetach(p, pid); err != nil {
 		return 0, 0, 0, err
 	}
-	p.detach = detachPrepared
+	p.detach = detachLegacy
 	if p.stdinFile != nil {
 		stdinFD = p.stdinFD
 	}
@@ -690,7 +696,7 @@ func (p *Process) CommitDetach() error {
 		return nil
 	case detachPrepared:
 		p.detach = detachCommitted
-	case detachAborted, detachAttached:
+	case detachAborted, detachAttached, detachLegacy:
 		p.mu.Unlock()
 		return ErrDetachNotPrepared
 	}
@@ -716,7 +722,7 @@ func (p *Process) AbortDetach() error {
 	case detachCommitted:
 		p.mu.Unlock()
 		return ErrDetachCommitted
-	case detachAttached:
+	case detachAttached, detachLegacy:
 		p.mu.Unlock()
 		return ErrDetachNotPrepared
 	case detachPrepared:

--- a/muxcore/upstream/process.go
+++ b/muxcore/upstream/process.go
@@ -286,6 +286,8 @@ func (p *Process) SetDrainTimeout(d time.Duration) {
 // exists and verify Start does not return before the full tree is retired.
 var startPostAuthorityHook = func(*Process) error { return nil }
 
+var afterSpawnPlatform = afterSpawnWindows
+
 var finalizeFailedStartTree = func(p *Process) error { return p.finalizeOwnedTree() }
 
 func Start(command string, args []string, env map[string]string, cwd string, logger *log.Logger) (*Process, error) {
@@ -405,26 +407,27 @@ func Start(command string, args []string, env map[string]string, cwd string, log
 		p.authorityMu.Unlock()
 	}
 
-	if captureErr != nil {
-		// Should not happen — Spawn already propagates PreStart errors — but if
-		// it does, retire the process before returning the setup error.
-		finalizeErr := finalizeFailedStart(p, proc, stdoutR, stdoutW, stderrR, stderrW)
-		return nil, errors.Join(captureErr, finalizeErr)
-	}
-
-	// Upstream owns the single transferable tree authority. Procgroup tree
-	// management is disabled for this spawn to avoid a second Job/PGID owner.
-	if err := afterSpawnWindows(p, proc.PID()); err != nil {
-		finalizeErr := finalizeFailedStart(p, proc, stdoutR, stdoutW, stderrR, stderrW)
-		return nil, errors.Join(fmt.Errorf("upstream: tree authority: %w", err), finalizeErr)
-	}
-	if err := startPostAuthorityHook(p); err != nil {
-		finalizeErr := finalizeFailedStart(p, proc, stdoutR, stdoutW, stderrR, stderrW)
-		startErr := errors.Join(err, finalizeErr)
+	failAfterSpawn := func(startErr error) (*Process, error) {
+		startErr = errors.Join(startErr, finalizeFailedStart(p, proc, stdoutR, stdoutW, stderrR, stderrW))
 		if !p.RetirementProven() {
 			return p, startErr
 		}
 		return nil, startErr
+	}
+
+	if captureErr != nil {
+		// Should not happen — Spawn already propagates PreStart errors — but if
+		// it does, retire the process before returning the setup error.
+		return failAfterSpawn(captureErr)
+	}
+
+	// Upstream owns the single transferable tree authority. Procgroup tree
+	// management is disabled for this spawn to avoid a second Job/PGID owner.
+	if err := afterSpawnPlatform(p, proc.PID()); err != nil {
+		return failAfterSpawn(fmt.Errorf("upstream: tree authority: %w", err))
+	}
+	if err := startPostAuthorityHook(p); err != nil {
+		return failAfterSpawn(err)
 	}
 
 	// Close our copy of the write end — the child inherited its own copy via

--- a/muxcore/upstream/process.go
+++ b/muxcore/upstream/process.go
@@ -34,12 +34,15 @@ import (
 // handler did not exit within timeout).
 // Safe to call after Close() — returns (0, nil) if already closed or detached.
 func (p *Process) SoftClose(timeout time.Duration) (int, error) {
+	p.closeMu.Lock()
+	defer p.closeMu.Unlock()
+
 	p.mu.Lock()
 	if p.closed || p.detach != detachAttached {
 		p.mu.Unlock()
 		return 0, nil
 	}
-	p.closed = true
+	p.retiring = true
 	p.mu.Unlock()
 
 	if p.stdin != nil {
@@ -48,19 +51,23 @@ func (p *Process) SoftClose(timeout time.Duration) (int, error) {
 
 	select {
 	case <-p.Done:
-		return softCloseExitCode(p.ExitErr), terminateProcessTree(p)
+		if err := p.finalizeOwnedTree(); err != nil {
+			return softCloseExitCode(p.ExitErr), err
+		}
+		p.markClosed()
+		return softCloseExitCode(p.ExitErr), nil
 	case <-time.After(timeout):
 	}
 
 	if p.proc != nil || p.pid > 0 {
-		killErr := terminateProcessTree(p)
+		if err := p.finalizeOwnedTree(); err != nil {
+			return -1, err
+		}
 		select {
 		case <-p.Done:
+			p.markClosed()
 		case <-time.After(5 * time.Second):
 			return -1, fmt.Errorf("upstream: process tree did not exit after termination")
-		}
-		if killErr != nil {
-			return softCloseExitCode(p.ExitErr), killErr
 		}
 		return softCloseExitCode(p.ExitErr), fmt.Errorf("upstream: forced kill after soft-close timeout")
 	}
@@ -107,6 +114,8 @@ const (
 	detachCommitted
 	detachAborted
 )
+
+const processTreeRetirementTimeout = 10 * time.Second
 
 // lineBuffer is a mutex-protected deque of lines for buffering stdout.
 // A drain goroutine pushes lines; ReadLine pops them.
@@ -187,18 +196,22 @@ type Process struct {
 	// detach quiesces and joins both before exposing their OS handles.
 	stdoutDrain *streamReadControl
 	stderrDrain *streamReadControl
-	// authorityMu protects the one-shot PGID/Job authority. Finalization,
-	// detach commit, and leader-exit cleanup atomically take and retire it.
+	// authorityMu protects the transferable PGID/Job authority. Finalization
+	// retains it on failure so a later owner-removal attempt can retry.
 	authorityMu sync.Mutex
 	spawnPgid   int
 	jobHandle   uintptr
 
 	lineBuf *lineBuffer
 
-	mu           sync.Mutex
-	closed       bool
-	detach       detachState
-	drainTimeout time.Duration // from x-mux.drainTimeout; overrides default 5s stdin-close wait
+	mu            sync.Mutex
+	closeMu       sync.Mutex
+	finalizeMu    sync.Mutex
+	closed        bool
+	retiring      bool
+	treeFinalized bool
+	detach        detachState
+	drainTimeout  time.Duration // from x-mux.drainTimeout; overrides default 5s stdin-close wait
 
 	// Done is closed when the process exits.
 	Done chan struct{}
@@ -209,15 +222,35 @@ type Process struct {
 // beginExitFinalization atomically decides whether this Process still owns
 // leader-exit cleanup. A detach that reaches detachPrepared first owns the
 // tree lease; an exit finalizer that reaches this method first marks the
-// Process closed so a later detach cannot expose handles from a dying tree.
+// Process retiring so writes and later detach attempts are rejected while
+// finalization remains retryable until the full tree is proven retired.
 func (p *Process) beginExitFinalization() bool {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if p.detach != detachAttached {
 		return false
 	}
-	p.closed = true
+	p.retiring = true
 	return true
+}
+
+func (p *Process) markClosed() {
+	p.mu.Lock()
+	p.closed = true
+	p.mu.Unlock()
+}
+
+func (p *Process) finalizeOwnedTree() error {
+	p.finalizeMu.Lock()
+	defer p.finalizeMu.Unlock()
+	if p.treeFinalized {
+		return nil
+	}
+	if err := terminateProcessTree(p); err != nil {
+		return err
+	}
+	p.treeFinalized = true
+	return nil
 }
 
 // SetDrainTimeout sets the graceful shutdown wait time after stdin close.
@@ -238,6 +271,11 @@ func (p *Process) SetDrainTimeout(d time.Duration) {
 // calling process. In daemon mode os.Stderr is typically discarded (daemon is detached
 // with cmd.Stderr=nil), so upstream crash diagnostics get lost — callers running under
 // a daemon MUST pass a logger to preserve stderr.
+// startPostAuthorityHook is a narrow regression-test seam. Production leaves
+// it as a no-op; tests use it to force a failure after process-tree authority
+// exists and verify Start does not return before the full tree is retired.
+var startPostAuthorityHook = func(*Process) error { return nil }
+
 func Start(command string, args []string, env map[string]string, cwd string, logger *log.Logger) (*Process, error) {
 	var merged []string
 	if len(env) > 0 {
@@ -343,17 +381,34 @@ func Start(command string, args []string, env map[string]string, cwd string, log
 		_ = stderrW.Close()
 		return nil, fmt.Errorf("upstream: spawn %s: %w", command, err)
 	}
+
+	p.proc = proc
+	p.pid = proc.PID()
+	// On Unix, Setpgid=true guarantees PGID == PID after spawn. We read
+	// proc.PID() to stay within the procgroup abstraction. The Windows build
+	// ignores spawnPgid and installs Job authority in afterSpawnWindows.
+	if pid := proc.PID(); pid != 0 {
+		p.authorityMu.Lock()
+		p.spawnPgid = pid
+		p.authorityMu.Unlock()
+	}
+
 	if captureErr != nil {
-		// Should not happen — Spawn already propagates PreStart errors — but be safe.
-		if p.stdin != nil {
-			_ = p.stdin.Close()
-		}
-		_ = stdoutR.Close()
-		_ = stdoutW.Close()
-		_ = stderrR.Close()
-		_ = stderrW.Close()
-		_ = proc.Kill()
-		return nil, captureErr
+		// Should not happen — Spawn already propagates PreStart errors — but if
+		// it does, retire the process before returning the setup error.
+		finalizeErr := finalizeFailedStart(p, proc, stdoutR, stdoutW, stderrR, stderrW)
+		return nil, errors.Join(captureErr, finalizeErr)
+	}
+
+	// Upstream owns the single transferable tree authority. Procgroup tree
+	// management is disabled for this spawn to avoid a second Job/PGID owner.
+	if err := afterSpawnWindows(p, proc.PID()); err != nil {
+		finalizeErr := finalizeFailedStart(p, proc, stdoutR, stdoutW, stderrR, stderrW)
+		return nil, errors.Join(fmt.Errorf("upstream: tree authority: %w", err), finalizeErr)
+	}
+	if err := startPostAuthorityHook(p); err != nil {
+		finalizeErr := finalizeFailedStart(p, proc, stdoutR, stdoutW, stderrR, stderrW)
+		return nil, errors.Join(err, finalizeErr)
 	}
 
 	// Close our copy of the write end — the child inherited its own copy via
@@ -363,28 +418,6 @@ func Start(command string, args []string, env map[string]string, cwd string, log
 	_ = stdoutW.Close()
 	_ = stderrW.Close()
 
-	// Upstream owns the single transferable tree authority. Procgroup tree
-	// management is disabled for this spawn to avoid a second Job/PGID owner.
-	if err := afterSpawnWindows(p, proc.PID()); err != nil {
-		_ = proc.Kill()
-		if p.stdin != nil {
-			_ = p.stdin.Close()
-		}
-		_ = stdoutR.Close()
-		_ = stderrR.Close()
-		return nil, fmt.Errorf("upstream: tree authority: %w", err)
-	}
-
-	p.proc = proc
-	p.pid = proc.PID()
-	// On Unix, Setpgid=true guarantees PGID == PID after spawn.
-	// We read proc.PID() to stay within the procgroup abstraction.
-	// spawnPgid is zero for handler-based processes.
-	if pid := proc.PID(); pid != 0 {
-		p.authorityMu.Lock()
-		p.spawnPgid = pid
-		p.authorityMu.Unlock()
-	}
 	p.lineBuf = newLineBuffer()
 
 	// Both readers publish cancellable read authority. Transactional handoff
@@ -399,27 +432,53 @@ func Start(command string, args []string, env map[string]string, cwd string, log
 	go func() {
 		<-proc.Done()
 		attached := p.beginExitFinalization()
+		var finalizeErr error
 		if attached {
 			if p.stdin != nil {
 				_ = p.stdin.Close()
 			}
-			_ = terminateProcessTree(p)
+			finalizeErr = p.finalizeOwnedTree()
 		}
 		<-stdoutDrained
 		<-stderrDrained
-		p.ExitErr = proc.Wait()
+		p.ExitErr = errors.Join(proc.Wait(), finalizeErr)
+		if finalizeErr == nil {
+			p.markClosed()
+		}
 		close(p.Done)
 	}()
 
 	return p, nil
 }
 
+func finalizeFailedStart(p *Process, proc *procgroup.Process, pipes ...*os.File) error {
+	if p.stdin != nil {
+		_ = p.stdin.Close()
+	}
+
+	finalizeErr := terminateProcessTree(p)
+	if finalizeErr != nil && proc != nil {
+		finalizeErr = errors.Join(finalizeErr, proc.Kill())
+	}
+	if proc != nil {
+		// procgroup.Done closes only after the leader and its platform-owned
+		// descendants are reaped. Blocking here is deliberate: a setup error is
+		// not allowed to escape while a child tree can still be alive.
+		<-proc.Done()
+	}
+	for _, pipe := range pipes {
+		if pipe != nil {
+			_ = pipe.Close()
+		}
+	}
+	return finalizeErr
+}
+
 // WriteLine sends a line of data to the upstream process stdin, followed by newline.
 func (p *Process) WriteLine(data []byte) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-
-	if p.closed {
+	if p.closed || p.retiring {
 		return fmt.Errorf("upstream: process closed")
 	}
 
@@ -453,6 +512,9 @@ func (p *Process) ReadLine() ([]byte, error) {
 //  3. If still alive: proc.GracefulKill() — SIGTERM→wait→SIGKILL on Unix,
 //     CTRL_BREAK_EVENT→wait→TerminateJobObject on Windows. Kills the whole tree.
 func (p *Process) Close() error {
+	p.closeMu.Lock()
+	defer p.closeMu.Unlock()
+
 	p.mu.Lock()
 	if p.closed {
 		p.mu.Unlock()
@@ -462,7 +524,7 @@ func (p *Process) Close() error {
 		p.mu.Unlock()
 		return nil
 	}
-	p.closed = true
+	p.retiring = true
 	stdinWait := p.drainTimeout
 	p.mu.Unlock()
 
@@ -475,18 +537,64 @@ func (p *Process) Close() error {
 
 	select {
 	case <-p.Done:
-		return terminateProcessTree(p)
+		if err := p.finalizeOwnedTree(); err != nil {
+			return err
+		}
+		p.markClosed()
+		return nil
 	case <-time.After(stdinWait):
 	}
-	if p.proc != nil || p.pid > 0 {
-		return terminateProcessTree(p)
+	if err := p.finalizeOwnedTree(); err != nil {
+		return err
 	}
-	return nil
+	if p.proc == nil && p.pid <= 0 {
+		p.markClosed()
+		return nil
+	}
+	select {
+	case <-p.Done:
+		p.markClosed()
+		return nil
+	case <-time.After(10 * time.Second):
+		return fmt.Errorf("upstream: process tree finalization not yet proven")
+	}
 }
 
 // PID returns the process ID of the upstream process.
 func (p *Process) PID() int {
 	return p.pid
+}
+
+// RetirementProven reports whether this Process no longer owns a live process
+// tree authority. Attached OS processes require both Process.Done and retired
+// process-group/Job authority. A committed detach is also terminal for this
+// owner because authority has transferred to the successor.
+func (p *Process) RetirementProven() bool {
+	p.mu.Lock()
+	detach := p.detach
+	closed := p.closed
+	hasOSProcess := p.proc != nil || p.pid > 0
+	p.mu.Unlock()
+
+	if detach == detachCommitted {
+		return true
+	}
+	if !hasOSProcess {
+		return closed
+	}
+
+	p.finalizeMu.Lock()
+	finalized := p.treeFinalized
+	p.finalizeMu.Unlock()
+	if !finalized {
+		return false
+	}
+	select {
+	case <-p.Done:
+		return true
+	default:
+		return false
+	}
 }
 
 // Detach releases ownership of the upstream process without terminating it.
@@ -504,7 +612,7 @@ func (p *Process) Detach() (pid int, stdinFD uintptr, stdoutFD uintptr, err erro
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	if p.closed {
+	if p.closed || p.retiring {
 		return 0, 0, 0, ErrAlreadyClosed
 	}
 	if p.detach != detachAttached {
@@ -531,7 +639,7 @@ func (p *Process) Detach() (pid int, stdinFD uintptr, stdoutFD uintptr, err erro
 // authority until the successor receives a duplicated handle.
 func (p *Process) DetachWithAuthority() (pid int, stdinFD, stdoutFD, stderrFD, authorityFD uintptr, err error) {
 	p.mu.Lock()
-	if p.closed {
+	if p.closed || p.retiring {
 		p.mu.Unlock()
 		return 0, 0, 0, 0, 0, ErrAlreadyClosed
 	}
@@ -605,9 +713,6 @@ func (p *Process) CommitDetach() error {
 func (p *Process) AbortDetach() error {
 	p.mu.Lock()
 	switch p.detach {
-	case detachAborted:
-		p.mu.Unlock()
-		return nil
 	case detachCommitted:
 		p.mu.Unlock()
 		return ErrDetachCommitted
@@ -616,14 +721,19 @@ func (p *Process) AbortDetach() error {
 		return ErrDetachNotPrepared
 	case detachPrepared:
 		p.detach = detachAborted
-		p.closed = true
+		p.retiring = true
+	case detachAborted:
+		p.retiring = true
 	}
 	p.mu.Unlock()
 
 	if p.stdin != nil {
 		_ = p.stdin.Close()
 	}
-	err := terminateProcessTree(p)
+	err := p.finalizeOwnedTree()
+	if err == nil {
+		p.markClosed()
+	}
 	if p.stdout != nil {
 		_ = p.stdout.Close()
 	}
@@ -634,7 +744,7 @@ func (p *Process) AbortDetach() error {
 		select {
 		case <-p.Done:
 		case <-time.After(5 * time.Second):
-			return fmt.Errorf("upstream: abort detach timed out waiting for tree exit")
+			return errors.Join(err, errors.New("upstream: aborted detach process did not exit"))
 		}
 	}
 	return err

--- a/muxcore/upstream/process.go
+++ b/muxcore/upstream/process.go
@@ -496,8 +496,14 @@ func finalizeFailedStart(p *Process, proc *procgroup.Process, pipes ...*os.File)
 		finalizeErr = errors.Join(finalizeErr, proc.Kill())
 	}
 	if finalizeErr == nil {
-		<-p.Done
-		p.markClosed()
+		timer := time.NewTimer(processTreeRetirementTimeout)
+		select {
+		case <-p.Done:
+			timer.Stop()
+			p.markClosed()
+		case <-timer.C:
+			finalizeErr = errors.New("upstream: failed-start retirement not yet proven")
+		}
 	}
 	for _, pipe := range pipes {
 		if pipe != nil {
@@ -769,7 +775,18 @@ func (p *Process) AbortDetach() error {
 		_ = p.stdin.Close()
 	}
 	err := p.finalizeOwnedTree()
-	if err == nil {
+	doneProven := p.proc == nil && p.pid == 0
+	if !doneProven {
+		timer := time.NewTimer(processTreeRetirementTimeout)
+		select {
+		case <-p.Done:
+			timer.Stop()
+			doneProven = true
+		case <-timer.C:
+			err = errors.Join(err, errors.New("upstream: aborted detach process did not exit"))
+		}
+	}
+	if err == nil && doneProven {
 		p.markClosed()
 	}
 	if p.stdout != nil {
@@ -777,13 +794,6 @@ func (p *Process) AbortDetach() error {
 	}
 	if p.stderr != nil {
 		_ = p.stderr.Close()
-	}
-	if p.proc != nil {
-		select {
-		case <-p.Done:
-		case <-time.After(5 * time.Second):
-			return errors.Join(err, errors.New("upstream: aborted detach process did not exit"))
-		}
 	}
 	return err
 }

--- a/muxcore/upstream/process.go
+++ b/muxcore/upstream/process.go
@@ -32,17 +32,26 @@ import (
 // and any error from the kill escalation. A non-nil error signals that a forced
 // kill occurred (either GracefulKill failed, kill succeeded after timeout, or the
 // handler did not exit within timeout).
-// Safe to call after Close() — returns (0, nil) if already closed or detached.
+// Safe to call after Close() — returns (0, nil) if already closed or authority was transferred.
 func (p *Process) SoftClose(timeout time.Duration) (int, error) {
 	p.closeMu.Lock()
 	defer p.closeMu.Unlock()
 
 	p.mu.Lock()
-	if p.closed || p.detach != detachAttached {
+	if p.closed {
 		p.mu.Unlock()
 		return 0, nil
 	}
-	p.retiring = true
+	switch p.detach {
+	case detachLegacy, detachCommitted:
+		p.mu.Unlock()
+		return 0, nil
+	case detachPrepared, detachAborted:
+		p.mu.Unlock()
+		return 0, p.AbortDetach()
+	case detachAttached:
+		p.retiring = true
+	}
 	p.mu.Unlock()
 
 	if p.stdin != nil {
@@ -277,6 +286,8 @@ func (p *Process) SetDrainTimeout(d time.Duration) {
 // exists and verify Start does not return before the full tree is retired.
 var startPostAuthorityHook = func(*Process) error { return nil }
 
+var finalizeFailedStartTree = func(p *Process) error { return p.finalizeOwnedTree() }
+
 func Start(command string, args []string, env map[string]string, cwd string, logger *log.Logger) (*Process, error) {
 	var merged []string
 	if len(env) > 0 {
@@ -409,7 +420,11 @@ func Start(command string, args []string, env map[string]string, cwd string, log
 	}
 	if err := startPostAuthorityHook(p); err != nil {
 		finalizeErr := finalizeFailedStart(p, proc, stdoutR, stdoutW, stderrR, stderrW)
-		return nil, errors.Join(err, finalizeErr)
+		startErr := errors.Join(err, finalizeErr)
+		if !p.RetirementProven() {
+			return p, startErr
+		}
+		return nil, startErr
 	}
 
 	// Close our copy of the write end — the child inherited its own copy via
@@ -452,20 +467,34 @@ func Start(command string, args []string, env map[string]string, cwd string, log
 	return p, nil
 }
 
+func observeFailedStartLeader(p *Process, proc *procgroup.Process) {
+	if proc == nil {
+		close(p.Done)
+		return
+	}
+	go func() {
+		p.ExitErr = proc.Wait()
+		close(p.Done)
+	}()
+}
+
 func finalizeFailedStart(p *Process, proc *procgroup.Process, pipes ...*os.File) error {
+	p.mu.Lock()
+	p.retiring = true
+	p.mu.Unlock()
+	observeFailedStartLeader(p, proc)
+
 	if p.stdin != nil {
 		_ = p.stdin.Close()
 	}
 
-	finalizeErr := terminateProcessTree(p)
+	finalizeErr := finalizeFailedStartTree(p)
 	if finalizeErr != nil && proc != nil {
 		finalizeErr = errors.Join(finalizeErr, proc.Kill())
 	}
-	if proc != nil {
-		// procgroup.Done closes only after the leader and its platform-owned
-		// descendants are reaped. Blocking here is deliberate: a setup error is
-		// not allowed to escape while a child tree can still be alive.
-		<-proc.Done()
+	if finalizeErr == nil {
+		<-p.Done
+		p.markClosed()
 	}
 	for _, pipe := range pipes {
 		if pipe != nil {

--- a/muxcore/upstream/process_test.go
+++ b/muxcore/upstream/process_test.go
@@ -42,6 +42,29 @@ func TestBeginExitFinalizationSerializesDetachLease(t *testing.T) {
 	})
 }
 
+func TestCloseRetriesAbortedDetachFinalization(t *testing.T) {
+	p := &Process{detach: detachAborted, Done: make(chan struct{})}
+	if err := p.Close(); err != nil {
+		t.Fatalf("Close() after aborted detach: %v", err)
+	}
+	if !p.RetirementProven() {
+		t.Fatal("Close() did not prove retirement for aborted detach")
+	}
+}
+
+func TestCloseDoesNotFinalizeCommittedDetach(t *testing.T) {
+	p := &Process{detach: detachCommitted, Done: make(chan struct{})}
+	if err := p.Close(); err != nil {
+		t.Fatalf("Close() after committed detach: %v", err)
+	}
+	p.mu.Lock()
+	closed := p.closed
+	p.mu.Unlock()
+	if closed {
+		t.Fatal("Close() reclaimed authority after committed detach")
+	}
+}
+
 func TestStartAndClose(t *testing.T) {
 	// Use a simple process that exits immediately
 	var cmd string

--- a/muxcore/upstream/softclose_test.go
+++ b/muxcore/upstream/softclose_test.go
@@ -1,6 +1,7 @@
 package upstream
 
 import (
+	"fmt"
 	"runtime"
 	"testing"
 	"time"
@@ -73,5 +74,19 @@ func TestSoftClose_UpstreamIgnoresStdinClose_FallsBackToKill(t *testing.T) {
 		// good — process was killed
 	case <-time.After(10 * time.Second):
 		t.Fatal("process not done after SoftClose forced kill path")
+	}
+}
+
+func TestSoftCloseRetriesAbortedDetachFinalization(t *testing.T) {
+	for _, state := range []detachState{detachPrepared, detachAborted} {
+		t.Run(fmt.Sprint(state), func(t *testing.T) {
+			p := &Process{detach: state, Done: make(chan struct{})}
+			if _, err := p.SoftClose(time.Millisecond); err != nil {
+				t.Fatalf("SoftClose() after detach state %d: %v", state, err)
+			}
+			if !p.RetirementProven() {
+				t.Fatalf("SoftClose() did not prove retirement for detach state %d", state)
+			}
+		})
 	}
 }

--- a/muxcore/upstream/spawn_other.go
+++ b/muxcore/upstream/spawn_other.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"syscall"
+	"time"
 )
 
 func afterSpawnWindows(p *Process, pid int) error { return nil }
@@ -19,7 +20,9 @@ func (p *Process) takeProcessGroupAuthority() int {
 }
 
 func terminateProcessTree(p *Process) error {
-	pgid := p.takeProcessGroupAuthority()
+	p.authorityMu.Lock()
+	defer p.authorityMu.Unlock()
+	pgid := p.spawnPgid
 	if pgid <= 0 {
 		if p.proc == nil {
 			return nil
@@ -28,9 +31,32 @@ func terminateProcessTree(p *Process) error {
 	}
 	err := syscall.Kill(-pgid, syscall.SIGKILL)
 	if errors.Is(err, syscall.ESRCH) {
+		p.spawnPgid = 0
 		return nil
 	}
-	return err
+	if err != nil {
+		return err
+	}
+
+	deadline := time.NewTimer(processTreeRetirementTimeout)
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer deadline.Stop()
+	defer ticker.Stop()
+	for {
+		err = syscall.Kill(-pgid, 0)
+		if errors.Is(err, syscall.ESRCH) {
+			p.spawnPgid = 0
+			return nil
+		}
+		if err != nil && !errors.Is(err, syscall.EPERM) {
+			return fmt.Errorf("probe process group %d: %w", pgid, err)
+		}
+		select {
+		case <-ticker.C:
+		case <-deadline.C:
+			return fmt.Errorf("process group %d retirement not proven after %s", pgid, processTreeRetirementTimeout)
+		}
+	}
 }
 
 func releaseTreeAuthority(p *Process) error {

--- a/muxcore/upstream/spawn_windows.go
+++ b/muxcore/upstream/spawn_windows.go
@@ -97,6 +97,8 @@ func resumeProcessThreads(pid int) error {
 	return nil
 }
 
+var resumeSpawnedProcessThreads = resumeProcessThreads
+
 func afterSpawnWindows(p *Process, pid int) error {
 	handle, err := windows.OpenProcess(
 		windows.PROCESS_SET_QUOTA|windows.PROCESS_TERMINATE|windows.PROCESS_QUERY_LIMITED_INFORMATION,
@@ -115,14 +117,9 @@ func afterSpawnWindows(p *Process, pid int) error {
 	p.jobHandle = uintptr(job)
 	p.authorityMu.Unlock()
 
-	if err := resumeProcessThreads(pid); err != nil {
-		p.authorityMu.Lock()
-		if p.jobHandle == uintptr(job) {
-			p.jobHandle = 0
-		}
-		p.authorityMu.Unlock()
-		_ = windows.TerminateJobObject(job, 1)
-		_ = windows.CloseHandle(job)
+	if err := resumeSpawnedProcessThreads(pid); err != nil {
+		// Keep the installed Job reachable. Start's shared failed-start path
+		// must terminate, wait, and close the exact authority before retry.
 		return err
 	}
 	return nil

--- a/muxcore/upstream/spawn_windows.go
+++ b/muxcore/upstream/spawn_windows.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os/exec"
 	"syscall"
+	"time"
 	"unsafe"
 
 	"golang.org/x/sys/windows"
@@ -136,18 +137,30 @@ func (p *Process) takeJobAuthority() windows.Handle {
 }
 
 func terminateProcessTree(p *Process) error {
-	job := p.takeJobAuthority()
+	p.authorityMu.Lock()
+	defer p.authorityMu.Unlock()
+	job := windows.Handle(p.jobHandle)
 	if job == 0 {
 		if p.proc == nil {
 			return nil
 		}
 		return p.proc.Kill()
 	}
-	err := windows.TerminateJobObject(job, 1)
-	_ = windows.CloseHandle(job)
-	if err != nil {
+	if err := windows.TerminateJobObject(job, 1); err != nil {
 		return fmt.Errorf("TerminateJobObject: %w", err)
 	}
+	waitMillis := uint32(processTreeRetirementTimeout / time.Millisecond)
+	status, err := windows.WaitForSingleObject(job, waitMillis)
+	if err != nil {
+		return fmt.Errorf("WaitForSingleObject(job): %w", err)
+	}
+	if status != windows.WAIT_OBJECT_0 {
+		return fmt.Errorf("job retirement not proven after %s (wait status=%d)", processTreeRetirementTimeout, status)
+	}
+	if err := windows.CloseHandle(job); err != nil {
+		return fmt.Errorf("CloseHandle(job): %w", err)
+	}
+	p.jobHandle = 0
 	return nil
 }
 

--- a/muxcore/upstream/spawn_windows_test.go
+++ b/muxcore/upstream/spawn_windows_test.go
@@ -3,6 +3,7 @@
 package upstream
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -54,5 +55,56 @@ func TestUpstreamJob_SurvivesDaemonJobClose(t *testing.T) {
 	case <-p.Done:
 	case <-time.After(5 * time.Second):
 		t.Fatal("upstream survived closing the final transferred authority")
+	}
+}
+
+func TestResumeFailureRetainsJobAuthorityUntilFinalization(t *testing.T) {
+	setupErr := errors.New("injected resume failure")
+	retirementErr := errors.New("injected unproven retirement")
+	previousResume := resumeSpawnedProcessThreads
+	previousFinalizer := finalizeFailedStartTree
+	var captured *Process
+	var sawJobAuthority bool
+
+	resumeSpawnedProcessThreads = func(int) error { return setupErr }
+	finalizeFailedStartTree = func(p *Process) error {
+		captured = p
+		p.authorityMu.Lock()
+		sawJobAuthority = p.jobHandle != 0
+		p.authorityMu.Unlock()
+		return retirementErr
+	}
+	t.Cleanup(func() {
+		resumeSpawnedProcessThreads = previousResume
+		finalizeFailedStartTree = previousFinalizer
+		if captured == nil || captured.RetirementProven() {
+			return
+		}
+		if err := captured.finalizeOwnedTree(); err != nil {
+			t.Errorf("finalize retained resume-failure authority: %v", err)
+			return
+		}
+		select {
+		case <-captured.Done:
+		case <-time.After(2 * time.Second):
+			t.Error("resume-failure process did not exit during cleanup")
+		}
+	})
+
+	proc, err := Start("ping", []string{"-n", "30", "127.0.0.1"}, nil, "", nil)
+	if proc == nil {
+		t.Fatal("Start() process = nil, want retained resume-failure authority")
+	}
+	if proc != captured {
+		t.Fatal("Start() did not return the resume-failure Process authority")
+	}
+	if !sawJobAuthority {
+		t.Fatal("Windows Job authority was discarded before failed-start finalization")
+	}
+	if !errors.Is(err, setupErr) || !errors.Is(err, retirementErr) {
+		t.Fatalf("Start() error = %v, want resume and retirement failures", err)
+	}
+	if proc.RetirementProven() {
+		t.Fatal("unfinalized resume-failure process reported proven retirement")
 	}
 }

--- a/muxcore/upstream/start_transaction_test.go
+++ b/muxcore/upstream/start_transaction_test.go
@@ -119,3 +119,93 @@ func TestRetirementProvenRequiresDoneAndTreeAuthority(t *testing.T) {
 		t.Fatal("committed authority transfer should be terminal for predecessor owner")
 	}
 }
+
+func TestStartPostAuthorityFailureRetainsUnprovenProcessAuthority(t *testing.T) {
+	pidFile := t.TempDir() + string(os.PathSeparator) + "descendant.pid"
+	setupErr := errors.New("injected post-authority failure")
+	retirementErr := errors.New("injected unproven retirement")
+	var captured *Process
+	var leaderPID int
+	var descendantPID int
+
+	previousStartHook := startPostAuthorityHook
+	previousFinalizer := finalizeFailedStartTree
+	startPostAuthorityHook = func(p *Process) error {
+		captured = p
+		leaderPID = p.PID()
+		deadline := time.Now().Add(5 * time.Second)
+		for time.Now().Before(deadline) {
+			data, err := os.ReadFile(pidFile)
+			if err == nil {
+				text := strings.TrimSpace(string(data))
+				if text == "" {
+					time.Sleep(10 * time.Millisecond)
+					continue
+				}
+				pid, parseErr := strconv.Atoi(text)
+				if parseErr != nil {
+					return fmt.Errorf("parse descendant pid: %w", parseErr)
+				}
+				descendantPID = pid
+				return setupErr
+			}
+			if !errors.Is(err, os.ErrNotExist) {
+				return fmt.Errorf("read descendant pid: %w", err)
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		return errors.New("descendant pid was not published")
+	}
+	finalizeFailedStartTree = func(*Process) error { return retirementErr }
+	t.Cleanup(func() {
+		startPostAuthorityHook = previousStartHook
+		finalizeFailedStartTree = previousFinalizer
+		if captured != nil && !captured.RetirementProven() {
+			_ = captured.finalizeOwnedTree()
+		}
+		if leaderPID > 0 && upstreamTestProcessAlive(leaderPID) {
+			killUpstreamTestProcess(leaderPID)
+		}
+		if descendantPID > 0 && upstreamTestProcessAlive(descendantPID) {
+			killUpstreamTestProcess(descendantPID)
+		}
+	})
+
+	env := make(map[string]string)
+	for _, item := range os.Environ() {
+		key, value, ok := strings.Cut(item, "=")
+		if ok {
+			env[key] = value
+		}
+	}
+	env[startFailureRoleEnv] = "leader"
+	env[startFailurePIDFileEnv] = pidFile
+
+	proc, err := Start(os.Args[0], []string{"-test.run=^TestStartPostAuthorityFailureFinalizesProcessTree$"}, env, "", nil)
+	if proc == nil {
+		t.Fatal("Start() process = nil, want retained unproven authority")
+	}
+	if proc != captured {
+		t.Fatal("Start() did not return the installed Process authority")
+	}
+	if !errors.Is(err, setupErr) || !errors.Is(err, retirementErr) {
+		t.Fatalf("Start() error = %v, want setup and retirement failures", err)
+	}
+	select {
+	case <-proc.Done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Process.Done did not report failed-start leader completion")
+	}
+	if proc.RetirementProven() {
+		t.Fatal("leader completion without tree finalization proved retirement")
+	}
+	if err := proc.Close(); err != nil {
+		t.Fatalf("Close() retry after failed start: %v", err)
+	}
+	if !proc.RetirementProven() {
+		t.Fatal("Close() retry did not prove failed-start retirement")
+	}
+	if upstreamTestProcessAlive(descendantPID) {
+		t.Fatalf("descendant pid %d still alive after retry", descendantPID)
+	}
+}

--- a/muxcore/upstream/start_transaction_test.go
+++ b/muxcore/upstream/start_transaction_test.go
@@ -209,3 +209,60 @@ func TestStartPostAuthorityFailureRetainsUnprovenProcessAuthority(t *testing.T) 
 		t.Fatalf("descendant pid %d still alive after retry", descendantPID)
 	}
 }
+
+func TestStartPlatformSetupFailureRetainsUnprovenProcessAuthority(t *testing.T) {
+	if os.Getenv(startFailureRoleEnv) == "platform" {
+		select {}
+	}
+
+	setupErr := errors.New("injected platform setup failure")
+	retirementErr := errors.New("injected unproven retirement")
+	var captured *Process
+
+	previousPlatform := afterSpawnPlatform
+	previousFinalizer := finalizeFailedStartTree
+	afterSpawnPlatform = func(p *Process, _ int) error {
+		captured = p
+		return setupErr
+	}
+	finalizeFailedStartTree = func(*Process) error { return retirementErr }
+	t.Cleanup(func() {
+		afterSpawnPlatform = previousPlatform
+		finalizeFailedStartTree = previousFinalizer
+		if captured == nil || captured.RetirementProven() {
+			return
+		}
+		if err := captured.finalizeOwnedTree(); err != nil {
+			t.Errorf("finalize retained platform-failure authority: %v", err)
+			return
+		}
+		select {
+		case <-captured.Done:
+		case <-time.After(2 * time.Second):
+			t.Error("retained platform-failure process did not exit during cleanup")
+		}
+	})
+
+	env := make(map[string]string)
+	for _, item := range os.Environ() {
+		key, value, ok := strings.Cut(item, "=")
+		if ok {
+			env[key] = value
+		}
+	}
+	env[startFailureRoleEnv] = "platform"
+
+	proc, err := Start(os.Args[0], []string{"-test.run=^TestStartPlatformSetupFailureRetainsUnprovenProcessAuthority$"}, env, "", nil)
+	if proc == nil {
+		t.Fatal("Start() process = nil, want retained platform-failure authority")
+	}
+	if proc != captured {
+		t.Fatal("Start() did not return the installed platform-failure authority")
+	}
+	if !errors.Is(err, setupErr) || !errors.Is(err, retirementErr) {
+		t.Fatalf("Start() error = %v, want setup and retirement failures", err)
+	}
+	if proc.RetirementProven() {
+		t.Fatal("unfinalized platform-failure process reported proven retirement")
+	}
+}

--- a/muxcore/upstream/start_transaction_test.go
+++ b/muxcore/upstream/start_transaction_test.go
@@ -45,7 +45,12 @@ func TestStartPostAuthorityFailureFinalizesProcessTree(t *testing.T) {
 		for time.Now().Before(deadline) {
 			data, err := os.ReadFile(pidFile)
 			if err == nil {
-				pid, parseErr := strconv.Atoi(strings.TrimSpace(string(data)))
+				text := strings.TrimSpace(string(data))
+				if text == "" {
+					time.Sleep(10 * time.Millisecond)
+					continue
+				}
+				pid, parseErr := strconv.Atoi(text)
 				if parseErr != nil {
 					return fmt.Errorf("parse descendant pid: %w", parseErr)
 				}

--- a/muxcore/upstream/start_transaction_test.go
+++ b/muxcore/upstream/start_transaction_test.go
@@ -37,6 +37,14 @@ func TestStartPostAuthorityFailureFinalizesProcessTree(t *testing.T) {
 	injected := errors.New("injected post-authority failure")
 	var leaderPID int
 	var descendantPID int
+	t.Cleanup(func() {
+		if leaderPID > 0 && upstreamTestProcessAlive(leaderPID) {
+			killUpstreamTestProcess(leaderPID)
+		}
+		if descendantPID > 0 && upstreamTestProcessAlive(descendantPID) {
+			killUpstreamTestProcess(descendantPID)
+		}
+	})
 
 	previousHook := startPostAuthorityHook
 	startPostAuthorityHook = func(p *Process) error {

--- a/muxcore/upstream/start_transaction_test.go
+++ b/muxcore/upstream/start_transaction_test.go
@@ -1,0 +1,116 @@
+package upstream
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	startFailureRoleEnv    = "MCPMUX_START_FAILURE_ROLE"
+	startFailurePIDFileEnv = "MCPMUX_START_FAILURE_PID_FILE"
+)
+
+func TestStartPostAuthorityFailureFinalizesProcessTree(t *testing.T) {
+	switch os.Getenv(startFailureRoleEnv) {
+	case "descendant":
+		select {}
+	case "leader":
+		cmd := exec.Command(os.Args[0], "-test.run=^TestStartPostAuthorityFailureFinalizesProcessTree$")
+		cmd.Env = append(os.Environ(), startFailureRoleEnv+"=descendant")
+		if err := cmd.Start(); err != nil {
+			t.Fatalf("start descendant: %v", err)
+		}
+		pidFile := os.Getenv(startFailurePIDFileEnv)
+		if err := os.WriteFile(pidFile, []byte(strconv.Itoa(cmd.Process.Pid)), 0o600); err != nil {
+			t.Fatalf("write descendant pid: %v", err)
+		}
+		select {}
+	}
+
+	pidFile := t.TempDir() + string(os.PathSeparator) + "descendant.pid"
+	injected := errors.New("injected post-authority failure")
+	var leaderPID int
+	var descendantPID int
+
+	previousHook := startPostAuthorityHook
+	startPostAuthorityHook = func(p *Process) error {
+		leaderPID = p.PID()
+		deadline := time.Now().Add(5 * time.Second)
+		for time.Now().Before(deadline) {
+			data, err := os.ReadFile(pidFile)
+			if err == nil {
+				pid, parseErr := strconv.Atoi(strings.TrimSpace(string(data)))
+				if parseErr != nil {
+					return fmt.Errorf("parse descendant pid: %w", parseErr)
+				}
+				descendantPID = pid
+				return injected
+			}
+			if !errors.Is(err, os.ErrNotExist) {
+				return fmt.Errorf("read descendant pid: %w", err)
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		return errors.New("descendant pid was not published")
+	}
+	t.Cleanup(func() { startPostAuthorityHook = previousHook })
+
+	env := make(map[string]string)
+	for _, item := range os.Environ() {
+		key, value, ok := strings.Cut(item, "=")
+		if ok {
+			env[key] = value
+		}
+	}
+	env[startFailureRoleEnv] = "leader"
+	env[startFailurePIDFileEnv] = pidFile
+
+	proc, err := Start(os.Args[0], []string{"-test.run=^TestStartPostAuthorityFailureFinalizesProcessTree$"}, env, "", nil)
+	if proc != nil {
+		t.Fatalf("Start() process = %#v, want nil on post-authority failure", proc)
+	}
+	if !errors.Is(err, injected) {
+		t.Fatalf("Start() error = %v, want injected failure", err)
+	}
+	if leaderPID <= 0 || descendantPID <= 0 {
+		t.Fatalf("captured pids = leader %d descendant %d, want both positive", leaderPID, descendantPID)
+	}
+	if upstreamTestProcessAlive(leaderPID) {
+		killUpstreamTestProcess(leaderPID)
+		t.Fatalf("leader pid %d still alive after Start returned", leaderPID)
+	}
+	if upstreamTestProcessAlive(descendantPID) {
+		killUpstreamTestProcess(descendantPID)
+		t.Fatalf("descendant pid %d still alive after Start returned", descendantPID)
+	}
+}
+
+func TestRetirementProvenRequiresDoneAndTreeAuthority(t *testing.T) {
+	done := make(chan struct{})
+	p := &Process{pid: 42, Done: done, treeFinalized: true}
+	if p.RetirementProven() {
+		t.Fatal("tree finalizer success alone must not prove retirement before Done")
+	}
+	close(done)
+	if !p.RetirementProven() {
+		t.Fatal("Done plus tree authority finalization should prove retirement")
+	}
+
+	doneWithoutAuthority := make(chan struct{})
+	close(doneWithoutAuthority)
+	p = &Process{pid: 42, Done: doneWithoutAuthority}
+	if p.RetirementProven() {
+		t.Fatal("leader Done alone must not prove process-tree retirement")
+	}
+
+	p = &Process{pid: 42, Done: make(chan struct{}), detach: detachCommitted}
+	if !p.RetirementProven() {
+		t.Fatal("committed authority transfer should be terminal for predecessor owner")
+	}
+}


### PR DESCRIPTION
## Summary

- add demand-driven upstream materialization for compatible template-backed owners: cached MCP discovery stays process-free until the first uncached request, which wakes exactly one generation on the same transport
- enforce fail-closed template identity, isolated-CWD shadowing, bounded revision mismatch fallback, and Windows case-insensitive effective-environment canonicalization
- preserve one exact process-tree authority across failed starts, restart pins, snapshot fallback, and mixed handoff outcomes; prepare the v0.28.0 release docs and pin CI/release builds to Go 1.25.12

## Compatibility

Backward-compatible feature release. Ordinary `engine.New` consumers require no source changes. Persistent/eager owners remain eager.

## Verification

- `go test -race -count=1 -timeout 180s ./...`
- `go -C muxcore test -race -count=1 -timeout 240s -p=1 ./...`
- `go vet ./...` and `go -C muxcore vet ./...`
- root and muxcore `go mod verify`
- Production Testing Playbook Scenario 8 focused lifecycle suite
- Production Testing Playbook Scenario 9 exact materialization suite
- repository critical suite: PASS 5/5, including Windows lifecycle convergence and native SessionHandler hot update
- `govulncheck ./...` in root and muxcore: 0 reachable vulnerabilities
- `gitleaks` across `origin/master..HEAD`: no leaks
- independent code/security/semantic convergence review: APPROVE / PASS / ACCEPT

## Release follow-through

After merge and green CI: publish annotated `v0.28.0` and `muxcore/v0.28.0`, verify artifact/tag/module parity, then update and re-read Aimux and Engram adoption issues before declaring `CONSUMER_HANDOFF_PASS`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Новые возможности**
  - Добавлен режим «cache-only» с отложенной materialization upstream при первом uncached-запросе; при наличии совместимого кэша повторные сессии запускаются быстрее.
  - Усилены правила совместимости шаблонов: fail-closed по SHA-256 identity security-relevant окружения и (для isolated) каноническому рабочему каталогу.
  - Повышена устойчивость graceful restart и handoff, включая корректную обработку финального ACK и восстановление после рестартов.
  - Расширены публичные средства управления запуском сервера и наблюдения состояния материализации.

- **Документация**
  - Обновлены README, README.ru, CHANGELOG, RELEASE_NOTES, AGENTS и производственный playbook под v0.28.0.

- **Инструменты**
  - CI и релизная сборка переведены на Go **1.25.12**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->