### PR TITLE
chore: release v0.29.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,8 +71,27 @@ do not call the full critical muxcore scope shipped.
 ### Upgrade
 
 ```bash
-go get github.com/thebtf/mcp-mux/muxcore@v0.29.0
+go get github.com/thebtf/mcp-mux/muxcore@v0.29.1
 ```
+
+### v0.29.1 - fallback start policy and exact-generation registry mutation
+
+**No required consumer code changes for ordinary `engine.New` users.**
+`supervisor.StartWithFallback` tries a distinct fallback only after the
+requested start fails cleanly with neither child nor admission authority. A
+failed attempt that retains child or admission authority returns it for
+`supervisor.Run` finalization rather than starting another generation.
+`ErrStartRollbackUnproven` remains fail-closed because admission cleanup is not
+process-tree retirement proof. Cancellation is preserved and never causes an
+additional fallback attempt.
+
+Owner-originated persistence, template-cache, zero-session, and upstream-exit
+callbacks mutate the daemon registry only through its exact-current-generation
+transaction; stale owner generations are no-ops, and process-generation
+authority stays in `muxcore/owner`.
+
+Rollback: pin `muxcore/v0.29.0` or restore the prior product binary; do not
+force a mixed-version live handoff.
 
 ### v0.29.0 - public stable-stdio supervisor
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.29.1] - 2026-07-19
+
 ### Added
 
 - Added `supervisor.StartWithFallback` for provider-generic requested/fallback
@@ -236,7 +238,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   v1-to-v2 compatibility, rollback behavior, forbidden local workarounds, and
   the distinction between Serena dashboard configuration and process cleanup.
 
-[Unreleased]: https://github.com/thebtf/mcp-mux/compare/v0.29.0...HEAD
+[Unreleased]: https://github.com/thebtf/mcp-mux/compare/v0.29.1...HEAD
+[0.29.1]: https://github.com/thebtf/mcp-mux/compare/v0.29.0...v0.29.1
 [0.29.0]: https://github.com/thebtf/mcp-mux/compare/v0.28.0...v0.29.0
 [0.28.0]: https://github.com/thebtf/mcp-mux/compare/v0.27.2...v0.28.0
 [0.27.2]: https://github.com/thebtf/mcp-mux/compare/v0.27.1...v0.27.2

--- a/README.md
+++ b/README.md
@@ -645,12 +645,13 @@ dormant frames.
 
 The stable stdio loop, strict MCP correlation, shared protocol-v2 codec,
 process-tree finalization, and generic peer-PID attestation are public in
-`muxcore/v0.29.0` through `muxcore/supervisor` and
+`muxcore/v0.29.1` through `muxcore/supervisor` and
 `muxcore/supervisor/attest`. Native consumers should pin that tag and use
-`supervisor.Run`, `supervisor.StartCommand`, `supervisor.ProtocolV2`, and the
-attestation package; they must not copy the `mcp-mux` product adapter, private
+`supervisor.Run`, `supervisor.StartCommand`, `supervisor.StartWithFallback`,
+`supervisor.ProtocolV2`, and the attestation package; they must not copy the
+`mcp-mux` product adapter, private
 wire constants, parser, replay loop, or exit code. To roll back, pin
-`muxcore/v0.28.0` or restore the prior product binary and use the product's
+`muxcore/v0.29.0` or restore the prior product binary and use the product's
 bounded replacement path rather than forcing a mixed-version live handoff.
 
 The shared daemon is owned by the stable launcher rather than by any supervised engine generation. The launcher prepares it before starting a child; on Windows the daemon therefore remains outside the child's KillOnJobClose Job Object. A supervised child never spawns that daemon inside its own process tree and exits back to the stable launcher if the daemon must be recreated, preserving the host-facing stdio pipe.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,82 +1,55 @@
-# mcp-mux v0.29.0
+# mcp-mux v0.29.1
 
 **Release date:** 2026-07-19
 
-**Type:** Backward-compatible feature release
+**Type:** Backward-compatible patch release
 
 ## Summary
 
-v0.29.0 makes the stable-stdio lifecycle boundary reusable. The new public
-`muxcore/supervisor` package keeps one MCP host transport attached while a
-product starts, parks, wakes, crashes, or replaces a child engine generation.
-The `mcp-mux` stable launcher now uses this package for generic transport,
-protocol, replay, correlation, and process-tree mechanics while retaining its
-product-specific active-engine authorization, version-store, fallback, update,
-shared-daemon, and operator policy.
+v0.29.1 adds a public, provider-generic start fallback helper to
+`muxcore/supervisor` and makes daemon registry mutations exact-generation
+transactions. These changes tighten lifecycle authority without changing the
+ordinary `engine.New` path.
 
