### PR TITLE
ci: configure SonarQube analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ dist/
 mcp-mux.versions/
 coverage.out
 coverage.html
+.scannerwork/
 .gomodcache/
 .agent/*
 !.agent/arch

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,9 @@
+sonar.projectKey=thebtf_mcp_mux
+sonar.projectName=mcp-mux
+sonar.sourceEncoding=UTF-8
+sonar.sources=.
+sonar.tests=.
+sonar.test.inclusions=**/*_test.go
+sonar.exclusions=**/*_test.go,**/testdata/**,**/vendor/**,**/bin/**,**/dist/**,**/mcp-mux.versions/**,**/.gomodcache/**,**/.gocache/**,**/.scannerwork/**,**/.aider*/**,**/.claude/**,**/.serena/**,**/.repro/**,**/.t/**,**/tmp/**,.agent/**,**/.agent/**,.agentledger/**,**/.agentledger/**,**/worktrees/**,**/*.exe,**/*.exe.*,**/*.test,**/*.out
+sonar.test.exclusions=**/testdata/**,**/vendor/**,**/bin/**,**/dist/**,**/mcp-mux.versions/**,**/.gomodcache/**,**/.gocache/**,**/.scannerwork/**,**/.aider*/**,**/.claude/**,**/.serena/**,**/.repro/**,**/.t/**,**/tmp/**,.agent/**,**/.agent/**,.agentledger/**,**/.agentledger/**,**/worktrees/**,**/*.exe,**/*.exe.*,**/*.test,**/*.out
+sonar.go.coverage.reportPaths=coverage.out,muxcore/coverage.out


### PR DESCRIPTION
## What
- add Go SonarQube configuration for root and muxcore modules
- ignore generated scanner artifacts

## Verification
- SonarScanner CLI 8.1.0.6389: PASS
- Quality Gate `Sonar way`: PASS
- exact analyzed head: `3117a68481d1504df91fe8604e0e7c44e32488ab`

Baseline scan had no generated coverage profiles; no product source changed.