### PR TITLE
docs: drop logon SID hardening debt

### DIFF
--- a/TECHNICAL_DEBT.md
+++ b/TECHNICAL_DEBT.md
@@ -38,8 +38,6 @@ current release:
   tombstone.
 - **Extremal retry coverage** — add a test with two prior general spawn retries,
   followed by two template mismatches and the cold fifth attempt.
-- **Windows DACL isolation** — evaluate a logon-SID DACL instead of an
-  account-SID DACL only if terminal-session isolation becomes a requirement.
 - **Detached listener test flake** —
   `TestDetachedProcessListenerAcceptsParentDial` failed once in the full Windows
   muxcore suite with empty helper output but passed 10 focused repetitions;


### PR DESCRIPTION
## Summary

Removes the `Windows DACL isolation` follow-up from `TECHNICAL_DEBT.md`. The operator explicitly rejected terminal-session restrictions as unnecessary for mcp-mux's current same-account trust model.

No runtime behavior changes. Existing account-SID DACL, token authentication, and process-owner checks remain unchanged.

## Verification

- `git diff --check`
- Documentation-only two-line deletion; no tests required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Документация**
  * Обновлён список технических задач: удалён пункт об оценке изоляции Windows DACL.
  * Добавлен пункт для отслеживания нестабильного теста отключённого слушателя, включая описание условий воспроизведения сбоя.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->