### PR TITLE
refactor: centralize post-v0.29 lifecycle authority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Added `supervisor.StartWithFallback` for provider-generic requested/fallback
   start policy. It retries only after a clean start failure with no child or
   admission authority, returns retained authority for supervisor finalization,
-  cleans admission-only rollback-unproven state in place when possible, returns
-  it for supervisor finalization when cleanup fails, and reduces callback errors
-  to fixed classifications that keep product engine identities opaque.
+  treats admission-only rollback-unproven state as terminal even after cleanup,
+  and reduces callback errors to fixed classifications that keep product engine
+  identities opaque.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Added
+
+- Added `supervisor.StartWithFallback` for provider-generic requested/fallback
+  start policy. It retries only after a clean start failure with no child or
+  admission authority, returns partial or rollback-unproven authority for the
+  supervisor to finalize, and keeps product engine identities out of errors.
+
+### Changed
+
+- Owner-originated persistence, template-cache, zero-session, and upstream-exit
+  callbacks now mutate daemon registry state through one exact-generation
+  transaction. Stale owner generations remain no-ops, while process-generation
+  authority stays in `muxcore/owner`.
+
 ## [0.29.0] - 2026-07-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 - Added `supervisor.StartWithFallback` for provider-generic requested/fallback
   start policy. It retries only after a clean start failure with no child or
-  admission authority, returns partial or rollback-unproven authority for the
-  supervisor to finalize, and keeps product engine identities out of errors.
+  admission authority, returns retained authority for supervisor finalization,
+  cleans admission-only rollback-unproven state in place when possible, returns
+  it for supervisor finalization when cleanup fails, and reduces callback errors
+  to fixed classifications that keep product engine identities opaque.
 
 ### Changed
 

--- a/cmd/mcp-mux/launcher_supervisor.go
+++ b/cmd/mcp-mux/launcher_supervisor.go
@@ -212,10 +212,9 @@ func canonicalLauncherEnginePath(path string) string {
 	return path
 }
 