-Ordinary `engine.New` consumers require no source changes. Products that need a
-stable host transport around replaceable engines can adopt the new public
-packages instead of copying the `mcp-mux` launcher protocol or adapter.
+## `supervisor.StartWithFallback`
 
-## Public muxcore API
+`supervisor.StartWithFallback` starts the requested engine first and tries a
+distinct fallback only when that attempt fails cleanly with neither child nor
+admission authority.
 
-- `supervisor.Run` and `supervisor.Config` own one host input/output pair and a
-  sequence of product-selected child generations.
-- `supervisor.StartCommand` supplies full Unix process-group or Windows Job
-  Object authority so the prior child tree is retired before a successor
-  starts.
-- `supervisor.ProtocolV2()` exposes the supported private lifecycle protocol
-  version without exporting product-private method strings or exit codes.
-- `supervisor/attest` supplies `StartParent`, `BindChildPID`, and
-  `VerifyParent` for one-shot, generation-bound direct-parent and exact-child-
-  PID proof on Windows, Linux, and Darwin. Unsupported platforms fail closed
-  for private lifecycle control while ordinary MCP supervision remains usable.
+- If a failed attempt retains child or admission authority, the helper returns
+  that authority to `supervisor.Run` for finalization instead of starting a
+  second generation.
+- `ErrStartRollbackUnproven` is terminal even when only admission cleanup is
+  available: closing admission is not proof that a process tree was retired.
+  The supervisor therefore remains fail-closed rather than overlapping
+  authorities.
+- Cancellation is preserved. A canceled requested attempt does not start a
+  fallback; cancellation from a fallback attempt is also returned, with any
+  retained authority still available for supervisor finalization.
+- Returned error classifications do not expose product engine identities.
 
-The product still owns executable and installed-layout authorization, active
-version and fallback selection, command/args/cwd/environment construction,
-bootstrap/update policy, shared-daemon placement, and operator exit behavior.
+## Exact-generation daemon registry updates
 
-## Transport and lifecycle guarantees
+Owner-originated persistence, template-cache, zero-session, and upstream-exit
+callbacks now update the daemon registry through one daemon-owned transaction.
+The transaction applies only when the originating owner is still the current
+registry generation for its server ID. Stale generations are no-ops, and
+process-generation authority remains in `muxcore/owner`.
 
-The supervisor provides one serialized host writer and admits at most one live
-child process-tree authority. Count-and-byte-bounded FIFO protects first
-delivery while a child starts, replays, finalizes, quiesces, or is dormant.
-Only the cached `initialize` / `notifications/initialized` handshake is
-replayed; arbitrary requests are never replayed. Lifecycle-permitted pings and
-server logging prelude remain correlated and ordered.
+## Compatibility
 
-Delivered requests lost across a generation change receive explicit JSON-RPC
-errors with their original IDs. Request, cancellation, progress-token, and MCP
-Tasks state is generation fenced, including immutable finalized task status in
-the presence of delayed `tasks/get`, `tasks/result`, cancel, or status traffic.
-Replacement discovery list-change notifications are emitted only when the
-initialize capabilities already visible to the host authorize them.
-
-When `StartCommand` is used, successor start waits for complete process-group
-or Job Object retirement. A start path that cannot prove rollback of partial
-authority fails closed instead of admitting an overlapping generation.
-
-## mcp-mux product integration
-
-The installed stable launcher owns the host stdio transport and prepares the
-shared daemon outside each replaceable child authority. Launcher-only dormancy,
-wake-on-demand, and installed active-engine switches therefore preserve the
-original host transport. A marked engine generation does not create the shared
-daemon inside its own process tree.
-
-Private dormant control is enabled only after protocol-v2 bilateral
-attestation succeeds for the exact child generation. Rolling combinations are
-fail-closed: a new supervisor runs an old engine as ordinary MCP, an old
-launcher runs a new engine without private dormancy, and a colliding private
-method from an unattested child is suppressed rather than committed or
-restarted in a loop.
+This patch is backward compatible for ordinary `engine.New` consumers and for
+existing supervisor users. Products that need requested/fallback start policy
+can adopt `supervisor.StartWithFallback`; they should continue to keep product
+engine selection and policy outside muxcore.
 
 ## Upgrade
 
 After the tags resolve, upgrade muxcore consumers with:
 
 ```bash
-go get github.com/thebtf/mcp-mux/muxcore@v0.29.0
+go get github.com/thebtf/mcp-mux/muxcore@v0.29.1
 ```
 
 For the product binary, use the versioned-engine upgrade path:
