### PR TITLE
fix(muxcore): fence reaper eviction snapshots

### DIFF
--- a/muxcore/daemon/owner_lifecycle.go
+++ b/muxcore/daemon/owner_lifecycle.go
@@ -181,7 +181,7 @@ func (d *Daemon) finalizeAndRemoveOwner(serverID string, expected *OwnerEntry, r
 		finishOwnerRemovalAttemptLocked(entry)
 		d.mu.Unlock()
 		if scheduleRetry {
-			d.scheduleOwnerFinalizationRetry(serverID, entry, reason, soft)
+			d.scheduleOwnerFinalizationRetry(serverID, entry, reason, soft, eligible)
 		}
 		return result, finalizationErr
 	}
@@ -198,7 +198,7 @@ func (d *Daemon) finalizeAndRemoveOwner(serverID string, expected *OwnerEntry, r
 		d.mu.Unlock()
 		pinErr := fmt.Errorf("owner %s gained a snapshot pin during finalization", shortServerID(serverID))
 		if scheduleRetry {
-			d.scheduleOwnerFinalizationRetry(serverID, entry, reason, soft)
+			d.scheduleOwnerFinalizationRetry(serverID, entry, reason, soft, eligible)
 		}
 		return result, errors.Join(finalizationErr, pinErr)
 	}
@@ -254,7 +254,7 @@ func (d *Daemon) finalizeOwnerWithRetry(ownerRef *owner.Owner, soft bool) (int, 
 	return exitCode, false, fmt.Errorf("owner finalization unproven after %d attempts: %w", ownerFinalizationAttempts, lastErr)
 }
 