-func launcherSupervisorStartResult(child *supervisor.CommandChild, admission *attest.Parent, actualPath string, fallback bool) supervisor.StartResult {
+func launcherSupervisorStartResult(child *supervisor.CommandChild, admission *attest.Parent, actualPath string) supervisor.StartResult {
 	result := supervisor.StartResult{
-		Actual:   supervisor.EngineRef{ID: canonicalLauncherEnginePath(actualPath)},
-		Fallback: fallback,
+		Actual: supervisor.EngineRef{ID: canonicalLauncherEnginePath(actualPath)},
 	}
 	if child != nil {
 		result.Child = child
@@ -232,37 +231,16 @@ func startDefaultSupervisedEngineChild(
 	args []string,
 	stderr io.Writer,
 ) (supervisor.StartResult, error) {
-	child, admission, err := launcherSupervisorCommandStart(ctx, launcherPath, enginePath, args, stderr)
-	if err == nil {
-		return launcherSupervisorStartResult(child, admission, enginePath, false), nil
-	}
-	if errors.Is(err, supervisor.ErrStartRollbackUnproven) && child == nil {
-		if admission != nil {
-			err = errors.Join(err, admission.Close())
+	requested := supervisor.EngineRef{ID: canonicalLauncherEnginePath(enginePath)}
+	fallback := supervisor.EngineRef{ID: canonicalLauncherEnginePath(launcherPath)}
+	return supervisor.StartWithFallback(ctx, requested, fallback, func(ctx context.Context, ref supervisor.EngineRef) (supervisor.StartResult, error) {
+		executablePath := enginePath
+		if ref != requested {
+			executablePath = launcherPath
 		}
-		return supervisor.StartResult{}, err
-	}
-	if errors.Is(err, supervisor.ErrStartRollbackUnproven) || child != nil || admission != nil {
-		return launcherSupervisorStartResult(child, admission, enginePath, false), err
-	}
-
-	if samePath(enginePath, launcherPath) {
-		return supervisor.StartResult{}, errors.New("active engine start failed and no distinct fallback is available")
-	}
-	fallbackChild, fallbackAdmission, fallbackErr := launcherSupervisorCommandStart(ctx, launcherPath, launcherPath, args, stderr)
-	if fallbackErr != nil {
-		if errors.Is(fallbackErr, supervisor.ErrStartRollbackUnproven) && fallbackChild == nil {
-			if fallbackAdmission != nil {
-				fallbackErr = errors.Join(fallbackErr, fallbackAdmission.Close())
-			}
-			return supervisor.StartResult{}, fallbackErr
-		}
-		if errors.Is(fallbackErr, supervisor.ErrStartRollbackUnproven) || fallbackChild != nil || fallbackAdmission != nil {
-			return launcherSupervisorStartResult(fallbackChild, fallbackAdmission, launcherPath, true), fallbackErr
-		}
-		return supervisor.StartResult{}, errors.New("active engine and stable launcher fallback start failed")
-	}
-	return launcherSupervisorStartResult(fallbackChild, fallbackAdmission, launcherPath, true), nil
+		child, admission, err := launcherSupervisorCommandStart(ctx, launcherPath, executablePath, args, stderr)
+		return launcherSupervisorStartResult(child, admission, executablePath), err
+	})
 }
 
 func startAttestedSupervisorCommand(

--- a/cmd/mcp-mux/launcher_supervisor_test.go
+++ b/cmd/mcp-mux/launcher_supervisor_test.go
@@ -287,13 +287,21 @@ func TestDefaultSupervisorDoesNotFallbackAfterUnprovenRollback(t *testing.T) {
 	if calls != 1 {
 		t.Fatalf("start calls = %d, fallback started before rollback proof", calls)
 	}
-	if result.Child != nil || result.Admission != nil {
-		t.Fatalf("non-process admission masked unproven rollback = %#v", result)
+	if result.Child != nil || result.Admission != admission {
+		t.Fatalf("unproven rollback authority = %#v, want returned admission", result)
+	}
+	select {
+	case <-admission.Done():
+		t.Fatal("start helper consumed admission owned by supervisor finalization")
+	default:
+	}
+	if closeErr := result.Admission.Close(); closeErr != nil {
+		t.Fatal(closeErr)
 	}
 	select {
 	case <-admission.Done():
 	case <-time.After(time.Second):
-		t.Fatal("unproven rollback left admission open")
+		t.Fatal("returned admission did not close")
 	}
 }
 

--- a/muxcore/daemon/daemon.go
+++ b/muxcore/daemon/daemon.go
@@ -2688,13 +2688,9 @@ func (d *Daemon) setOwnerPersistent(expected *owner.Owner, persistent bool) bool
 		return false
 	}
 	serverID := expected.ServerID()
-	d.mu.Lock()
-	entry, ok := d.owners[serverID]
-	ok = ok && entry != nil && entry.Owner == expected
-	if ok {
+	ok := d.mutateCurrentOwnerEntry(expected, func(entry *OwnerEntry) {
 		entry.Persistent = persistent
-	}
-	d.mu.Unlock()
+	})
 	if ok {
 		d.logger.Printf("owner %s persistent=%v", shortServerID(serverID), persistent)
 	}
@@ -2716,21 +2712,21 @@ func (d *Daemon) publishOwnerCache(expected *owner.Owner, snap mcpsnapshot.Owner
 	if d.beforeOwnerCachePublish != nil {
 		d.beforeOwnerCachePublish(expected)
 	}
-	serverID := expected.ServerID()
-	d.mu.Lock()
-	entry, ok := d.owners[serverID]
-	if !ok || entry == nil || entry.Owner != expected {
-		d.mu.Unlock()
+	snap.Persistent = d.persistent || snap.Persistent
+	var command, key string
+	var revision uint64
+	var published bool
+	if !d.mutateCurrentOwnerEntry(expected, func(entry *OwnerEntry) {
+		command = entry.Command
+		key, revision, published = d.updateTemplateLocked(entry.Command, entry.Args, snap)
+		if published {
+			entry.Persistent = snap.Persistent
+		}
+	}) {
 		return false
 	}
-	snap.Persistent = d.persistent || snap.Persistent
-	key, revision, published := d.updateTemplateLocked(entry.Command, entry.Args, snap)
 	if published {
-		entry.Persistent = snap.Persistent
-	}
-	d.mu.Unlock()
-	if published {
-		d.logger.Printf("template cache updated for %s (key=%s revision=%d scope=%s)", entry.Command, key[:8], revision, snap.Classification)
+		d.logger.Printf("template cache updated for %s (key=%s revision=%d scope=%s)", command, key[:8], revision, snap.Classification)
 	}
 	return published
 }
@@ -2739,16 +2735,14 @@ func (d *Daemon) invalidateOwnerTemplate(expected *owner.Owner) {
 	if expected == nil {
 		return
 	}
-	serverID := expected.ServerID()
-	d.mu.Lock()
-	entry, ok := d.owners[serverID]
-	if !ok || entry == nil || entry.Owner != expected {
-		d.mu.Unlock()
+	var command, key string
+	var existed bool
+	if !d.mutateCurrentOwnerEntry(expected, func(entry *OwnerEntry) {
+		command = entry.Command
+		key, existed = d.invalidateTemplateLocked(entry.Command, entry.Args)
+	}) {
 		return
 	}
-	command := entry.Command
-	key, existed := d.invalidateTemplateLocked(command, entry.Args)
-	d.mu.Unlock()
 	if existed {
 		d.logger.Printf("template cache invalidated for %s (key=%s)", command, key[:8])
 	}
@@ -3229,14 +3223,11 @@ func (d *Daemon) onZeroSessions(expected *owner.Owner) {
 		delay = override
 	}
 	zeroAt := time.Now()
-	d.mu.Lock()
-	entry, ok := d.owners[serverID]
-	ok = ok && entry != nil && entry.Owner == expected
-	if ok {
+	var entry *OwnerEntry
+	if !d.mutateCurrentOwnerEntry(expected, func(current *OwnerEntry) {
+		entry = current
 		entry.LastSession = zeroAt
-	}
-	d.mu.Unlock()
-	if !ok {
+	}) {
 		return
 	}
 	d.logger.Printf("owner %s: zero sessions (cleanup delay %s)", shortServerID(serverID), delay)
@@ -3277,16 +3268,16 @@ func (d *Daemon) onUpstreamExit(expected *owner.Owner) {
 		return
 	}
 	serverID := expected.ServerID()
-	d.mu.Lock()
-	entry, ok := d.owners[serverID]
-	if !ok || entry == nil || entry.Owner != expected {
-		d.mu.Unlock()
+	var entry *OwnerEntry
+	var persistent bool
+	if !d.mutateCurrentOwnerEntry(expected, func(current *OwnerEntry) {
+		entry = current
+		cmdKey := entry.Command + " " + strings.Join(entry.Args, " ")
+		d.recordCrash(cmdKey)
+		persistent = entry.Persistent
+	}) {
 		return
 	}
-	cmdKey := entry.Command + " " + strings.Join(entry.Args, " ")
-	d.recordCrash(cmdKey)
-	persistent := entry.Persistent
-	d.mu.Unlock()
 	if persistent {
 		d.logger.Printf("owner %s: upstream exited; owner-local persistent recovery remains authoritative", shortServerID(serverID))
 		return

--- a/muxcore/daemon/owner_lifecycle.go
+++ b/muxcore/daemon/owner_lifecycle.go
@@ -59,6 +59,25 @@ func newOwnerRemovalStats() ownerRemovalStats {
 	return ownerRemovalStats{ByReason: make(map[ownerRemovalReason]uint64)}
 }
 
+// mutateCurrentOwnerEntry is the daemon-owned exact-generation registry seam.
+// It applies mutate only while expected is still the current owner generation
+// registered for its server ID. mutate runs with d.mu held and must not call
+// code that reacquires d.mu.
+func (d *Daemon) mutateCurrentOwnerEntry(expected *owner.Owner, mutate func(*OwnerEntry)) bool {
+	if expected == nil {
+		return false
+	}
+	serverID := expected.ServerID()
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	entry, ok := d.owners[serverID]
+	if !ok || entry == nil || entry.Owner != expected {
+		return false
+	}
+	mutate(entry)
+	return true
+}
+
 func (s ownerRemovalStats) statusMap() map[string]any {
 	byReason := make(map[string]uint64, len(s.ByReason))
 	for reason, count := range s.ByReason {

--- a/muxcore/supervisor/api_external_test.go
+++ b/muxcore/supervisor/api_external_test.go
@@ -66,6 +66,8 @@ func TestPublicContractCompilesExternally(t *testing.T) {
 	_ = run
 	var startCommand func(context.Context, supervisor.Command) (*supervisor.CommandChild, error) = supervisor.StartCommand
 	_ = startCommand
+	var startWithFallback func(context.Context, supervisor.EngineRef, supervisor.EngineRef, supervisor.StartFunc) (supervisor.StartResult, error) = supervisor.StartWithFallback
+	_ = startWithFallback
 	_ = supervisor.Command{
 		Path:   "engine",
 		Args:   []string{"serve"},

--- a/muxcore/supervisor/command.go
+++ b/muxcore/supervisor/command.go
@@ -18,7 +18,8 @@ const defaultCommandGracefulTimeout = time.Second
 var (
 	// ErrStartRollbackUnproven reports that a failed StartFunc attempt may still
 	// own a child process, process tree, or admission endpoint. Run treats this
-	// as terminal unless the callback returns that authority for another cleanup.
+	// as terminal unless returned Child authority proves full tree retirement;
+	// admission authority is closed but is not process-retirement proof.
 	ErrStartRollbackUnproven = errors.New("supervisor: failed start rollback unproven")
 
 	// ErrProcessTreeUnproven reports that a command leader terminated without a

--- a/muxcore/supervisor/fallback.go
+++ b/muxcore/supervisor/fallback.go
@@ -17,8 +17,8 @@ var (
 // Engine identities remain opaque and are never included in returned errors.
 // Failed attempts that retain authority are returned immediately with a fixed
 // classification so Run can finalize the exact authority before any later
-// generation starts. Admission-only rollback-unproven state is cleaned here;
-// failed cleanup returns that admission authority for Run to finalize.
+// generation starts. Rollback-unproven state remains fail-closed; admission
+// authority is returned for Run to close but cannot prove process retirement.
 func StartWithFallback(ctx context.Context, requested, fallback EngineRef, start StartFunc) (StartResult, error) {
 	if start == nil {
 		return StartResult{}, errNilFallbackStarter
@@ -49,15 +49,6 @@ func StartWithFallback(ctx context.Context, requested, fallback EngineRef, start
 
 func retainFailedStart(result StartResult, err error) (StartResult, error, bool) {
 	rollbackUnproven := errors.Is(err, ErrStartRollbackUnproven)
-	if rollbackUnproven && isNilInterface(result.Child) {
-		if isNilInterface(result.Admission) {
-			return StartResult{}, ErrStartRollbackUnproven, true
-		}
-		if closeErr := result.Admission.Close(); closeErr == nil {
-			return StartResult{}, ErrStartRollbackUnproven, true
-		}
-		return result, errors.Join(errRetainedStart, ErrStartRollbackUnproven), true
-	}
 	if rollbackUnproven || startResultHasAuthority(result) {
 		retainedErr := errRetainedStart
 		if rollbackUnproven {

--- a/muxcore/supervisor/fallback.go
+++ b/muxcore/supervisor/fallback.go
@@ -9,13 +9,16 @@ var (
 	errNilFallbackStarter = errors.New("supervisor: nil fallback starter")
 	errNoDistinctFallback = errors.New("supervisor: requested child start failed and no distinct fallback is available")
 	errFallbackStart      = errors.New("supervisor: requested child and fallback start failed")
+	errRetainedStart      = errors.New("supervisor: child start failed with retained authority")
 )
 
 // StartWithFallback starts requested first, then fallback only after a clean
 // requested-start failure that returned no child or admission authority.
 // Engine identities remain opaque and are never included in returned errors.
-// A partial or rollback-unproven start is returned immediately so Run can
-// finalize the exact authority before any later generation starts.
+// Failed attempts that retain authority are returned immediately with a fixed
+// classification so Run can finalize the exact authority before any later
+// generation starts. Admission-only rollback-unproven state is cleaned here;
+// failed cleanup returns that admission authority for Run to finalize.
 func StartWithFallback(ctx context.Context, requested, fallback EngineRef, start StartFunc) (StartResult, error) {
 	if start == nil {
 		return StartResult{}, errNilFallbackStarter
@@ -45,14 +48,22 @@ func StartWithFallback(ctx context.Context, requested, fallback EngineRef, start
 }
 
 func retainFailedStart(result StartResult, err error) (StartResult, error, bool) {
-	if errors.Is(err, ErrStartRollbackUnproven) && isNilInterface(result.Child) {
-		if !isNilInterface(result.Admission) {
-			err = errors.Join(err, result.Admission.Close())
+	rollbackUnproven := errors.Is(err, ErrStartRollbackUnproven)
+	if rollbackUnproven && isNilInterface(result.Child) {
+		if isNilInterface(result.Admission) {
+			return StartResult{}, ErrStartRollbackUnproven, true
 		}
-		return StartResult{}, err, true
+		if closeErr := result.Admission.Close(); closeErr == nil {
+			return StartResult{}, ErrStartRollbackUnproven, true
+		}
+		return result, errors.Join(errRetainedStart, ErrStartRollbackUnproven), true
 	}
-	if errors.Is(err, ErrStartRollbackUnproven) || startResultHasAuthority(result) {
-		return result, err, true
+	if rollbackUnproven || startResultHasAuthority(result) {
+		retainedErr := errRetainedStart
+		if rollbackUnproven {
+			retainedErr = errors.Join(retainedErr, ErrStartRollbackUnproven)
+		}
+		return result, retainedErr, true
 	}
 	return StartResult{}, nil, false
 }

--- a/muxcore/supervisor/fallback.go
+++ b/muxcore/supervisor/fallback.go
@@ -32,6 +32,9 @@ func StartWithFallback(ctx context.Context, requested, fallback EngineRef, start
 	if retained, retainedErr, terminal := retainFailedStart(result, err); terminal {
 		return retained, retainedErr
 	}
+	if err := ctx.Err(); err != nil {
+		return StartResult{}, err
+	}
 	if requested == fallback {
 		return StartResult{}, errNoDistinctFallback
 	}

--- a/muxcore/supervisor/fallback.go
+++ b/muxcore/supervisor/fallback.go
@@ -47,6 +47,9 @@ func StartWithFallback(ctx context.Context, requested, fallback EngineRef, start
 	if retained, retainedErr, terminal := retainFailedStart(result, err); terminal {
 		return retained, retainedErr
 	}
+	if err := ctx.Err(); err != nil {
+		return StartResult{}, err
+	}
 	return StartResult{}, errFallbackStart
 }
 

--- a/muxcore/supervisor/fallback.go
+++ b/muxcore/supervisor/fallback.go
@@ -1,0 +1,58 @@
+package supervisor
+
+import (
+	"context"
+	"errors"
+)
+
+var (
+	errNilFallbackStarter = errors.New("supervisor: nil fallback starter")
+	errNoDistinctFallback = errors.New("supervisor: requested child start failed and no distinct fallback is available")
+	errFallbackStart      = errors.New("supervisor: requested child and fallback start failed")
+)
+
+// StartWithFallback starts requested first, then fallback only after a clean
+// requested-start failure that returned no child or admission authority.
+// Engine identities remain opaque and are never included in returned errors.
+// A partial or rollback-unproven start is returned immediately so Run can
+// finalize the exact authority before any later generation starts.
+func StartWithFallback(ctx context.Context, requested, fallback EngineRef, start StartFunc) (StartResult, error) {
+	if start == nil {
+		return StartResult{}, errNilFallbackStarter
+	}
+
+	result, err := start(ctx, requested)
+	result.Fallback = false
+	if err == nil {
+		return result, nil
+	}
+	if retained, retainedErr, terminal := retainFailedStart(result, err); terminal {
+		return retained, retainedErr
+	}
+	if requested == fallback {
+		return StartResult{}, errNoDistinctFallback
+	}
+
+	result, err = start(ctx, fallback)
+	result.Fallback = true
+	if err == nil {
+		return result, nil
+	}
+	if retained, retainedErr, terminal := retainFailedStart(result, err); terminal {
+		return retained, retainedErr
+	}
+	return StartResult{}, errFallbackStart
+}
+
+func retainFailedStart(result StartResult, err error) (StartResult, error, bool) {
+	if errors.Is(err, ErrStartRollbackUnproven) && isNilInterface(result.Child) {
+		if !isNilInterface(result.Admission) {
+			err = errors.Join(err, result.Admission.Close())
+		}
+		return StartResult{}, err, true
+	}
+	if errors.Is(err, ErrStartRollbackUnproven) || startResultHasAuthority(result) {
+		return result, err, true
+	}
+	return StartResult{}, nil, false
+}

--- a/muxcore/supervisor/fallback.go
+++ b/muxcore/supervisor/fallback.go
@@ -30,6 +30,9 @@ func StartWithFallback(ctx context.Context, requested, fallback EngineRef, start
 		return result, nil
 	}
 	if retained, retainedErr, terminal := retainFailedStart(result, err); terminal {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			retainedErr = errors.Join(retainedErr, ctxErr)
+		}
 		return retained, retainedErr
 	}
 	if err := ctx.Err(); err != nil {
@@ -45,6 +48,9 @@ func StartWithFallback(ctx context.Context, requested, fallback EngineRef, start
 		return result, nil
 	}
 	if retained, retainedErr, terminal := retainFailedStart(result, err); terminal {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			retainedErr = errors.Join(retainedErr, ctxErr)
+		}
 		return retained, retainedErr
 	}
 	if err := ctx.Err(); err != nil {

--- a/muxcore/supervisor/fallback_test.go
+++ b/muxcore/supervisor/fallback_test.go
@@ -42,6 +42,35 @@ func TestStartWithFallbackUsesFallbackAfterCleanFailure(t *testing.T) {
 	}
 }
 
+func TestStartWithFallbackDoesNotStartFallbackAfterContextCancellation(t *testing.T) {
+	const requestedID = "secret-requested-engine"
+	requested := EngineRef{ID: requestedID}
+	fallback := EngineRef{ID: "fallback-engine"}
+	ctx, cancel := context.WithCancel(context.Background())
+	calls := 0
+
+	result, err := StartWithFallback(ctx, requested, fallback, func(_ context.Context, ref EngineRef) (StartResult, error) {
+		calls++
+		if ref == requested {
+			cancel()
+			return StartResult{}, errors.New("requested failure exposed " + requestedID)
+		}
+		return StartResult{Actual: ref}, nil
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("StartWithFallback() error = %v, want context cancellation", err)
+	}
+	if strings.Contains(err.Error(), requestedID) {
+		t.Fatalf("StartWithFallback() error leaked requested identity: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("start calls = %d, want requested attempt only", calls)
+	}
+	if startResultHasAuthority(result) {
+		t.Fatalf("result = %#v, want no authority", result)
+	}
+}
+
 func TestStartWithFallbackReturnsAdmissionWithoutRetryForUnprovenRollback(t *testing.T) {
 	const requestedID = "secret-requested-engine"
 	const fallbackID = "secret-fallback-engine"

--- a/muxcore/supervisor/fallback_test.go
+++ b/muxcore/supervisor/fallback_test.go
@@ -71,6 +71,35 @@ func TestStartWithFallbackDoesNotStartFallbackAfterContextCancellation(t *testin
 	}
 }
 
+func TestStartWithFallbackPreservesCancellationFromFallbackAttempt(t *testing.T) {
+	const fallbackID = "secret-fallback-engine"
+	requested := EngineRef{ID: "requested-engine"}
+	fallback := EngineRef{ID: fallbackID}
+	ctx, cancel := context.WithCancel(context.Background())
+	calls := 0
+
+	result, err := StartWithFallback(ctx, requested, fallback, func(_ context.Context, ref EngineRef) (StartResult, error) {
+		calls++
+		if ref == requested {
+			return StartResult{}, errors.New("requested start failed")
+		}
+		cancel()
+		return StartResult{}, errors.New("fallback failure exposed " + fallbackID)
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("StartWithFallback() error = %v, want context cancellation", err)
+	}
+	if strings.Contains(err.Error(), fallbackID) {
+		t.Fatalf("StartWithFallback() error leaked fallback identity: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("start calls = %d, want requested then fallback", calls)
+	}
+	if startResultHasAuthority(result) {
+		t.Fatalf("result = %#v, want no authority", result)
+	}
+}
+
 func TestStartWithFallbackReturnsAdmissionWithoutRetryForUnprovenRollback(t *testing.T) {
 	const requestedID = "secret-requested-engine"
 	const fallbackID = "secret-fallback-engine"

--- a/muxcore/supervisor/fallback_test.go
+++ b/muxcore/supervisor/fallback_test.go
@@ -8,14 +8,15 @@ import (
 )
 
 type fallbackTestAdmission struct {
-	closed int
+	closed   int
+	closeErr error
 }
 
 func (*fallbackTestAdmission) Verified() bool { return false }
 
 func (admission *fallbackTestAdmission) Close() error {
 	admission.closed++
-	return nil
+	return admission.closeErr
 }
 
 func TestStartWithFallbackUsesFallbackAfterCleanFailure(t *testing.T) {
@@ -42,20 +43,28 @@ func TestStartWithFallbackUsesFallbackAfterCleanFailure(t *testing.T) {
 }
 
 func TestStartWithFallbackDoesNotRetryUnprovenRollback(t *testing.T) {
+	const requestedID = "secret-requested-engine"
+	const fallbackID = "secret-fallback-engine"
 	admission := new(fallbackTestAdmission)
 	calls := 0
 
 	result, err := StartWithFallback(
 		context.Background(),
-		EngineRef{ID: "engine-a"},
-		EngineRef{ID: "stable-launcher"},
+		EngineRef{ID: requestedID},
+		EngineRef{ID: fallbackID},
 		func(context.Context, EngineRef) (StartResult, error) {
 			calls++
-			return StartResult{Admission: admission}, ErrStartRollbackUnproven
+			return StartResult{Admission: admission}, errors.Join(
+				ErrStartRollbackUnproven,
+				errors.New("rollback exposed "+requestedID+" "+fallbackID),
+			)
 		},
 	)
 	if !errors.Is(err, ErrStartRollbackUnproven) {
 		t.Fatalf("StartWithFallback() error = %v, want ErrStartRollbackUnproven", err)
+	}
+	if strings.Contains(err.Error(), requestedID) || strings.Contains(err.Error(), fallbackID) {
+		t.Fatalf("StartWithFallback() error leaked identities: %v", err)
 	}
 	if calls != 1 {
 		t.Fatalf("start calls = %d, want 1", calls)
@@ -68,21 +77,61 @@ func TestStartWithFallbackDoesNotRetryUnprovenRollback(t *testing.T) {
 	}
 }
 
+func TestStartWithFallbackReturnsAdmissionWhenRollbackCleanupFails(t *testing.T) {
+	const requestedID = "secret-requested-engine"
+	const fallbackID = "secret-fallback-engine"
+	admission := &fallbackTestAdmission{closeErr: errors.New("close exposed " + requestedID + " " + fallbackID)}
+	calls := 0
+
+	result, err := StartWithFallback(
+		context.Background(),
+		EngineRef{ID: requestedID},
+		EngineRef{ID: fallbackID},
+		func(context.Context, EngineRef) (StartResult, error) {
+			calls++
+			return StartResult{Admission: admission}, errors.Join(
+				ErrStartRollbackUnproven,
+				errors.New("rollback exposed "+requestedID+" "+fallbackID),
+			)
+		},
+	)
+	if !errors.Is(err, ErrStartRollbackUnproven) {
+		t.Fatalf("StartWithFallback() error = %v, want ErrStartRollbackUnproven", err)
+	}
+	if strings.Contains(err.Error(), requestedID) || strings.Contains(err.Error(), fallbackID) {
+		t.Fatalf("StartWithFallback() error leaked identities: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("start calls = %d, want 1", calls)
+	}
+	if result.Admission != admission || result.Fallback {
+		t.Fatalf("result = %#v, want requested admission authority", result)
+	}
+	if admission.closed != 1 {
+		t.Fatalf("admission Close calls = %d, want 1", admission.closed)
+	}
+}
+
 func TestStartWithFallbackReturnsPartialAuthorityWithoutRetry(t *testing.T) {
+	const requestedID = "secret-requested-engine"
+	const fallbackID = "secret-fallback-engine"
 	admission := new(fallbackTestAdmission)
 	calls := 0
 
 	result, err := StartWithFallback(
 		context.Background(),
-		EngineRef{ID: "engine-a"},
-		EngineRef{ID: "stable-launcher"},
+		EngineRef{ID: requestedID},
+		EngineRef{ID: fallbackID},
 		func(context.Context, EngineRef) (StartResult, error) {
 			calls++
-			return StartResult{Admission: admission}, errors.New("partial start")
+			return StartResult{Admission: admission}, errors.New("partial start " + requestedID + " " + fallbackID)
 		},
 	)
 	if err == nil {
 		t.Fatal("StartWithFallback() error = nil, want partial-start error")
+	}
+	if strings.Contains(err.Error(), requestedID) || strings.Contains(err.Error(), fallbackID) {
+		t.Fatalf("StartWithFallback() error leaked identities: %v", err)
 	}
 	if calls != 1 {
 		t.Fatalf("start calls = %d, want 1", calls)
@@ -92,6 +141,35 @@ func TestStartWithFallbackReturnsPartialAuthorityWithoutRetry(t *testing.T) {
 	}
 	if admission.closed != 0 {
 		t.Fatalf("admission Close calls = %d, want supervisor finalization to own cleanup", admission.closed)
+	}
+}
+
+func TestStartWithFallbackRedactsFallbackPartialAuthority(t *testing.T) {
+	const requestedID = "secret-requested-engine"
+	const fallbackID = "secret-fallback-engine"
+	requested := EngineRef{ID: requestedID}
+	fallback := EngineRef{ID: fallbackID}
+	admission := new(fallbackTestAdmission)
+	calls := 0
+
+	result, err := StartWithFallback(context.Background(), requested, fallback, func(_ context.Context, ref EngineRef) (StartResult, error) {
+		calls++
+		if ref == requested {
+			return StartResult{}, errors.New("requested failure exposed " + requestedID)
+		}
+		return StartResult{Admission: admission}, errors.New("fallback failure exposed " + fallbackID)
+	})
+	if err == nil {
+		t.Fatal("StartWithFallback() error = nil, want fallback partial-start error")
+	}
+	if strings.Contains(err.Error(), requestedID) || strings.Contains(err.Error(), fallbackID) {
+		t.Fatalf("StartWithFallback() error leaked identities: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("start calls = %d, want 2", calls)
+	}
+	if result.Admission != admission || !result.Fallback {
+		t.Fatalf("result = %#v, want fallback partial authority", result)
 	}
 }
 
@@ -121,8 +199,8 @@ func TestStartWithFallbackRedactsFailedIdentities(t *testing.T) {
 		context.Background(),
 		EngineRef{ID: requestedID},
 		EngineRef{ID: fallbackID},
-		func(context.Context, EngineRef) (StartResult, error) {
-			return StartResult{}, errors.New("start failed")
+		func(_ context.Context, ref EngineRef) (StartResult, error) {
+			return StartResult{}, errors.New("start failed for " + ref.ID)
 		},
 	)
 	if err == nil {

--- a/muxcore/supervisor/fallback_test.go
+++ b/muxcore/supervisor/fallback_test.go
@@ -42,42 +42,7 @@ func TestStartWithFallbackUsesFallbackAfterCleanFailure(t *testing.T) {
 	}
 }
 
-func TestStartWithFallbackDoesNotRetryUnprovenRollback(t *testing.T) {
-	const requestedID = "secret-requested-engine"
-	const fallbackID = "secret-fallback-engine"
-	admission := new(fallbackTestAdmission)
-	calls := 0
-
-	result, err := StartWithFallback(
-		context.Background(),
-		EngineRef{ID: requestedID},
-		EngineRef{ID: fallbackID},
-		func(context.Context, EngineRef) (StartResult, error) {
-			calls++
-			return StartResult{Admission: admission}, errors.Join(
-				ErrStartRollbackUnproven,
-				errors.New("rollback exposed "+requestedID+" "+fallbackID),
-			)
-		},
-	)
-	if !errors.Is(err, ErrStartRollbackUnproven) {
-		t.Fatalf("StartWithFallback() error = %v, want ErrStartRollbackUnproven", err)
-	}
-	if strings.Contains(err.Error(), requestedID) || strings.Contains(err.Error(), fallbackID) {
-		t.Fatalf("StartWithFallback() error leaked identities: %v", err)
-	}
-	if calls != 1 {
-		t.Fatalf("start calls = %d, want 1", calls)
-	}
-	if result.Child != nil || result.Admission != nil {
-		t.Fatalf("result = %#v, want no returned authority after admission cleanup", result)
-	}
-	if admission.closed != 1 {
-		t.Fatalf("admission Close calls = %d, want 1", admission.closed)
-	}
-}
-
-func TestStartWithFallbackReturnsAdmissionWhenRollbackCleanupFails(t *testing.T) {
+func TestStartWithFallbackReturnsAdmissionWithoutRetryForUnprovenRollback(t *testing.T) {
 	const requestedID = "secret-requested-engine"
 	const fallbackID = "secret-fallback-engine"
 	admission := &fallbackTestAdmission{closeErr: errors.New("close exposed " + requestedID + " " + fallbackID)}
@@ -107,8 +72,8 @@ func TestStartWithFallbackReturnsAdmissionWhenRollbackCleanupFails(t *testing.T)
 	if result.Admission != admission || result.Fallback {
 		t.Fatalf("result = %#v, want requested admission authority", result)
 	}
-	if admission.closed != 1 {
-		t.Fatalf("admission Close calls = %d, want 1", admission.closed)
+	if admission.closed != 0 {
+		t.Fatalf("admission Close calls = %d, want supervisor finalization to own cleanup", admission.closed)
 	}
 }
 

--- a/muxcore/supervisor/fallback_test.go
+++ b/muxcore/supervisor/fallback_test.go
@@ -100,6 +100,51 @@ func TestStartWithFallbackPreservesCancellationFromFallbackAttempt(t *testing.T)
 	}
 }
 
+func TestStartWithFallbackPreservesCancellationWithRetainedAuthority(t *testing.T) {
+	requested := EngineRef{ID: "secret-requested-engine"}
+	fallback := EngineRef{ID: "secret-fallback-engine"}
+	tests := []struct {
+		name         string
+		cancelOn     EngineRef
+		wantCalls    int
+		wantFallback bool
+	}{
+		{name: "requested", cancelOn: requested, wantCalls: 1},
+		{name: "fallback", cancelOn: fallback, wantCalls: 2, wantFallback: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			admission := new(fallbackTestAdmission)
+			calls := 0
+
+			result, err := StartWithFallback(ctx, requested, fallback, func(_ context.Context, ref EngineRef) (StartResult, error) {
+				calls++
+				if ref != test.cancelOn {
+					return StartResult{}, errors.New("clean start failure")
+				}
+				cancel()
+				return StartResult{Admission: admission}, errors.New("retained failure exposed " + ref.ID)
+			})
+			if !errors.Is(err, context.Canceled) {
+				t.Fatalf("StartWithFallback() error = %v, want context cancellation", err)
+			}
+			if strings.Contains(err.Error(), requested.ID) || strings.Contains(err.Error(), fallback.ID) {
+				t.Fatalf("StartWithFallback() error leaked engine identity: %v", err)
+			}
+			if calls != test.wantCalls {
+				t.Fatalf("start calls = %d, want %d", calls, test.wantCalls)
+			}
+			if result.Admission != admission || result.Fallback != test.wantFallback {
+				t.Fatalf("result = %#v, want retained admission fallback=%v", result, test.wantFallback)
+			}
+			if admission.closed != 0 {
+				t.Fatalf("admission Close calls = %d, want supervisor finalization", admission.closed)
+			}
+		})
+	}
+}
+
 func TestStartWithFallbackReturnsAdmissionWithoutRetryForUnprovenRollback(t *testing.T) {
 	const requestedID = "secret-requested-engine"
 	const fallbackID = "secret-fallback-engine"

--- a/muxcore/supervisor/fallback_test.go
+++ b/muxcore/supervisor/fallback_test.go
@@ -1,0 +1,140 @@
+package supervisor
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+type fallbackTestAdmission struct {
+	closed int
+}
+
+func (*fallbackTestAdmission) Verified() bool { return false }
+
+func (admission *fallbackTestAdmission) Close() error {
+	admission.closed++
+	return nil
+}
+
+func TestStartWithFallbackUsesFallbackAfterCleanFailure(t *testing.T) {
+	requested := EngineRef{ID: "engine-a"}
+	fallback := EngineRef{ID: "stable-launcher"}
+	var calls []EngineRef
+
+	result, err := StartWithFallback(context.Background(), requested, fallback, func(_ context.Context, ref EngineRef) (StartResult, error) {
+		calls = append(calls, ref)
+		if ref == requested {
+			return StartResult{}, errors.New("requested start failed")
+		}
+		return StartResult{Actual: ref}, nil
+	})
+	if err != nil {
+		t.Fatalf("StartWithFallback() error = %v", err)
+	}
+	if len(calls) != 2 || calls[0] != requested || calls[1] != fallback {
+		t.Fatalf("start calls = %#v, want requested then fallback", calls)
+	}
+	if result.Actual != fallback || !result.Fallback {
+		t.Fatalf("result = %#v, want successful fallback", result)
+	}
+}
+
+func TestStartWithFallbackDoesNotRetryUnprovenRollback(t *testing.T) {
+	admission := new(fallbackTestAdmission)
+	calls := 0
+
+	result, err := StartWithFallback(
+		context.Background(),
+		EngineRef{ID: "engine-a"},
+		EngineRef{ID: "stable-launcher"},
+		func(context.Context, EngineRef) (StartResult, error) {
+			calls++
+			return StartResult{Admission: admission}, ErrStartRollbackUnproven
+		},
+	)
+	if !errors.Is(err, ErrStartRollbackUnproven) {
+		t.Fatalf("StartWithFallback() error = %v, want ErrStartRollbackUnproven", err)
+	}
+	if calls != 1 {
+		t.Fatalf("start calls = %d, want 1", calls)
+	}
+	if result.Child != nil || result.Admission != nil {
+		t.Fatalf("result = %#v, want no returned authority after admission cleanup", result)
+	}
+	if admission.closed != 1 {
+		t.Fatalf("admission Close calls = %d, want 1", admission.closed)
+	}
+}
+
+func TestStartWithFallbackReturnsPartialAuthorityWithoutRetry(t *testing.T) {
+	admission := new(fallbackTestAdmission)
+	calls := 0
+
+	result, err := StartWithFallback(
+		context.Background(),
+		EngineRef{ID: "engine-a"},
+		EngineRef{ID: "stable-launcher"},
+		func(context.Context, EngineRef) (StartResult, error) {
+			calls++
+			return StartResult{Admission: admission}, errors.New("partial start")
+		},
+	)
+	if err == nil {
+		t.Fatal("StartWithFallback() error = nil, want partial-start error")
+	}
+	if calls != 1 {
+		t.Fatalf("start calls = %d, want 1", calls)
+	}
+	if result.Admission != admission || result.Fallback {
+		t.Fatalf("result = %#v, want requested partial authority", result)
+	}
+	if admission.closed != 0 {
+		t.Fatalf("admission Close calls = %d, want supervisor finalization to own cleanup", admission.closed)
+	}
+}
+
+func TestStartWithFallbackRejectsSameIdentity(t *testing.T) {
+	calls := 0
+	_, err := StartWithFallback(
+		context.Background(),
+		EngineRef{ID: "same"},
+		EngineRef{ID: "same"},
+		func(context.Context, EngineRef) (StartResult, error) {
+			calls++
+			return StartResult{}, errors.New("start failed")
+		},
+	)
+	if err == nil {
+		t.Fatal("StartWithFallback() error = nil, want no-distinct-fallback error")
+	}
+	if calls != 1 {
+		t.Fatalf("start calls = %d, want 1", calls)
+	}
+}
+
+func TestStartWithFallbackRedactsFailedIdentities(t *testing.T) {
+	const requestedID = "secret-requested-engine"
+	const fallbackID = "secret-fallback-engine"
+	_, err := StartWithFallback(
+		context.Background(),
+		EngineRef{ID: requestedID},
+		EngineRef{ID: fallbackID},
+		func(context.Context, EngineRef) (StartResult, error) {
+			return StartResult{}, errors.New("start failed")
+		},
+	)
+	if err == nil {
+		t.Fatal("StartWithFallback() error = nil, want fallback failure")
+	}
+	if strings.Contains(err.Error(), requestedID) || strings.Contains(err.Error(), fallbackID) {
+		t.Fatalf("StartWithFallback() error leaked identities: %v", err)
+	}
+}
+
+func TestStartWithFallbackRejectsNilStarter(t *testing.T) {
+	if _, err := StartWithFallback(context.Background(), EngineRef{}, EngineRef{}, nil); err == nil {
+		t.Fatal("StartWithFallback() error = nil, want nil starter error")
+	}
+}

--- a/muxcore/supervisor/run.go
+++ b/muxcore/supervisor/run.go
@@ -279,14 +279,14 @@ func (runner *runner) handleStartAttempt(event startAttemptEvent) {
 	}
 	runner.starting = false
 	if event.err != nil {
-		hadAuthority := startResultHasAuthority(event.result)
-		if hadAuthority {
+		hadChildAuthority := !isNilInterface(event.result.Child)
+		if startResultHasAuthority(event.result) {
 			if cleanupErr := runner.cleanupInvalidStart(event.result); cleanupErr != nil {
 				runner.terminate(ReasonProtocolFailure, errors.Join(event.err, cleanupErr))
 				return
 			}
 		}
-		if errors.Is(event.err, ErrStartRollbackUnproven) && !hadAuthority {
+		if errors.Is(event.err, ErrStartRollbackUnproven) && !hadChildAuthority {
 			runner.terminate(ReasonProtocolFailure, event.err)
 			return
 		}

--- a/muxcore/supervisor/run_test.go
+++ b/muxcore/supervisor/run_test.go
@@ -28,6 +28,34 @@ func (admission *testAdmission) Close() error {
 	return nil
 }
 
+type scriptedTestAdmission struct {
+	mu        sync.Mutex
+	closeErrs []error
+	closed    int
+}
+
+func (*scriptedTestAdmission) Verified() bool { return false }
+
+func (admission *scriptedTestAdmission) Close() error {
+	admission.mu.Lock()
+	defer admission.mu.Unlock()
+	call := admission.closed
+	admission.closed++
+	if len(admission.closeErrs) == 0 {
+		return nil
+	}
+	if call >= len(admission.closeErrs) {
+		return admission.closeErrs[len(admission.closeErrs)-1]
+	}
+	return admission.closeErrs[call]
+}
+
+func (admission *scriptedTestAdmission) closeCalls() int {
+	admission.mu.Lock()
+	defer admission.mu.Unlock()
+	return admission.closed
+}
+
 type testChild struct {
 	stdinWriter  *io.PipeWriter
 	inputReader  *io.PipeReader
@@ -2027,6 +2055,67 @@ func TestRunUnprovenStartRollbackTerminatesWithoutRetry(t *testing.T) {
 	}
 	if starts != 1 {
 		t.Fatalf("start attempts = %d, want one fail-closed attempt", starts)
+	}
+}
+
+func TestRunStartWithFallbackAdmissionOnlyRollbackUnprovenTerminates(t *testing.T) {
+	tests := []struct {
+		name      string
+		closeErrs []error
+		wantError string
+	}{
+		{name: "cleanup succeeds"},
+		{
+			name:      "cleanup fails then would succeed",
+			closeErrs: []error{errors.New("transient admission cleanup failure"), nil},
+			wantError: "transient admission cleanup failure",
+		},
+		{
+			name:      "cleanup remains failed",
+			closeErrs: []error{errors.New("persistent admission cleanup failure")},
+			wantError: "persistent admission cleanup failure",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			requested := EngineRef{ID: "requested-engine"}
+			fallback := EngineRef{ID: "fallback-engine"}
+			admission := &scriptedTestAdmission{closeErrs: test.closeErrs}
+			startCalls := 0
+			fallbackCalls := 0
+			harness := startHarness(t, Config{
+				Resolve: func(context.Context) (EngineRef, error) { return requested, nil },
+				Start: func(ctx context.Context, ref EngineRef) (StartResult, error) {
+					return StartWithFallback(ctx, ref, fallback, func(_ context.Context, candidate EngineRef) (StartResult, error) {
+						startCalls++
+						if candidate == fallback {
+							fallbackCalls++
+						}
+						return StartResult{Admission: admission}, ErrStartRollbackUnproven
+					})
+				},
+				RetryDelay: 5 * time.Millisecond,
+			})
+			defer harness.hostInput.Close()
+
+			select {
+			case err := <-harness.done:
+				if !errors.Is(err, ErrStartRollbackUnproven) {
+					t.Fatalf("Run error = %v, want rollback-unproven sentinel", err)
+				}
+				if test.wantError != "" && !strings.Contains(err.Error(), test.wantError) {
+					t.Fatalf("Run error = %v, want %q", err, test.wantError)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("Run retried after admission-only rollback remained unproven")
+			}
+			if startCalls != 1 || fallbackCalls != 0 {
+				t.Fatalf("start calls = %d, fallback calls = %d; want one requested attempt", startCalls, fallbackCalls)
+			}
+			if calls := admission.closeCalls(); calls != 1 {
+				t.Fatalf("admission Close calls = %d, want one supervisor cleanup attempt", calls)
+			}
+		})
 	}
 }
 

--- a/muxcore/supervisor/supervisor.go
+++ b/muxcore/supervisor/supervisor.go
@@ -54,7 +54,9 @@ type ControlAdmission interface {
 }
 
 // StartResult identifies the child that actually started. Actual may differ
-// from the requested engine when the product approved a fallback.
+// from the requested engine when the product approved a fallback. On error,
+// non-nil Child or Admission fields transfer exact cleanup authority to Run;
+// they are never published as a live generation.
 type StartResult struct {
 	Child     Child
 	Actual    EngineRef
@@ -66,8 +68,10 @@ type StartResult struct {
 type ResolveFunc func(context.Context) (EngineRef, error)
 
 // StartFunc starts one requested engine generation. Implementations must honor
-// context cancellation and roll back every partial process or admission
-// authority before returning an error.
+// context cancellation and, before returning an error, either retire every
+// partial authority or return all remaining Child and Admission authority in
+// StartResult. ErrStartRollbackUnproven is required while process-tree
+// retirement remains unproven.
 type StartFunc func(context.Context, EngineRef) (StartResult, error)
 
 // State is the externally observable supervisor state.


### PR DESCRIPTION
## Summary

- exports `supervisor.StartWithFallback` as the single provider-generic requested/fallback start policy and cuts the stable launcher over to it;
- preserves opaque engine identities and returns exact partial authority to `Run` for finalization;
- fail-closes admission-only `ErrStartRollbackUnproven` even after admission cleanup, so only returned child/process-tree authority can permit a retry;
- centralizes five owner-originated daemon registry mutations behind one exact-generation transaction;
- records the changes under `Unreleased` without changing v0.29.0 release notes or protocol documentation.

## Verification

- root `go test ./... -count=1`: PASS
- muxcore `go test ./... -count=1`: PASS
- `go test -race ./supervisor -count=1`: PASS
- `go test -race ./daemon -count=1`: PASS
- root and muxcore `go vet ./...`: PASS
- Windows critical suite: PASS, 5/5; 8/8 host transports dormant/wake/active-engine-switch with zero run-scoped survivors
- release-toolchain (`go1.25.12`) `govulncheck ./...`: 0 called vulnerabilities in root and muxcore
- independent correctness review: APPROVE
- independent S4 security re-review: PASS; prior admission-only rollback finding resolved
- independent contract/reality verification: ACCEPT

## Release posture

This PR is source integration only. It does **not** publish a new tag and does not close #140. Aimux/Engram adoption authorities remain Engram #406/#407, with #400 carried forward under #407. A later publication decision remains blocked until those exact-version consumer gates are terminal and release-git state is clean.

Refs #140

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Новые возможности**
  * Добавлен единый механизм запуска с автоматическим переходом на резервный вариант после безопасного сбоя основного.
  * Уточнена обработка частично завершённых запусков и ошибок отката без лишних повторных попыток.
* **Исправления**
  * Повышена надёжность обновления состояния владельцев: устаревшие поколения больше не изменяют актуальное состояние.
  * Улучшено управление жизненным циклом ресурсов при сбоях запуска и завершении процессов.
* **Документация**
  * Обновлены описания поведения запуска, отката и передачи результатов при использовании резервного варианта.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->