@@ -85,36 +58,23 @@ For the product binary, use the versioned-engine upgrade path:
 .\mcp-mux.exe upgrade --restart
 ```
 
-Specialized consumers should integrate `supervisor.Run`,
-`supervisor.StartCommand`, `supervisor.ProtocolV2`, and
-`supervisor/attest`. Do not copy the `mcp-mux` private method strings, exit
-code, parser, replay loop, attestation exchange, or launcher adapter.
+## Rollback
 
-## Compatibility and rollback
+To roll back this patch, pin `muxcore/v0.29.0` or restore the previous product
+binary. Do not force a mixed-version live handoff; use the product's bounded
+replacement path.
 
-v0.29.0 is backward compatible for ordinary `engine.New` consumers. To roll
-back, pin `muxcore/v0.28.0` or restore the previous product binary. Do not
-force a mixed-version live supervisor handoff or forward an old attestation
-advertisement; run without private dormancy and restart through the product's
-bounded replacement path.
+## Verification scope
 
-## Verification
+The release verification scope covers focused supervisor fallback behavior
+(clean failure, retained authority, rollback-unproven, and cancellation),
+exact-generation daemon registry mutation behavior, and the relevant public
+API and lifecycle regression coverage. These notes prepare the release; they
+do not claim a final tag or publication.
 
-Release verification covers root and muxcore suites, `go vet`, the supervisor
-race suite, strict replay/correlation/Tasks regressions, public API compile
-tests, attestation on supported platforms plus unsupported-platform fail-
-closed behavior, and the repository critical lifecycle suite. Product smoke
-evidence includes parallel host transports reaching launcher-only dormancy,
-waking on demand, and surviving an installed active-engine switch on the same
-stdio pipes.
+## Post-publication consumer handoff
 
-## Consumer handoff
-
-This is a consumer-impacting muxcore release for products that adopt stable
-stdio supervision or private dormant control. After `muxcore/v0.29.0` resolves,
-update and re-read the Aimux and Engram adoption issues with the released tag,
-public API boundary, single-authority and replay invariants, forbidden private-
-protocol copies, required customer-mode smoke evidence, rollback notes, and
-provider commit/test/module-resolution proof. If that cannot be completed,
-record `CONSUMER_HANDOFF_BLOCKED` and do not claim the full critical muxcore scope
-shipped.
+After publication, Aimux and Engram require fresh handoff against the exact
+released version, including their module-resolution, provider commit, and
+consumer verification evidence. Their adoption follows publication and is not
+represented as completed by these notes.

--- a/muxcore/README.md
+++ b/muxcore/README.md
@@ -15,16 +15,33 @@ consumers; muxcore is a runtime layer and downstream behavior changes matter.
 Install the current release after its tag resolves through the Go proxy:
 
 ```bash
-go get github.com/thebtf/mcp-mux/muxcore@v0.29.0
+go get github.com/thebtf/mcp-mux/muxcore@v0.29.1
 ```
 
-v0.29.0 includes the v0.28.0 demand-driven materialization and fail-closed
-process-retirement contracts described below, plus the earlier native update,
-registry, namespace, reconnect, idle/dormant, and protocol-v2 handoff behavior.
-It adds the public `muxcore/supervisor` and `muxcore/supervisor/attest`
-packages for products that need one stable MCP host transport around
-replaceable child engines. Ordinary `engine.New` users require no source
-change.
+v0.29.1 includes the v0.29.0 stable-stdio supervisor, v0.28.0 demand-driven
+materialization, and fail-closed process-retirement contracts described below,
+plus the earlier native update, registry, namespace, reconnect, idle/dormant,
+and protocol-v2 handoff behavior. It adds the public
+`supervisor.StartWithFallback` policy helper and exact-generation daemon
+registry mutation. Ordinary `engine.New` users require no source change.
+
+### v0.29.1 - fallback start policy and exact-generation registry mutation
+
+**No required consumer code changes for ordinary `engine.New` users.**
+`supervisor.StartWithFallback` tries a distinct fallback only after a requested
+start fails cleanly with neither child nor admission authority. Failed attempts
+that retain authority return it to `supervisor.Run` for finalization instead of
+starting a second generation. `ErrStartRollbackUnproven` remains fail-closed,
+because admission cleanup alone is not process-tree retirement proof;
+cancellation is preserved and never starts an additional fallback attempt.
+
+Owner-originated persistence, template-cache, zero-session, and upstream-exit
+callbacks mutate the daemon registry only through its exact-current-generation
+transaction. Stale owner generations are no-ops, while process-generation
+authority stays in `muxcore/owner`.
+
+Current rollback: pin `muxcore/v0.29.0` or restore the prior product binary;
+do not force a mixed-version live handoff.
 
 ### v0.29.0 - public stable-stdio supervisor
 
@@ -457,15 +474,15 @@ Rules:
 Use it for cheap admission decisions such as local rate limiting. Do not put
 network calls, database writes, or heavy policy evaluation in this hook.
 
-## Stable Stdio Supervisor (v0.29.0)
+## Stable Stdio Supervisor (v0.29.x)
 
 `muxcore/supervisor` is the public boundary for products whose MCP host keeps
 one stdio transport open while the product replaces a child engine executable.
-Introduced in `muxcore/v0.29.0`. After the tag resolves through the Go proxy,
-pin it with:
+Introduced in `muxcore/v0.29.0`. After the current tag resolves through the Go
+proxy, pin `muxcore/v0.29.1` with:
 
 ```bash