-func (d *Daemon) scheduleOwnerFinalizationRetry(serverID string, entry *OwnerEntry, reason ownerRemovalReason, soft bool) {
+func (d *Daemon) scheduleOwnerFinalizationRetry(serverID string, entry *OwnerEntry, reason ownerRemovalReason, soft bool, eligible func(*OwnerEntry) bool) {
 	d.mu.Lock()
 	if d.owners[serverID] != entry || entry.removalRetrying {
 		d.mu.Unlock()
@@ -278,7 +278,7 @@ func (d *Daemon) scheduleOwnerFinalizationRetry(serverID string, entry *OwnerEnt
 				timer.Stop()
 				return
 			}
-			result, err := d.finalizeAndRemoveOwner(serverID, entry, reason, soft, nil, false)
+			result, err := d.finalizeAndRemoveOwner(serverID, entry, reason, soft, eligible, false)
 			if result.Removed || err == nil {
 				return
 			}

--- a/muxcore/daemon/owner_lifecycle.go
+++ b/muxcore/daemon/owner_lifecycle.go
@@ -121,7 +121,7 @@ func (d *Daemon) removeOwnerIfCurrentAndZeroIdle(serverID string, expected *Owne
 		soft = false
 	}
 	removed, err := d.finalizeAndRemoveOwner(serverID, entry, reason, soft, func(current *OwnerEntry) bool {
-		return current.LastSession.Equal(zeroAt)
+		return current.Owner == ownerRef && !current.Persistent && current.LastSession.Equal(zeroAt)
 	}, true)
 	return removed, removed.Removed, err
 }
@@ -255,6 +255,12 @@ func (d *Daemon) finalizeOwnerWithRetry(ownerRef *owner.Owner, soft bool) (int, 
 }
 
 func (d *Daemon) scheduleOwnerFinalizationRetry(serverID string, entry *OwnerEntry, reason ownerRemovalReason, soft bool, eligible func(*OwnerEntry) bool) {
+	if reason == ownerRemovalReasonIdle || reason == ownerRemovalReasonZombie {
+		previousEligible := eligible
+		eligible = func(current *OwnerEntry) bool {
+			return current != nil && !current.Persistent && (previousEligible == nil || previousEligible(current))
+		}
+	}
 	d.mu.Lock()
 	if d.owners[serverID] != entry || entry.removalRetrying {
 		d.mu.Unlock()

--- a/muxcore/daemon/owner_lifecycle.go
+++ b/muxcore/daemon/owner_lifecycle.go
@@ -181,7 +181,7 @@ func (d *Daemon) finalizeAndRemoveOwner(serverID string, expected *OwnerEntry, r
 		finishOwnerRemovalAttemptLocked(entry)
 		d.mu.Unlock()
 		if scheduleRetry {
-			d.scheduleOwnerFinalizationRetry(serverID, entry, reason, soft, eligible)
+			d.scheduleOwnerFinalizationRetry(serverID, entry, reason, soft)
 		}
 		return result, finalizationErr
 	}
@@ -198,7 +198,7 @@ func (d *Daemon) finalizeAndRemoveOwner(serverID string, expected *OwnerEntry, r
 		d.mu.Unlock()
 		pinErr := fmt.Errorf("owner %s gained a snapshot pin during finalization", shortServerID(serverID))
 		if scheduleRetry {
-			d.scheduleOwnerFinalizationRetry(serverID, entry, reason, soft, eligible)
+			d.scheduleOwnerFinalizationRetry(serverID, entry, reason, soft)
 		}
 		return result, errors.Join(finalizationErr, pinErr)
 	}
@@ -254,13 +254,7 @@ func (d *Daemon) finalizeOwnerWithRetry(ownerRef *owner.Owner, soft bool) (int, 
 	return exitCode, false, fmt.Errorf("owner finalization unproven after %d attempts: %w", ownerFinalizationAttempts, lastErr)
 }
 
-func (d *Daemon) scheduleOwnerFinalizationRetry(serverID string, entry *OwnerEntry, reason ownerRemovalReason, soft bool, eligible func(*OwnerEntry) bool) {
-	if reason == ownerRemovalReasonIdle || reason == ownerRemovalReasonZombie {
-		previousEligible := eligible
-		eligible = func(current *OwnerEntry) bool {
-			return current != nil && !current.Persistent && (previousEligible == nil || previousEligible(current))
-		}
-	}
+func (d *Daemon) scheduleOwnerFinalizationRetry(serverID string, entry *OwnerEntry, reason ownerRemovalReason, soft bool) {
 	d.mu.Lock()
 	if d.owners[serverID] != entry || entry.removalRetrying {
 		d.mu.Unlock()
@@ -284,7 +278,9 @@ func (d *Daemon) scheduleOwnerFinalizationRetry(serverID string, entry *OwnerEnt
 				timer.Stop()
 				return
 			}
-			result, err := d.finalizeAndRemoveOwner(serverID, entry, reason, soft, eligible, false)
+			// FinalizeForRemoval has already torn down admission. Keep retiring
+			// that exact generation even if reusable-entry metadata changes.
+			result, err := d.finalizeAndRemoveOwner(serverID, entry, reason, soft, nil, false)
 			if result.Removed || err == nil {
 				return
 			}

--- a/muxcore/daemon/owner_lifecycle_test.go
+++ b/muxcore/daemon/owner_lifecycle_test.go
@@ -416,6 +416,65 @@ func TestReaperFinalizationRetryPreservesEligibilityGate(t *testing.T) {
 	}
 }
 
+func TestZeroSessionFinalizationRetryRejectsNewPersistence(t *testing.T) {
+	d := testDaemon(t)
+	d.supervisor = nil
+	sid := "zero-session-retry-persistent"
+	o := testReconnectOwner(t, sid)
+	zeroAt := time.Now().Add(-time.Second)
+	entry := &OwnerEntry{
+		Owner:       o,
+		ServerID:    sid,
+		LastSession: zeroAt,
+		IdleTimeout: time.Millisecond,
+	}
+	d.mu.Lock()
+	d.owners[sid] = entry
+	d.mu.Unlock()
+	time.Sleep(20 * time.Millisecond)
+
+	original := finalizeOwnerForRemoval
+	var calls atomic.Int32
+	finalizeOwnerForRemoval = func(got *owner.Owner, soft bool) (int, bool, error) {
+		if got != o || !soft {
+			t.Fatalf("finalizer got owner=%p soft=%v, want owner=%p soft=true", got, soft, o)
+		}
+		if calls.Add(1) <= ownerFinalizationAttempts {
+			return 0, false, errors.New("synthetic zero-session retirement pending")
+		}
+		return 0, true, nil
+	}
+	t.Cleanup(func() { finalizeOwnerForRemoval = original })
+
+	if _, removed, err := d.removeOwnerIfCurrentAndZeroIdle(sid, entry, zeroAt, time.Millisecond); err == nil {
+		t.Fatal("zero-session removal unexpectedly proved finalization")
+	} else if removed {
+		t.Fatal("zero-session removal forgot owner before retry")
+	}
+	if got := calls.Load(); got != ownerFinalizationAttempts {
+		t.Fatalf("synchronous finalizer calls=%d, want %d", got, ownerFinalizationAttempts)
+	}
+	d.mu.Lock()
+	entry.Persistent = true
+	retrying := entry.removalRetrying
+	d.mu.Unlock()
+	if !retrying {
+		t.Fatal("zero-session removal did not schedule finalization retry")
+	}
+
+	waitForDaemonCondition(t, time.Second, func() bool {
+		d.mu.RLock()
+		defer d.mu.RUnlock()
+		return !entry.removalRetrying
+	}, "zero-session retry did not settle after persistence changed")
+	if current := d.Entry(sid); current != entry || !current.Persistent {
+		t.Fatal("zero-session retry removed or unpinned persistent owner")
+	}
+	if got := calls.Load(); got != ownerFinalizationAttempts {
+		t.Fatalf("finalizer calls=%d after persistence changed, want %d", got, ownerFinalizationAttempts)
+	}
+}
+
 func TestOwnerRemovalKeepsEntryWhenFinalizationUnproven(t *testing.T) {
 	d := testDaemon(t)
 	d.supervisor = nil

--- a/muxcore/daemon/owner_lifecycle_test.go
+++ b/muxcore/daemon/owner_lifecycle_test.go
@@ -360,10 +360,10 @@ func TestReaperFinalizationRetryRetainsLivePIDAndOwnerState(t *testing.T) {
 	}
 }
 
-func TestReaperFinalizationRetryPreservesEligibilityGate(t *testing.T) {
+func TestReaperFinalizationRetryContinuesAfterEntryMetadataChanges(t *testing.T) {
 	d := testDaemon(t)
 	d.supervisor = nil
-	sid := "reaper-retry-eligibility"
+	sid := "reaper-retry-retirement"
 	o := testReconnectOwner(t, sid)
 	entry := &OwnerEntry{
 		Owner:       o,
@@ -397,29 +397,24 @@ func TestReaperFinalizationRetryPreservesEligibilityGate(t *testing.T) {
 	}
 	d.mu.Lock()
 	entry.Persistent = true
+	entry.LastSession = time.Now()
+	entry.IdleTimeout = time.Hour
 	retrying := entry.removalRetrying
 	d.mu.Unlock()
 	if !retrying {
 		t.Fatal("reaper did not schedule finalization retry")
 	}
 
-	waitForDaemonCondition(t, time.Second, func() bool {
-		d.mu.RLock()
-		defer d.mu.RUnlock()
-		return !entry.removalRetrying
-	}, "scheduled retry did not settle after eligibility changed")
-	if current := d.Entry(sid); current != entry {
-		t.Fatal("scheduled retry removed owner after it became persistent")
-	}
-	if got := calls.Load(); got != ownerFinalizationAttempts {
-		t.Fatalf("finalizer calls=%d after eligibility changed, want %d", got, ownerFinalizationAttempts)
+	waitForDaemonCondition(t, time.Second, func() bool { return d.Entry(sid) == nil }, "scheduled retry stopped after teardown metadata changed")
+	if got := calls.Load(); got < ownerFinalizationAttempts+1 {
+		t.Fatalf("finalizer calls=%d, want retry after teardown began", got)
 	}
 }
 
-func TestZeroSessionFinalizationRetryRejectsNewPersistence(t *testing.T) {
+func TestZeroSessionFinalizationRetryContinuesAfterPersistenceChange(t *testing.T) {
 	d := testDaemon(t)
 	d.supervisor = nil
-	sid := "zero-session-retry-persistent"
+	sid := "zero-session-retry-retirement"
 	o := testReconnectOwner(t, sid)
 	zeroAt := time.Now().Add(-time.Second)
 	entry := &OwnerEntry{
@@ -462,16 +457,9 @@ func TestZeroSessionFinalizationRetryRejectsNewPersistence(t *testing.T) {
 		t.Fatal("zero-session removal did not schedule finalization retry")
 	}
 
-	waitForDaemonCondition(t, time.Second, func() bool {
-		d.mu.RLock()
-		defer d.mu.RUnlock()
-		return !entry.removalRetrying
-	}, "zero-session retry did not settle after persistence changed")
-	if current := d.Entry(sid); current != entry || !current.Persistent {
-		t.Fatal("zero-session retry removed or unpinned persistent owner")
-	}
-	if got := calls.Load(); got != ownerFinalizationAttempts {
-		t.Fatalf("finalizer calls=%d after persistence changed, want %d", got, ownerFinalizationAttempts)
+	waitForDaemonCondition(t, time.Second, func() bool { return d.Entry(sid) == nil }, "zero-session retry stopped after teardown persistence changed")
+	if got := calls.Load(); got < ownerFinalizationAttempts+1 {
+		t.Fatalf("finalizer calls=%d, want retry after zero-session teardown began", got)
 	}
 }
 

--- a/muxcore/daemon/owner_lifecycle_test.go
+++ b/muxcore/daemon/owner_lifecycle_test.go
@@ -360,6 +360,62 @@ func TestReaperFinalizationRetryRetainsLivePIDAndOwnerState(t *testing.T) {
 	}
 }
 
+func TestReaperFinalizationRetryPreservesEligibilityGate(t *testing.T) {
+	d := testDaemon(t)
+	d.supervisor = nil
+	sid := "reaper-retry-eligibility"
+	o := testReconnectOwner(t, sid)
+	entry := &OwnerEntry{
+		Owner:       o,
+		ServerID:    sid,
+		LastSession: time.Now().Add(-time.Second),
+		IdleTimeout: time.Millisecond,
+	}
+	d.mu.Lock()
+	d.owners[sid] = entry
+	d.mu.Unlock()
+	time.Sleep(20 * time.Millisecond)
+
+	original := finalizeOwnerForRemoval
+	var calls atomic.Int32
+	finalizeOwnerForRemoval = func(got *owner.Owner, soft bool) (int, bool, error) {
+		if got != o || !soft {
+			t.Fatalf("finalizer got owner=%p soft=%v, want owner=%p soft=true", got, soft, o)
+		}
+		if calls.Add(1) <= ownerFinalizationAttempts {
+			return 0, false, errors.New("synthetic whole-tree proof pending")
+		}
+		return 0, true, nil
+	}
+	t.Cleanup(func() { finalizeOwnerForRemoval = original })
+
+	if affected := (&Reaper{daemon: d, logger: d.logger}).sweep(); affected != 0 {
+		t.Fatalf("first reaper sweep affected=%d, want retryable owner retained", affected)
+	}
+	if got := calls.Load(); got != ownerFinalizationAttempts {
+		t.Fatalf("synchronous finalizer calls=%d, want %d", got, ownerFinalizationAttempts)
+	}
+	d.mu.Lock()
+	entry.Persistent = true
+	retrying := entry.removalRetrying
+	d.mu.Unlock()
+	if !retrying {
+		t.Fatal("reaper did not schedule finalization retry")
+	}
+
+	waitForDaemonCondition(t, time.Second, func() bool {
+		d.mu.RLock()
+		defer d.mu.RUnlock()
+		return !entry.removalRetrying
+	}, "scheduled retry did not settle after eligibility changed")
+	if current := d.Entry(sid); current != entry {
+		t.Fatal("scheduled retry removed owner after it became persistent")
+	}
+	if got := calls.Load(); got != ownerFinalizationAttempts {
+		t.Fatalf("finalizer calls=%d after eligibility changed, want %d", got, ownerFinalizationAttempts)
+	}
+}
+
 func TestOwnerRemovalKeepsEntryWhenFinalizationUnproven(t *testing.T) {
 	d := testDaemon(t)
 	d.supervisor = nil

--- a/muxcore/daemon/reaper.go
+++ b/muxcore/daemon/reaper.go
@@ -36,6 +36,24 @@ type Reaper struct {
 	stopped  chan struct{}
 }
 
+type reaperOwnerView struct {
+	sid         string
+	entry       *OwnerEntry
+	owner       *owner.Owner
+	persistent  bool
+	idleTimeout time.Duration
+	lastSession time.Time
+}
+
+func (v reaperOwnerView) matches(current *OwnerEntry) bool {
+	return current != nil &&
+		current == v.entry &&
+		current.Owner == v.owner &&
+		current.Persistent == v.persistent &&
+		current.IdleTimeout == v.idleTimeout &&
+		current.LastSession.Equal(v.lastSession)
+}
+
 // NewReaper creates and starts a reaper goroutine.
 func NewReaper(d *Daemon, interval time.Duration) *Reaper {
 	if interval == 0 {
@@ -100,11 +118,16 @@ func (r *Reaper) sweep() int {
 	affected := 0
 
 	r.daemon.mu.RLock()
-	entries := make([]*OwnerEntry, 0, len(r.daemon.owners))
-	sids := make([]string, 0, len(r.daemon.owners))
-	for sid, e := range r.daemon.owners {
-		entries = append(entries, e)
-		sids = append(sids, sid)
+	entries := make([]reaperOwnerView, 0, len(r.daemon.owners))
+	for sid, entry := range r.daemon.owners {
+		entries = append(entries, reaperOwnerView{
+			sid:         sid,
+			entry:       entry,
+			owner:       entry.Owner,
+			persistent:  entry.Persistent,
+			idleTimeout: entry.IdleTimeout,
+			lastSession: entry.LastSession,
+		})
 	}
 	r.daemon.mu.RUnlock()
 
@@ -113,12 +136,12 @@ func (r *Reaper) sweep() int {
 	// reconnect history ages past its 30-minute refresh window.
 	totalPendingSwept := 0
 	totalBoundSwept := 0
-	for _, entry := range entries {
-		if entry.Owner == nil {
+	for _, view := range entries {
+		if view.owner == nil {
 			continue
 		}
-		totalPendingSwept += entry.Owner.SessionMgr().SweepExpiredPending()
-		totalBoundSwept += entry.Owner.SessionMgr().SweepExpiredBound()
+		totalPendingSwept += view.owner.SessionMgr().SweepExpiredPending()
+		totalBoundSwept += view.owner.SessionMgr().SweepExpiredBound()
 	}
 	if totalPendingSwept > 0 {
 		r.logger.Printf("reaper: swept %d expired pending tokens", totalPendingSwept)
@@ -127,11 +150,13 @@ func (r *Reaper) sweep() int {
 		r.logger.Printf("reaper: swept %d expired bound tokens", totalBoundSwept)
 	}
 
-	for i, entry := range entries {
-		sid := sids[i]
+	for _, view := range entries {
+		sid := view.sid
+		entry := view.entry
+		ownerRef := view.owner
 
 		// Skip placeholders — owner is still being created by Spawn.
-		if entry.Owner == nil {
+		if ownerRef == nil {
 			continue
 		}
 
@@ -139,40 +164,42 @@ func (r *Reaper) sweep() int {
 		// inside the owner-local controller; explicit teardown is completed by
 		// the removal path that owns it.
 		select {
-		case <-entry.Owner.Done():
+		case <-ownerRef.Done():
 			continue
 		default:
 		}
 
 		sample := evictionSample{
-			Sessions:               entry.Owner.SessionCount(),
-			PendingSessions:        entry.Owner.SessionMgr().PendingCount(),
-			Persistent:             entry.Persistent,
-			PendingRequests:        entry.Owner.PendingRequests(),
-			ActiveProgressTokens:   entry.Owner.ActiveProgressTokens(),
-			HasBusyWork:            entry.Owner.HasActiveBusyWork(),
-			UpstreamDead:           entry.Owner.UpstreamDead(),
-			CacheReady:             entry.Owner.CacheReady(),
-			MaterializationBlocked: entry.Owner.MaterializationBlocksEviction(),
-			IdleTimeout:            entry.IdleTimeout,
-			OwnerIdleOverride:      entry.Owner.IdleTimeout(),
-			LastSession:            entry.LastSession,
-			LastActivity:           entry.Owner.LastActivity(),
-			IsolatedClassified:     entry.Owner.IsClassifiedIsolated(),
+			Sessions:               ownerRef.SessionCount(),
+			PendingSessions:        ownerRef.SessionMgr().PendingCount(),
+			Persistent:             view.persistent,
+			PendingRequests:        ownerRef.PendingRequests(),
+			ActiveProgressTokens:   ownerRef.ActiveProgressTokens(),
+			HasBusyWork:            ownerRef.HasActiveBusyWork(),
+			UpstreamDead:           ownerRef.UpstreamDead(),
+			CacheReady:             ownerRef.CacheReady(),
+			MaterializationBlocked: ownerRef.MaterializationBlocksEviction(),
+			IdleTimeout:            view.idleTimeout,
+			OwnerIdleOverride:      ownerRef.IdleTimeout(),
+			LastSession:            view.lastSession,
+			LastActivity:           ownerRef.LastActivity(),
+			IsolatedClassified:     ownerRef.IsClassifiedIsolated(),
 		}
 		decision := shouldEvict(sample, now, r.daemon.ownerIdleTimeout, r.daemon.isolatedIdleTimeout)
 		if decision.evict {
-			var result ownerRemovalResult
+			reason := ownerRemovalReasonIdle
+			soft := true
 			if decision.reason == "zombie" {
+				reason = ownerRemovalReasonZombie
+				soft = false
 				r.logger.Printf("reaper: owner %s upstream dead with 0 sessions, removing", sid[:8])
-				result, _ = r.daemon.removeOwnerIfCurrent(sid, entry, ownerRemovalReasonZombie, false)
 			} else {
 				r.logger.Printf(
 					"reaper: owner %s %s for %.0fs (timeout %.0fs), soft-removing",
 					sid[:8], decision.reason, decision.elapsed.Seconds(), decision.idleTimeout.Seconds(),
 				)
-				result, _ = r.daemon.removeOwnerIfCurrent(sid, entry, ownerRemovalReasonIdle, true)
 			}
+			result, _ := r.daemon.finalizeAndRemoveOwner(sid, entry, reason, soft, view.matches, true)
 			if result.Removed {
 				affected++
 			}

--- a/muxcore/daemon/reaper_test.go
+++ b/muxcore/daemon/reaper_test.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"log"
 	"os"
+	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -154,6 +156,104 @@ func TestReaperRespectsConfigPersistent(t *testing.T) {
 	}
 	if logOutput := logs.String(); strings.Contains(logOutput, "soft-removing") || strings.Contains(logOutput, "upstream dead with 0 sessions, removing") {
 		t.Fatalf("reaper log indicates eviction for persistent owner: %s", logOutput)
+	}
+}
+
+func TestReaperSnapshotsMutableOwnerEntryMetadata(t *testing.T) {
+	d := testDaemon(t)
+	sid := "reaper-entry-snapshot"
+	o := testReconnectOwner(t, sid)
+	entry := &OwnerEntry{
+		Owner:       o,
+		ServerID:    sid,
+		Persistent:  true,
+		LastSession: time.Now(),
+		IdleTimeout: time.Hour,
+	}
+	d.mu.Lock()
+	d.owners[sid] = entry
+	d.mu.Unlock()
+
+	const iterations = 1000
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		<-start
+		for range iterations {
+			d.mu.Lock()
+			entry.Persistent = true
+			entry.LastSession = time.Now()
+			entry.IdleTimeout = time.Hour
+			d.mu.Unlock()
+			runtime.Gosched()
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		r := &Reaper{daemon: d, logger: d.logger}
+		for range iterations {
+			if affected := r.sweep(); affected != 0 {
+				t.Errorf("sweep() affected %d persistent owners, want 0", affected)
+			}
+			runtime.Gosched()
+		}
+	}()
+	close(start)
+	wg.Wait()
+
+	if got := d.Entry(sid); got != entry {
+		t.Fatal("concurrent metadata snapshots replaced the owner entry")
+	}
+}
+
+func TestReaperOwnerViewRejectsChangedEntryState(t *testing.T) {
+	ownerRef := testReconnectOwner(t, "reaper-view-current")
+	otherOwner := testReconnectOwner(t, "reaper-view-other")
+	lastSession := time.Now()
+	newView := func() (*OwnerEntry, reaperOwnerView) {
+		entry := &OwnerEntry{
+			Owner:       ownerRef,
+			ServerID:    "reaper-view-current",
+			LastSession: lastSession,
+			IdleTimeout: time.Minute,
+		}
+		return entry, reaperOwnerView{
+			entry:       entry,
+			owner:       ownerRef,
+			lastSession: lastSession,
+			idleTimeout: time.Minute,
+		}
+	}
+
+	entry, view := newView()
+	if !view.matches(entry) {
+		t.Fatal("unchanged owner entry did not match its reaper snapshot")
+	}
+	replacement := *entry
+	if view.matches(&replacement) {
+		t.Fatal("replacement entry matched stale reaper snapshot")
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*OwnerEntry)
+	}{
+		{name: "owner", mutate: func(entry *OwnerEntry) { entry.Owner = otherOwner }},
+		{name: "persistent", mutate: func(entry *OwnerEntry) { entry.Persistent = true }},
+		{name: "idle timeout", mutate: func(entry *OwnerEntry) { entry.IdleTimeout += time.Second }},
+		{name: "last session", mutate: func(entry *OwnerEntry) { entry.LastSession = entry.LastSession.Add(time.Second) }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			entry, view := newView()
+			test.mutate(entry)
+			if view.matches(entry) {
+				t.Fatal("changed owner entry matched stale reaper snapshot")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes the macOS `-race` failure exposed by docs-only PR #143 in `TestPendingPersistenceConcurrentReaperRetriesWithoutDemandAndDeniesSuspend`.

`Reaper.sweep` copied `*OwnerEntry` pointers under `Daemon.mu`, released the lock, then read mutable `Owner`, `Persistent`, `IdleTimeout`, and `LastSession` fields. `Daemon.onZeroSessions` correctly writes `LastSession` under the mutex, so the reaper read raced with session disconnect.

The fix:

- snapshots owner identity and reaper metadata by value under `Daemon.mu`;
- keeps owner-local method calls outside the daemon lock;
- revalidates entry identity, owner, persistence, timeout, and session timestamp under the lock before destructive eviction begins;
- preserves the irreversible retirement boundary: once `FinalizeForRemoval` tears down admission, scheduled retries keep retiring that exact generation through `FINALIZE_BLOCKED` until process-tree authority is proven;
- adds race and stale-snapshot regressions for both the reversible pre-removal gate and irreversible retry path.

## Review

Independent review found the pre-removal stale-metadata gap. A later reviewer conflict about post-teardown eligibility was resolved against ADR-013 and the `Owner.FinalizeForRemoval` state machine: metadata can cancel removal before teardown, but cannot revive a generation after admission is torn down. The local reviewer re-checked and agreed with that boundary.

## Verification

- `go test -race ./daemon -run TestReaperOwnerViewRejectsChangedEntryState -count=50`
- `go test -race ./daemon -run TestReaperSnapshotsMutableOwnerEntryMetadata -count=10`
- `go test -race ./daemon -run TestPendingPersistenceConcurrentReaperRetriesWithoutDemandAndDeniesSuspend -count=50`
- `go test -race ./daemon -run "Test(.*FinalizationRetry.*|ZeroSessionCleanup.*|ReaperOwnerView.*|ReaperSnapshots.*)$" -count=10`
- `go test -race ./daemon -run TestReaper -count=5`
- `go test -race ./daemon -count=1`
- `go test ./... -count=1` in `muxcore`
- `go test ./... -count=1` at repository root
- `go vet ./...` in both Go modules

Full daemon and muxcore suites were run serially because their tests intentionally share deterministic socket and snapshot namespaces.