-go get github.com/thebtf/mcp-mux/muxcore@v0.29.0
+go get github.com/thebtf/mcp-mux/muxcore@v0.29.1
 ```
 
 Minimal ordinary-supervision shape:
@@ -489,6 +506,13 @@ err := supervisor.Run(ctx, supervisor.Config{
     },
 })
 ```
+
+For requested/fallback engine policy, make `Config.Start` call
+`supervisor.StartWithFallback(ctx, requested, fallback, start)`, where `start`
+returns each attempt's `StartResult`. The fallback runs only after a clean
+requested failure with no child or admission authority; retained authority is
+returned to `Run` for finalization. A rollback-unproven result is fail-closed,
+and cancellation is returned without starting a later fallback attempt.
 
 `HostIn` transfers ownership of an `io.ReadCloser` to `Run` for the invocation.
 Its `Close` method must unblock any pending `Read`; the supervisor closes it on
@@ -560,9 +584,12 @@ old engine as ordinary MCP; an old launcher runs a new engine without private
 dormancy; and a pre-attestation engine that emits a colliding private method is
 suppressed rather than committed or restarted in a loop. Do not copy the v2
 method strings, exit code, parser, replay loop, or attestation into a consumer.
-Use `supervisor.ProtocolV2()`, `supervisor.Run`, and `supervisor/attest`.
+Use the public APIs `supervisor.ProtocolV2()`, `supervisor.Run`,
+`supervisor.StartCommand`, `supervisor.StartWithFallback`, and
+`supervisor/attest`.
 
-To roll back, pin `muxcore/v0.28.0` or restore the prior product binary. Do not
+To roll back the current v0.29.1 patch, pin `muxcore/v0.29.0` or restore the
+prior product binary. Do not
 force a mixed-version live supervisor handoff or forward an old attestation
 advertisement. Old/new combinations run as ordinary MCP without private
 dormancy and should restart through the product's bounded replacement path.


### PR DESCRIPTION
## Summary

- prepare the backward-compatible `v0.29.1` / `muxcore/v0.29.1` patch release
- document `supervisor.StartWithFallback` and exact-generation daemon registry mutation
- update current consumer pin, canonical muxcore guide, product upgrade, and rollback guidance
- keep consumer adoption as post-publication governance

## Scope

Documentation-only release commit. Changed paths are exactly `AGENTS.md`, `CHANGELOG.md`, `README.md`, `RELEASE_NOTES.md`, and `muxcore/README.md`; production source, modules, workflows, and tests are unchanged from merged source commit `6b78e78d49693f26c63072a34c645fef8193b891`.

## Verification

- independent release-doc checker: APPROVE on the corrected docs-only patch
- root and muxcore `go test ./... -count=1`: PASS
- root and muxcore `go vet ./...`: PASS
- supervisor and daemon race suites: PASS
- root and muxcore `go mod verify`: PASS
- root and muxcore `govulncheck` on Go 1.25.12: zero called vulnerabilities
- fresh repository critical suite: PASS 5/5, lifecycle 8/8, zero run-scoped survivors
- customer-mode emulation: `PRODUCT_WORKS`
- production-readiness bug, code, and security passes: PASS / APPROVE / PROCEED

## Review corrections

- restored historical v0.29.0 consumer and rollback guidance
- updated the canonical `muxcore/README.md` install pin, v0.29.1 contract, `StartWithFallback` usage, API inventory, and rollback
- restored the standalone product-binary `mcp-mux upgrade --restart` path

## Release governance

The operator authorized routine publication under the current release rules. After both tags resolve, fresh exact-version Engram handoff comments will be posted for Aimux #406, Engram #407, and carried materialization obligations #400. GitHub #140 remains the aggregate post-release consumer acceptance gate.